### PR TITLE
Add TrenchBroom-style drag brush creation

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -202,7 +202,10 @@
           },
           {
             "name": "action.editor.camera.frame_selected",
-            "bindings": [{ "device": "keyboard", "key": "U", "modifiers": ["ctrl"] }]
+            "bindings": [
+              { "device": "keyboard", "key": "U", "modifiers": ["ctrl"] },
+              { "device": "keyboard", "key": "U", "modifiers": ["gui"] }
+            ]
           },
           {
             "name": "action.move.forward",

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -985,8 +985,8 @@
             "if": {
               "type": "scene_state.compare",
               "key": "editor.tool.mode",
-              "op": "!=",
-              "value": "select",
+              "op": "==",
+              "value": "player_start",
               "default": "select"
             },
             "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
@@ -1530,6 +1530,7 @@
                 "type": "editor.brush_world.validate_enclosure",
                 "world": "brush.editor_shell.target",
                 "player_start": "player_start.editor_shell",
+                "allow_missing_player_start": true,
                 "message": "editor source enclosure is sealed",
                 "outputs": {
                   "valid_key": "editor.leak.valid",
@@ -1572,6 +1573,7 @@
               {
                 "type": "editor.player_start.apply",
                 "name": "player_start.editor_shell",
+                "allow_missing_player_start": true,
                 "message": "test run player start applied",
                 "outputs": {
                   "valid_key": "editor.test_run.enter.valid",
@@ -1631,16 +1633,7 @@
       }
     ]
   },
-  "editor_player_starts": [
-    {
-      "name": "player_start.editor_shell",
-      "scene": "scene.editor_shell.test_run",
-      "target": "entity.editor_shell.player",
-      "position": [0.0, 1.6, 4.0],
-      "yaw": 3.14159,
-      "pitch": 0.0
-    }
-  ],
+  "editor_player_starts": [],
   "brush_worlds": [
     {
       "name": "brush.editor_shell.target",
@@ -1687,32 +1680,7 @@
           }
         }
       ],
-      "brushes": [
-        {
-          "name": "brush.target.cube",
-          "contents": ["solid", "player_clip"],
-          "editor": {
-            "stable_id": "editor.brush.target_cube",
-            "display_name": "Selectable Cube",
-            "prefab": "prefab.editor_shell.cube"
-          },
-          "faces": [
-            { "plane": { "normal": [1, 0, 0], "distance": 2 }, "material": "mat.editor.wall" },
-            {
-              "plane": { "normal": [-1, 0, 0], "distance": 0 },
-              "material": "mat.editor.wall",
-              "editor": {
-                "stable_id": "editor.face.target_cube.left",
-                "display_name": "Left Face"
-              }
-            },
-            { "plane": { "normal": [0, 1, 0], "distance": 2 }, "material": "mat.editor.wall" },
-            { "plane": { "normal": [0, -1, 0], "distance": 0 }, "material": "mat.editor.floor" },
-            { "plane": { "normal": [0, 0, 1], "distance": 2 }, "material": "mat.editor.wall" },
-            { "plane": { "normal": [0, 0, -1], "distance": 0 }, "material": "mat.editor.wall" }
-          ]
-        }
-      ]
+      "brushes": []
     }
   ],
   "editor_brush_sources": [
@@ -1720,20 +1688,7 @@
       "world": "brush.editor_shell.target",
       "coordinate_system": "fixed_millimeters",
       "meters_per_unit": 0.001,
-      "boxes": [
-        {
-          "stable_id": "editor.brush.target_cube",
-          "name": "brush.target.cube",
-          "prefab": "prefab.editor_shell.cube",
-          "material": "mat.editor.wall",
-          "face_materials": {
-            "ny": "mat.editor.floor"
-          },
-          "min": [0, 0, 0],
-          "max": [2000, 2000, 2000],
-          "contents": ["solid", "player_clip"]
-        }
-      ]
+      "boxes": []
     }
   ],
   "world": {

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -402,13 +402,13 @@
               "player_start_source_path_key": "editor.player_start.source_path"
             }
           },
-          { "type": "scene_state.set", "key": "editor.grid.size", "value": 8.0 },
+          { "type": "scene_state.set", "key": "editor.grid.size", "value": 16.0 },
           { "type": "scene_state.set", "key": "editor.ortho.size", "value": 48.0 },
           { "type": "scene_state.set", "key": "editor.mode", "value": "select" },
           { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
           { "type": "scene_state.set", "key": "editor.brush.prefab", "value": "floor" },
-          { "type": "scene_state.set", "key": "editor.brush.grid_size", "value": 8.0 },
-          { "type": "scene_state.set", "key": "editor.brush.height", "value": 8.0 },
+          { "type": "scene_state.set", "key": "editor.brush.grid_size", "value": 16.0 },
+          { "type": "scene_state.set", "key": "editor.brush.height", "value": 16.0 },
           { "type": "scene_state.set", "key": "editor.brush.elevation", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.brush.thickness", "value": 0.2 },
           { "type": "scene_state.set", "key": "editor.brush.material", "value": "mat.editor.floor" },

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -201,6 +201,10 @@
             "bindings": [{ "device": "keyboard", "key": "LSHIFT" }]
           },
           {
+            "name": "action.editor.camera.frame_selected",
+            "bindings": [{ "device": "keyboard", "key": "U", "modifiers": ["ctrl"] }]
+          },
+          {
             "name": "action.move.forward",
             "bindings": [{ "device": "keyboard", "key": "W" }]
           },
@@ -1792,7 +1796,8 @@
             "zoom_wheel": "action.editor.ortho.zoom.wheel",
             "look": "action.editor.camera.look",
             "mouse_pan": "action.editor.camera.pan",
-            "fast": "action.editor.camera.fast"
+            "fast": "action.editor.camera.fast",
+            "frame_selected": "action.editor.camera.frame_selected"
           },
           "mode_key": "editor.view.mode",
           "quad_mode": "quad_view",

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -402,13 +402,13 @@
               "player_start_source_path_key": "editor.player_start.source_path"
             }
           },
-          { "type": "scene_state.set", "key": "editor.grid.size", "value": 16.0 },
+          { "type": "scene_state.set", "key": "editor.grid.size", "value": 1.0 },
           { "type": "scene_state.set", "key": "editor.ortho.size", "value": 48.0 },
           { "type": "scene_state.set", "key": "editor.mode", "value": "select" },
           { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
           { "type": "scene_state.set", "key": "editor.brush.prefab", "value": "floor" },
-          { "type": "scene_state.set", "key": "editor.brush.grid_size", "value": 16.0 },
-          { "type": "scene_state.set", "key": "editor.brush.height", "value": 16.0 },
+          { "type": "scene_state.set", "key": "editor.brush.grid_size", "value": 1.0 },
+          { "type": "scene_state.set", "key": "editor.brush.height", "value": 1.0 },
           { "type": "scene_state.set", "key": "editor.brush.elevation", "value": 0.0 },
           { "type": "scene_state.set", "key": "editor.brush.thickness", "value": 0.2 },
           { "type": "scene_state.set", "key": "editor.brush.material", "value": "mat.editor.floor" },
@@ -418,6 +418,7 @@
           { "type": "scene_state.set", "key": "editor.palette.game_object.cursor", "value": "player_start" },
           { "type": "scene_state.set", "key": "editor.inspector.collapsed", "value": false },
           { "type": "scene_state.set", "key": "editor.inspector.tab", "value": "Map" },
+          { "type": "scene_state.set", "key": "editor.grid.menu.open", "value": false },
           { "type": "scene_state.set", "key": "editor.view.mode", "value": "flyby_3d" },
           { "type": "scene_state.set", "key": "editor.work_plane.normal", "value": [0.0, 1.0, 0.0] },
           { "type": "scene_state.set", "key": "editor.work_plane.distance", "value": 0.0 },
@@ -512,14 +513,14 @@
           {
             "type": "scene_state.cycle",
             "key": "editor.grid.size",
-            "default": 8.0,
+            "default": 1.0,
             "direction": -1,
             "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           {
             "type": "scene_state.cycle",
             "key": "editor.brush.grid_size",
-            "default": 8.0,
+            "default": 1.0,
             "direction": -1,
             "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
@@ -532,14 +533,14 @@
           {
             "type": "scene_state.cycle",
             "key": "editor.grid.size",
-            "default": 8.0,
+            "default": 1.0,
             "direction": 1,
             "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },
           {
             "type": "scene_state.cycle",
             "key": "editor.brush.grid_size",
-            "default": 8.0,
+            "default": 1.0,
             "direction": 1,
             "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
           },

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -133,9 +133,19 @@
       "work_plane_distance_key": "editor.work_plane.distance",
       "floor_material": "mat.editor.floor",
       "ceiling_material": "mat.editor.ceiling",
-      "default_snap": 8.0,
-      "default_grid_size": 8.0,
+      "default_snap": 16.0,
+      "default_grid_size": 16.0,
       "default_elevation": 0.0,
+      "drag_create": {
+        "mode": "drag_box",
+        "kind": "box",
+        "world": "brush.editor_shell.target",
+        "prefab": "editor.box",
+        "material_key": "editor.brush.material",
+        "material": "mat.editor.floor",
+        "contents": ["solid"],
+        "message": "drag brush preview"
+      },
       "outputs": {
         "active_key": "editor.placement_preview.active",
         "valid_key": "editor.placement_preview.valid",
@@ -218,7 +228,7 @@
           "kind": "box",
           "label": "Floor",
           "category": "blockout",
-          "description": "8m gray floor tile"
+          "description": "grid-sized gray floor tile"
         },
         {
           "mode": "wall",
@@ -234,7 +244,7 @@
           "kind": "box",
           "label": "Ceiling",
           "category": "blockout",
-          "description": "8m gray ceiling tile"
+          "description": "grid-sized gray ceiling tile"
         },
         {
           "mode": "sky",
@@ -1072,7 +1082,7 @@
       {
         "name": "ui.editor_shell.tool_toolbar.grid.label",
         "format": "Grid %.3g",
-        "bindings": [{ "type": "scene_state", "key": "editor.grid.size", "default": 8.0 }],
+        "bindings": [{ "type": "scene_state", "key": "editor.grid.size", "default": 16.0 }],
         "font": "font.editor_shell.ui",
         "x": 790,
         "y": 54,

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -133,8 +133,8 @@
       "work_plane_distance_key": "editor.work_plane.distance",
       "floor_material": "mat.editor.floor",
       "ceiling_material": "mat.editor.ceiling",
-      "default_snap": 16.0,
-      "default_grid_size": 16.0,
+      "default_snap": 1.0,
+      "default_grid_size": 1.0,
       "default_elevation": 0.0,
       "drag_create": {
         "mode": "drag_box",
@@ -218,6 +218,15 @@
           "message": "player start preview"
         }
       ]
+    },
+    "grid_widget": {
+      "grid_key": "editor.grid.size",
+      "brush_grid_key": "editor.brush.grid_size",
+      "open_key": "editor.grid.menu.open",
+      "button": { "x": 735, "y": 45, "w": 110, "h": 28 },
+      "popup": { "x": 735, "y": 76, "w": 110, "h": 288 },
+      "row_height": 24,
+      "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
     },
     "palette": {
       "selected_key": "editor.tool.mode",
@@ -518,6 +527,17 @@
         "color": [24, 34, 48, 245],
         "border_color": [120, 165, 205, 235],
         "border_thickness": 1
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.popup",
+        "x": 735,
+        "y": 76,
+        "w": 110,
+        "h": 288,
+        "color": [16, 22, 32, 248],
+        "border_color": [120, 165, 205, 245],
+        "border_thickness": 1,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
       },
       {
         "name": "ui.editor_shell.left_inspector.panel",
@@ -1082,13 +1102,145 @@
       {
         "name": "ui.editor_shell.tool_toolbar.grid.label",
         "format": "Grid %.3g",
-        "bindings": [{ "type": "scene_state", "key": "editor.grid.size", "default": 16.0 }],
+        "bindings": [{ "type": "scene_state", "key": "editor.grid.size", "default": 1.0 }],
         "font": "font.editor_shell.ui",
         "x": 790,
         "y": 54,
         "align": "center",
         "color": [230, 245, 255, 250],
         "scale": 0.54
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.0",
+        "text": "Grid 0.125",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 85,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.1",
+        "text": "Grid 0.25",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 109,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.2",
+        "text": "Grid 0.5",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 133,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.3",
+        "text": "Grid 1",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 157,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.4",
+        "text": "Grid 2",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 181,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.5",
+        "text": "Grid 4",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 205,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.6",
+        "text": "Grid 8",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 229,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.7",
+        "text": "Grid 16",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 253,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.8",
+        "text": "Grid 32",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 277,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.9",
+        "text": "Grid 64",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 301,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.10",
+        "text": "Grid 128",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 325,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.tool_toolbar.grid.option.11",
+        "text": "Grid 256",
+        "font": "font.editor_shell.ui",
+        "x": 790,
+        "y": 349,
+        "align": "center",
+        "color": [230, 245, 255, 250],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.grid.menu.open", "op": "==", "value": true, "default": false }
       },
       {
         "name": "ui.editor_shell.left_inspector.title",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -46,7 +46,8 @@
       "action.editor.camera.down",
       "action.editor.camera.look",
       "action.editor.camera.pan",
-      "action.editor.camera.fast"
+      "action.editor.camera.fast",
+      "action.editor.camera.frame_selected"
     ]
   },
   "entities": ["entity.editor_shell.camera"],
@@ -110,6 +111,12 @@
         "compiled_first_vertex_key": "editor.selection.compiled_first_vertex",
         "compiled_vertex_count_key": "editor.selection.compiled_vertex_count",
         "compiled_triangle_count_key": "editor.selection.compiled_triangle_count",
+        "bounds_min_key": "editor.selection.bounds_min",
+        "bounds_max_key": "editor.selection.bounds_max",
+        "dimensions_key": "editor.selection.dimensions",
+        "dimension_x_key": "editor.selection.dimension_x",
+        "dimension_y_key": "editor.selection.dimension_y",
+        "dimension_z_key": "editor.selection.dimension_z",
         "element_index_key": "editor.selection.element_index",
         "face_index_key": "editor.selection.face_index",
         "fraction_key": "editor.selection.fraction",
@@ -119,9 +126,18 @@
       "hover_outputs": {
         "hit_key": "editor.hover.hit",
         "element_key": "editor.hover.element",
+        "material_key": "editor.hover.material",
+        "element_stable_id_key": "editor.hover.element_stable_id",
         "face_stable_id_key": "editor.hover.face_stable_id",
         "face_rendered_key": "editor.hover.face_rendered",
-        "compiled_face_index_key": "editor.hover.compiled_face_index"
+        "compiled_face_index_key": "editor.hover.compiled_face_index",
+        "bounds_min_key": "editor.hover.bounds_min",
+        "bounds_max_key": "editor.hover.bounds_max",
+        "dimensions_key": "editor.hover.dimensions",
+        "dimension_x_key": "editor.hover.dimension_x",
+        "dimension_y_key": "editor.hover.dimension_y",
+        "dimension_z_key": "editor.hover.dimension_z",
+        "point_key": "editor.hover.point"
       },
       "on_select": "signal.editor.pointer.primary"
     },
@@ -631,6 +647,17 @@
         "name": "ui.editor_shell.left_inspector.row.status",
         "x": 24,
         "y": 276,
+        "w": 272,
+        "h": 26,
+        "color": [20, 26, 36, 228],
+        "border_color": [32, 40, 54, 210],
+        "border_thickness": 1,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.inspector.collapsed", "op": "==", "value": false, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.left_inspector.row.id",
+        "x": 24,
+        "y": 306,
         "w": 272,
         "h": 26,
         "color": [20, 26, 36, 228],
@@ -1329,7 +1356,8 @@
       },
       {
         "name": "ui.editor_shell.left_inspector.row.selection.value",
-        "text": "none",
+        "format": "%s",
+        "bindings": [{ "type": "scene_state", "key": "editor.selection.element", "default": "none" }],
         "font": "font.editor_shell.ui",
         "x": 284,
         "y": 223,
@@ -1340,7 +1368,7 @@
       },
       {
         "name": "ui.editor_shell.left_inspector.row.brushes.label",
-        "text": "Brushes",
+        "text": "Hover",
         "font": "font.editor_shell.ui",
         "x": 34,
         "y": 253,
@@ -1350,7 +1378,8 @@
       },
       {
         "name": "ui.editor_shell.left_inspector.row.brushes.value",
-        "text": "mock",
+        "format": "%s",
+        "bindings": [{ "type": "scene_state", "key": "editor.hover.element", "default": "none" }],
         "font": "font.editor_shell.ui",
         "x": 284,
         "y": 253,
@@ -1361,7 +1390,7 @@
       },
       {
         "name": "ui.editor_shell.left_inspector.row.status.label",
-        "text": "Status",
+        "text": "Dims",
         "font": "font.editor_shell.ui",
         "x": 34,
         "y": 283,
@@ -1371,10 +1400,37 @@
       },
       {
         "name": "ui.editor_shell.left_inspector.row.status.value",
-        "text": "ready",
+        "format": "%.2f x %.2f x %.2f",
+        "bindings": [
+          { "type": "scene_state", "key": "editor.hover.dimension_x", "default": 0.0 },
+          { "type": "scene_state", "key": "editor.hover.dimension_y", "default": 0.0 },
+          { "type": "scene_state", "key": "editor.hover.dimension_z", "default": 0.0 }
+        ],
         "font": "font.editor_shell.ui",
         "x": 284,
         "y": 283,
+        "align": "right",
+        "color": [230, 236, 246, 245],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.inspector.collapsed", "op": "==", "value": false, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.left_inspector.row.id.label",
+        "text": "Stable ID",
+        "font": "font.editor_shell.ui",
+        "x": 34,
+        "y": 313,
+        "color": [150, 185, 225, 235],
+        "scale": 0.5,
+        "visible_if": { "type": "scene_state.compare", "key": "editor.inspector.collapsed", "op": "==", "value": false, "default": false }
+      },
+      {
+        "name": "ui.editor_shell.left_inspector.row.id.value",
+        "format": "%s",
+        "bindings": [{ "type": "scene_state", "key": "editor.hover.element_stable_id", "default": "none" }],
+        "font": "font.editor_shell.ui",
+        "x": 284,
+        "y": 313,
         "align": "right",
         "color": [230, 236, 246, 245],
         "scale": 0.5,

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -92,12 +92,14 @@ shortcuts do not shadow camera movement.
 | `Esc` | palette open | close the palette without quitting |
 | left mouse drag | Select Mode, empty space | create a source-backed box brush on the active grid |
 | left mouse drag | Select Mode, selected brush | move selected brushes with snap-to-grid |
-| arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on Z/X |
-| `PageUp` / `PageDown` | Select Mode, brush selected | move selected brushes up/down by the active grid size (`Fn+Up` / `Fn+Down` on many macOS keyboards) |
+| arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on Z/X (`Up` moves +X, `Down` moves -X) |
+| `PageUp` / `PageDown` | Select Mode, brush selected | move selected brushes up/down on Y by the active grid size (`Fn+Up` / `Fn+Down` on many macOS keyboards) |
+| `Ctrl`/`Alt` + `Up`/`Down` | Select Mode, brush selected | move selected brushes up/down on Y by the active grid size on keyboards without Fn navigation keys |
+| `Home` / `End` | Select Mode, brush selected | rotate selected brushes around their center in 90-degree Y-axis steps (`Fn+Left` / `Fn+Right` on many macOS keyboards) |
+| `Ctrl`/`Alt` + `Left`/`Right` | Select Mode, brush selected | rotate selected brushes around their center in 90-degree Y-axis steps on keyboards without Fn navigation keys |
 | mouse click | Brush/Game Object Mode | place the selected prefab at the snapped preview position |
 | mouse click | Select Mode | select or deselect the highlighted brush |
 | `Shift` + mouse click | Select Mode | add or remove the highlighted brush from the selected set |
-| `[` and `]` | Select Mode | lower or raise selected brush height/elevation by one active grid step |
 | `Delete` / `Backspace` | Select Mode | delete all selected brushes |
 | `Delete` / `Backspace` | other editor modes | delete the active highlighted tile or game object |
 | `Enter` | palette closed | commit the current preview placement |
@@ -122,8 +124,9 @@ shortcuts do not shadow camera movement.
    should be created using the active `1` unit grid.
 2. Click the new brush, then use the arrow keys to nudge it by the active grid
    size. Use `PageUp` / `PageDown` or macOS `Fn+Up` / `Fn+Down` to move it
-   vertically. Drag the selected brush with left mouse and confirm it moves on
-   the same grid.
+   vertically, and use `Home` / `End` or macOS `Fn+Left` / `Fn+Right` to rotate
+   it in 90-degree Y-axis steps. Drag the selected brush with left mouse and
+   confirm it moves on the same grid.
 3. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
 4. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
    needed, and place at least one wall.
@@ -178,11 +181,9 @@ The following should be true during a good test drive:
 - `B` enters Brush Paint Mode. `M` enters Texture Mode. Brush/material palette
   selections update the same data-authored mode and brush-setting state.
 - `Space` enters Select Mode from editor layouts and the 3D flyby view. Select
-  Mode owns brush selection and multi-selection. `[` and `]` resize generic
-  selected brushes by the active grid step. Thin floor slabs can move below the
-  default plane; the editor creates deterministic side-wall fill brushes for
-  the exposed vertical space and removes the matching fill segment when raised
-  back up.
+  Mode owns brush selection and multi-selection. Arrow-key movement, vertical
+  movement, and 90-degree Y-axis rotation all operate on source brushes by the
+  active grid step.
 - Game object placement uses its own tighter snap grid, so player starts can be
   placed precisely while floor/wall/ceiling/sky brushes stay aligned to the larger
   blockout grid.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -71,6 +71,10 @@ panel interaction. Brush feedback is cursor-driven: the highlighted brush and
 flashing placement preview should follow the OS cursor without drawing a second
 virtual hit cursor.
 
+The editor starts in Select Mode with a `16` unit grid. In Select Mode, dragging
+left mouse in empty space creates a source-backed box brush. The preview expands
+while dragging, and release commits the same validated source command.
+
 ## Keybindings
 
 Tool and object selection should go through palettes so level-authoring
@@ -86,6 +90,9 @@ shortcuts do not shadow camera movement.
 | arrow keys | palette open | move the active palette cursor |
 | `Enter` | palette open | select the highlighted palette item and close the palette |
 | `Esc` | palette open | close the palette without quitting |
+| left mouse drag | Select Mode, empty space | create a source-backed box brush on the active grid |
+| arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on X/Z |
+| `PageUp` / `PageDown` | Select Mode, brush selected | move selected brushes up/down by the active grid size (`Fn+Up` / `Fn+Down` on many macOS keyboards) |
 | mouse click | Brush/Game Object Mode | place the selected prefab at the snapped preview position |
 | mouse click | Select Mode | select or deselect the highlighted brush |
 | `Shift` + mouse click | Select Mode | add or remove the highlighted brush from the selected set |
@@ -110,28 +117,33 @@ shortcuts do not shadow camera movement.
 
 ## Suggested Pass
 
-1. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
-2. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
+1. In Select Mode, drag left mouse in empty space and release. A new box brush
+   should be created using the active `16` unit grid.
+2. Click the new brush, then use the arrow keys to nudge it by the active grid
+   size. Use `PageUp` / `PageDown` or macOS `Fn+Up` / `Fn+Down` to move it
+   vertically.
+3. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
+4. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
    needed, and place at least one wall.
-3. Press `B`, move to Ceiling with the arrow keys, press `Enter`, and place a
+5. Press `B`, move to Ceiling with the arrow keys, press `Enter`, and place a
    ceiling tile.
-4. Press `B`, move to Sky with the arrow keys, press `Enter`, and place a sky
+6. Press `B`, move to Sky with the arrow keys, press `Enter`, and place a sky
    tile over an opening. The brush should seal leak validation; sky rendering
    will be revisited when a better editor skybox is authored.
-5. Press `G`, press `Enter` to select Player Start, and place it on the floor.
-6. Press `Space`, click a tile to select it, press `]`, and confirm the brush
+7. Press `G`, press `Enter` to select Player Start, and place it on the floor.
+8. Press `Space`, click a tile to select it, press `]`, and confirm the brush
    stretches upward while its bottom face stays anchored. Press `[` on a floor
    slab at the default floor plane and confirm the floor slab can move below
    the plane; the editor should add side-wall fill brushes around the exposed
    height change.
-7. Enter the lowered area, switch back to Brush Paint Mode, and place floor,
+9. Enter the lowered area, switch back to Brush Paint Mode, and place floor,
    wall, and ceiling tiles. Their previews should stay on the lowered
    connected grid instead of snapping back to the original world plane.
-8. Press `Delete` or `Backspace`; the tile should disappear. Shift-click
+10. Press `Delete` or `Backspace`; the tile should disappear. Shift-click
    multiple tiles to delete a set.
-9. Press `Ctrl+S` or `Command+S` and confirm the output
+11. Press `Ctrl+S` or `Command+S` and confirm the output
    file should contain `brush_worlds`, `editor_brush_sources`, and `editor_player_starts`.
-10. Press `F5`; the editor should validate the brush source model, then switch
+12. Press `F5`; the editor should validate the brush source model, then switch
    into the playable test scene using the current in-memory map and player
    start. Source overlaps, near-gaps, and reachable leaks are warning-level
    diagnostics during this MVP iteration: debug markers and scene-state
@@ -142,7 +154,7 @@ shortcuts do not shadow camera movement.
    orange candidate marker on the nearest source-box face associated with that
    leak boundary. The candidate brush face should also become the active
    selection, making the suspected source face obvious in the selection outline.
-11. In the playable scene, use `WASD` and mouse look to verify the player starts
+13. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
 
 ## Correctness Checks
@@ -151,6 +163,9 @@ The following should be true during a good test drive:
 
 - Placement previews snap to the active grid size and resize when `+` / `-` is
   pressed. The second toolbar's Grid widget should update to the same value.
+- The default grid size is `16`. Select Mode left-drag creation, brush-mode
+  placement previews, and selected-brush arrow-key movement should all use the
+  same active grid value.
 - The old left-side debug dump is no longer visible. The new left Inspector
   panel is visible with Map, Entity, and Face placeholder tabs, and `I`
   collapses it to a small strip.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -116,7 +116,7 @@ shortcuts do not shadow camera movement.
 | mouse wheel | 3D flyby | dolly camera forward/back |
 | `Q` / `E` | 3D flyby | move camera down/up |
 | `Left Shift` | 3D flyby | move faster |
-| `Ctrl+U` | 3D flyby | frame the selected or hovered brush in view |
+| `Ctrl+U` / `Command+U` | 3D flyby | frame the selected or hovered brush in view |
 | `Ctrl+S` / `Command+S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
 | `T` | palette closed | report that disk test-run manifest handoff is disabled for this MVP iteration |
 | `F5` | palette closed | enter the playable test scene from the placed player start |

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -120,35 +120,42 @@ shortcuts do not shadow camera movement.
 
 ## Suggested Pass
 
+The shell project intentionally starts empty: no starter cube and no default
+player-start marker. This keeps every visible brush and marker attributable to
+your current editing session.
+
 1. In Select Mode, drag left mouse in empty space and release. A new box brush
    should be created using the active `1` unit grid.
-2. Click the new brush, then use the arrow keys to nudge it by the active grid
+2. Click the new brush, then click empty space. The selection should clear
+   without creating a brush. Brush creation from the pointer requires a
+   left-button drag, not a plain click.
+3. Select the brush again, then use the arrow keys to nudge it by the active grid
    size. Use `PageUp` / `PageDown` or macOS `Fn+Up` / `Fn+Down` to move it
    vertically, and use `Home` / `End` or macOS `Fn+Left` / `Fn+Right` to rotate
    it in 90-degree Y-axis steps. Drag the selected brush with left mouse and
    confirm it moves on the same grid.
-3. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
-4. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
+4. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
+5. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
    needed, and place at least one wall.
-5. Press `B`, move to Ceiling with the arrow keys, press `Enter`, and place a
+6. Press `B`, move to Ceiling with the arrow keys, press `Enter`, and place a
    ceiling tile.
-6. Press `B`, move to Sky with the arrow keys, press `Enter`, and place a sky
+7. Press `B`, move to Sky with the arrow keys, press `Enter`, and place a sky
    tile over an opening. The brush should seal leak validation; sky rendering
    will be revisited when a better editor skybox is authored.
-7. Press `G`, press `Enter` to select Player Start, and place it on the floor.
-8. Press `Space`, click a tile to select it, press `]`, and confirm the brush
+8. Press `G`, press `Enter` to select Player Start, and place it on the floor.
+9. Press `Space`, click a tile to select it, press `]`, and confirm the brush
    stretches upward while its bottom face stays anchored. Press `[` on a floor
    slab at the default floor plane and confirm the floor slab can move below
    the plane; the editor should add side-wall fill brushes around the exposed
    height change.
-9. Enter the lowered area, switch back to Brush Paint Mode, and place floor,
+10. Enter the lowered area, switch back to Brush Paint Mode, and place floor,
    wall, and ceiling tiles. Their previews should stay on the lowered
    connected grid instead of snapping back to the original world plane.
-10. Press `Delete` or `Backspace`; the tile should disappear. Shift-click
+11. Press `Delete` or `Backspace`; the tile should disappear. Shift-click
    multiple tiles to delete a set.
-11. Press `Ctrl+S` or `Command+S` and confirm the output
+12. Press `Ctrl+S` or `Command+S` and confirm the output
    file should contain `brush_worlds`, `editor_brush_sources`, and `editor_player_starts`.
-12. Press `F5`; the editor should validate the brush source model, then switch
+13. Press `F5`; the editor should validate the brush source model, then switch
    into the playable test scene using the current in-memory map and player
    start. Source overlaps, near-gaps, and reachable leaks are warning-level
    diagnostics during this MVP iteration: debug markers and scene-state
@@ -159,7 +166,7 @@ shortcuts do not shadow camera movement.
    orange candidate marker on the nearest source-box face associated with that
    leak boundary. The candidate brush face should also become the active
    selection, making the suspected source face obvious in the selection outline.
-13. In the playable scene, use `WASD` and mouse look to verify the player starts
+14. In the playable scene, use `WASD` and mouse look to verify the player starts
    where you placed the marker and collides with the graybox geometry.
 
 ## Correctness Checks
@@ -221,7 +228,8 @@ The following should be true during a good test drive:
 - Brush picking and placement trace from the hardware cursor. The highlighted
   brush should be the brush under the cursor; if no brush is hit, placement
   falls back to the ground work plane. In brush mode, the flashing preview
-  bounds should move as the cursor moves.
+  bounds should move as the cursor moves, but a plain click in empty space
+  should not commit a brush.
 - `Ctrl+S` and `Command+S` export JSON containing `brush_worlds`, `editor_brush_sources`, and
   `editor_player_starts`, then writes the same fragment to the CLI output path.
 - `T` does not write a test-run manifest during this MVP iteration.

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -58,7 +58,9 @@ an obvious snap reference.
 The left Inspector panel is visible by default. It currently contains
 placeholder Map, Entity, and Face tabs so the editor has a stable destination
 for selection diagnostics and property editing in later slices. Press `I` to
-collapse or expand the panel.
+collapse or expand the panel. Hovering a brush updates the Inspector with the
+brush name, dimensions, and stable ID; use the stable ID when reporting geometry
+issues because it persists through save/reopen.
 
 A bottom console pane spans the editor width below the viewport. The Console
 tab shows recent editor messages and mirrors those messages to the terminal via
@@ -90,14 +92,14 @@ shortcuts do not shadow camera movement.
 | arrow keys | palette open | move the active palette cursor |
 | `Enter` | palette open | select the highlighted palette item and close the palette |
 | `Esc` | palette open | close the palette without quitting |
-| left mouse drag | Select Mode, empty space | create a source-backed box brush on the active grid |
+| left mouse drag | Select Mode, empty space | create a source-backed box brush on the active grid; a single click only clears/changes selection |
 | left mouse drag | Select Mode, selected brush | move selected brushes with snap-to-grid |
+| `Alt`/`Option` + left mouse drag | Select Mode, selected brush | move selected brushes only on the Y axis with snap-to-grid |
 | arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on Z/X (`Up` moves +X, `Down` moves -X) |
 | `PageUp` / `PageDown` | Select Mode, brush selected | move selected brushes up/down on Y by the active grid size (`Fn+Up` / `Fn+Down` on many macOS keyboards) |
 | `Ctrl`/`Alt` + `Up`/`Down` | Select Mode, brush selected | move selected brushes up/down on Y by the active grid size on keyboards without Fn navigation keys |
 | `Home` / `End` | Select Mode, brush selected | rotate selected brushes around their center in 90-degree Y-axis steps (`Fn+Left` / `Fn+Right` on many macOS keyboards) |
 | `Ctrl`/`Alt` + `Left`/`Right` | Select Mode, brush selected | rotate selected brushes around their center in 90-degree Y-axis steps on keyboards without Fn navigation keys |
-| mouse click | Brush/Game Object Mode | place the selected prefab at the snapped preview position |
 | mouse click | Select Mode | select or deselect the highlighted brush |
 | `Shift` + mouse click | Select Mode | add or remove the highlighted brush from the selected set |
 | `Delete` / `Backspace` | Select Mode | delete all selected brushes |
@@ -109,10 +111,12 @@ shortcuts do not shadow camera movement.
 | `C` | palette closed | cycle tools for debug/testing |
 | `WASD` | 3D flyby | move camera |
 | right mouse drag | 3D flyby | rotate camera without capturing the hardware cursor |
+| `Alt`/`Option` + right mouse drag | 3D flyby | orbit around the hovered brush or work-plane point |
 | middle mouse drag | 3D flyby | pan camera left/right/up/down |
 | mouse wheel | 3D flyby | dolly camera forward/back |
 | `Q` / `E` | 3D flyby | move camera down/up |
 | `Left Shift` | 3D flyby | move faster |
+| `Ctrl+U` | 3D flyby | frame the selected or hovered brush in view |
 | `Ctrl+S` / `Command+S` | palette closed | export editable level JSON in memory and save it to the CLI output path |
 | `T` | palette closed | report that disk test-run manifest handoff is disabled for this MVP iteration |
 | `F5` | palette closed | enter the playable test scene from the placed player start |

--- a/docs/editor-test-drive.md
+++ b/docs/editor-test-drive.md
@@ -71,7 +71,7 @@ panel interaction. Brush feedback is cursor-driven: the highlighted brush and
 flashing placement preview should follow the OS cursor without drawing a second
 virtual hit cursor.
 
-The editor starts in Select Mode with a `16` unit grid. In Select Mode, dragging
+The editor starts in Select Mode with a `1` unit grid. In Select Mode, dragging
 left mouse in empty space creates a source-backed box brush. The preview expands
 while dragging, and release commits the same validated source command.
 
@@ -91,17 +91,18 @@ shortcuts do not shadow camera movement.
 | `Enter` | palette open | select the highlighted palette item and close the palette |
 | `Esc` | palette open | close the palette without quitting |
 | left mouse drag | Select Mode, empty space | create a source-backed box brush on the active grid |
-| arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on X/Z |
+| left mouse drag | Select Mode, selected brush | move selected brushes with snap-to-grid |
+| arrow keys | Select Mode, brush selected | move selected brushes by the active grid size on Z/X |
 | `PageUp` / `PageDown` | Select Mode, brush selected | move selected brushes up/down by the active grid size (`Fn+Up` / `Fn+Down` on many macOS keyboards) |
 | mouse click | Brush/Game Object Mode | place the selected prefab at the snapped preview position |
 | mouse click | Select Mode | select or deselect the highlighted brush |
 | `Shift` + mouse click | Select Mode | add or remove the highlighted brush from the selected set |
-| right click | editor view | delete the highlighted tile or game object |
 | `[` and `]` | Select Mode | lower or raise selected brush height/elevation by one active grid step |
 | `Delete` / `Backspace` | Select Mode | delete all selected brushes |
 | `Delete` / `Backspace` | other editor modes | delete the active highlighted tile or game object |
 | `Enter` | palette closed | commit the current preview placement |
 | `+` / `-` | palette closed | increase or decrease grid size through the fixed ladder: 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256 |
+| Grid widget | second toolbar | click to open the grid-size list, then click a row to set the active grid |
 | `R` | palette closed | toggle wall axis for manual wall placement |
 | `C` | palette closed | cycle tools for debug/testing |
 | `WASD` | 3D flyby | move camera |
@@ -118,10 +119,11 @@ shortcuts do not shadow camera movement.
 ## Suggested Pass
 
 1. In Select Mode, drag left mouse in empty space and release. A new box brush
-   should be created using the active `16` unit grid.
+   should be created using the active `1` unit grid.
 2. Click the new brush, then use the arrow keys to nudge it by the active grid
    size. Use `PageUp` / `PageDown` or macOS `Fn+Up` / `Fn+Down` to move it
-   vertically.
+   vertically. Drag the selected brush with left mouse and confirm it moves on
+   the same grid.
 3. Press `B`, leave Floor selected, press `Enter`, and place a floor tile.
 4. Press `B`, move to Wall with the arrow keys, press `Enter`, press `R` if
    needed, and place at least one wall.
@@ -163,7 +165,7 @@ The following should be true during a good test drive:
 
 - Placement previews snap to the active grid size and resize when `+` / `-` is
   pressed. The second toolbar's Grid widget should update to the same value.
-- The default grid size is `16`. Select Mode left-drag creation, brush-mode
+- The default grid size is `1`. Select Mode left-drag creation, selected-brush dragging, brush-mode
   placement previews, and selected-brush arrow-key movement should all use the
   same active grid value.
 - The old left-side debug dump is no longer visible. The new left Inspector

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1384,6 +1384,9 @@ boxes; runtime brush geometry is generated only after the source candidate
 passes validation. The preview reuses the editor debug overlay's
 `command_preview` flag and color, so editor hosts do not need a second rendering
 path.
+`drag_create` optionally enables TrenchBroom-style select-mode brush creation:
+the editor dry-runs the same source-box command while the pointer is dragged in
+empty space, then commits that exact command on release.
 
 ```json
 {
@@ -1392,8 +1395,16 @@ path.
       "tool_key": "editor.tool.mode",
       "snap_key": "editor.grid.size",
       "grid_size_key": "editor.grid.size",
-      "default_snap": 8.0,
-      "default_grid_size": 8.0,
+      "default_snap": 16.0,
+      "default_grid_size": 16.0,
+      "drag_create": {
+        "mode": "drag_box",
+        "kind": "box",
+        "world": "brush.level.blockout",
+        "prefab": "editor.box",
+        "material": "mat.stone_floor",
+        "contents": ["solid"]
+      },
       "outputs": {
         "active_key": "editor.placement_preview.active",
         "mode_key": "editor.placement_preview.mode",

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1386,7 +1386,10 @@ passes validation. The preview reuses the editor debug overlay's
 path.
 `drag_create` optionally enables TrenchBroom-style select-mode brush creation:
 the editor dry-runs the same source-box command while the pointer is dragged in
-empty space, then commits that exact command on release.
+empty space, then commits that exact command on release. `grid_widget` can
+describe a small authored toolbar dropdown for selecting the active snap size.
+The widget writes both the general grid key and the brush grid key so previews,
+drag creation, selected-brush dragging, and arrow-key nudging stay in sync.
 
 ```json
 {
@@ -1395,8 +1398,8 @@ empty space, then commits that exact command on release.
       "tool_key": "editor.tool.mode",
       "snap_key": "editor.grid.size",
       "grid_size_key": "editor.grid.size",
-      "default_snap": 16.0,
-      "default_grid_size": 16.0,
+      "default_snap": 1.0,
+      "default_grid_size": 1.0,
       "drag_create": {
         "mode": "drag_box",
         "kind": "box",
@@ -1445,6 +1448,15 @@ empty space, then commits that exact command on release.
           "size": [0.5, 1.8, 0.5]
         }
       ]
+    },
+    "grid_widget": {
+      "grid_key": "editor.grid.size",
+      "brush_grid_key": "editor.brush.grid_size",
+      "open_key": "editor.grid.menu.open",
+      "button": { "x": 735, "y": 45, "w": 110, "h": 28 },
+      "popup": { "x": 735, "y": 76, "w": 110, "h": 288 },
+      "row_height": 24,
+      "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
     }
   }
 }

--- a/include/slayer3d/input.h
+++ b/include/slayer3d/input.h
@@ -397,6 +397,18 @@ extern "C"
      */
     Uint8 slayer3d_input_get_pressed_mouse_button(const slayer3d_input_manager *input);
 
+    /** @brief Return true if the scancode was pressed during the current input tick. */
+    bool slayer3d_input_is_scancode_pressed(const slayer3d_input_manager *input, SDL_Scancode scancode);
+
+    /** @brief Return true if the mouse button is currently held down. */
+    bool slayer3d_input_is_mouse_button_down(const slayer3d_input_manager *input, Uint8 button);
+
+    /** @brief Return true if the mouse button was pressed during the current input tick. */
+    bool slayer3d_input_is_mouse_button_pressed(const slayer3d_input_manager *input, Uint8 button);
+
+    /** @brief Return true if the mouse button was released during the current input tick. */
+    bool slayer3d_input_is_mouse_button_released(const slayer3d_input_manager *input, Uint8 button);
+
     /**
      * @brief Return true if any button-like input or action was pressed this tick.
      *

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -780,6 +780,56 @@ static void restore_source_box_coordinates(editor_brush_source_box_runtime *box,
     }
 }
 
+static int normalized_quarter_turns(int quarter_turns)
+{
+    int normalized = quarter_turns % 4;
+    if (normalized < 0)
+        normalized += 4;
+    return normalized;
+}
+
+static void rotate_source_box_face_materials_y_once(editor_brush_source_box_runtime *box)
+{
+    if (box == NULL)
+        return;
+
+    char *old_px = box->face_materials[0];
+    char *old_nx = box->face_materials[1];
+    char *old_pz = box->face_materials[4];
+    char *old_nz = box->face_materials[5];
+
+    box->face_materials[5] = old_px;
+    box->face_materials[4] = old_nx;
+    box->face_materials[0] = old_pz;
+    box->face_materials[1] = old_nz;
+}
+
+static bool rotate_source_coord_pair_y(int x, int z, int center_x2, int center_z2, int quarter_turns, int *out_x,
+                                       int *out_z)
+{
+    if (out_x == NULL || out_z == NULL)
+        return false;
+
+    int dx2 = 2 * x - center_x2;
+    int dz2 = 2 * z - center_z2;
+    for (int turn = 0; turn < quarter_turns; ++turn)
+    {
+        const int next_dx2 = dz2;
+        const int next_dz2 = -dx2;
+        dx2 = next_dx2;
+        dz2 = next_dz2;
+    }
+
+    const int rotated_x2 = center_x2 + dx2;
+    const int rotated_z2 = center_z2 + dz2;
+    if ((rotated_x2 % 2) != 0 || (rotated_z2 % 2) != 0)
+        return false;
+
+    *out_x = rotated_x2 / 2;
+    *out_z = rotated_z2 / 2;
+    return true;
+}
+
 static bool load_editor_brush_source_box(yyjson_val *box, editor_brush_source_box_runtime *out_box, char *error_buffer,
                                          int error_buffer_size)
 {
@@ -2153,6 +2203,85 @@ bool editor_brush_world_translate_source_box(brush_world_runtime *world_runtime,
     if (!editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
     {
         restore_source_box_coordinates(box, old_min, old_max);
+        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+        return false;
+    }
+    return true;
+}
+
+bool editor_brush_world_rotate_source_box_y_quarter_turns(brush_world_runtime *world_runtime, const char *brush_name,
+                                                          int quarter_turns, char *error_buffer, int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed brush rotation requires a source model");
+        return false;
+    }
+
+    const int normalized_turns = normalized_quarter_turns(quarter_turns);
+    if (normalized_turns == 0)
+        return true;
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_name);
+    if (source_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        return false;
+    }
+
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    int old_min[3];
+    int old_max[3];
+    copy_source_box_coordinates(box, old_min, old_max);
+
+    const int center_x2 = old_min[0] + old_max[0];
+    const int center_z2 = old_min[2] + old_max[2];
+    int new_min_x = INT_MAX;
+    int new_max_x = INT_MIN;
+    int new_min_z = INT_MAX;
+    int new_max_z = INT_MIN;
+    const int xs[2] = {old_min[0], old_max[0]};
+    const int zs[2] = {old_min[2], old_max[2]};
+    for (int xi = 0; xi < 2; ++xi)
+    {
+        for (int zi = 0; zi < 2; ++zi)
+        {
+            int rotated_x = 0;
+            int rotated_z = 0;
+            if (!rotate_source_coord_pair_y(xs[xi], zs[zi], center_x2, center_z2, normalized_turns, &rotated_x,
+                                            &rotated_z))
+            {
+                set_error(error_buffer, error_buffer_size,
+                          "source brush rotation would leave the brush off the integer source grid");
+                return false;
+            }
+            new_min_x = SDL_min(new_min_x, rotated_x);
+            new_max_x = SDL_max(new_max_x, rotated_x);
+            new_min_z = SDL_min(new_min_z, rotated_z);
+            new_max_z = SDL_max(new_max_z, rotated_z);
+        }
+    }
+
+    box->min[0] = new_min_x;
+    box->max[0] = new_max_x;
+    box->min[2] = new_min_z;
+    box->max[2] = new_max_z;
+    for (int turn = 0; turn < normalized_turns; ++turn)
+        rotate_source_box_face_materials_y_once(box);
+
+    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size))
+    {
+        restore_source_box_coordinates(box, old_min, old_max);
+        for (int turn = 0; turn < 4 - normalized_turns; ++turn)
+            rotate_source_box_face_materials_y_once(box);
+        return false;
+    }
+
+    if (!editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+    {
+        restore_source_box_coordinates(box, old_min, old_max);
+        for (int turn = 0; turn < 4 - normalized_turns; ++turn)
+            rotate_source_box_face_materials_y_once(box);
         (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
         return false;
     }

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -1664,8 +1664,9 @@ static const char *source_prefab_for_material(const char *material)
 
 static bool source_prefab_name_supported(const char *prefab)
 {
-    return prefab != NULL && (SDL_strcmp(prefab, "floor") == 0 || SDL_strcmp(prefab, "wall") == 0 ||
-                              SDL_strcmp(prefab, "ceiling") == 0 || SDL_strcmp(prefab, "sky") == 0);
+    return prefab != NULL &&
+           (SDL_strcmp(prefab, "floor") == 0 || SDL_strcmp(prefab, "wall") == 0 || SDL_strcmp(prefab, "ceiling") == 0 ||
+            SDL_strcmp(prefab, "sky") == 0 || SDL_strcmp(prefab, "box") == 0 || SDL_strcmp(prefab, "editor.box") == 0);
 }
 
 static unsigned int source_prefab_default_contents(const char *prefab, unsigned int authored_contents)

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -453,6 +453,42 @@ static void update_editor_camera_orthographic_controller(slayer3d_game_data_runt
     }
 }
 
+static bool editor_camera_hover_or_selection_pivot(slayer3d_game_data_runtime *runtime, bool prefer_selection,
+                                                   slayer3d_vec3 *out_pivot, slayer3d_bounding_box *out_bounds)
+{
+    if (runtime == NULL || out_pivot == NULL)
+        return false;
+
+    slayer3d_game_data_editor_selection selection;
+    if (prefer_selection && slayer3d_game_data_get_active_editor_selection(runtime, &selection) && selection.has_bounds)
+    {
+        *out_pivot = slayer3d_vec3_scale(slayer3d_vec3_add(selection.bounds.min, selection.bounds.max), 0.5f);
+        if (out_bounds != NULL)
+            *out_bounds = selection.bounds;
+        return true;
+    }
+
+    if (slayer3d_properties_get_bool(runtime->scene_state, "editor.hover.hit", false))
+    {
+        *out_pivot = slayer3d_properties_get_vec3(runtime->scene_state, "editor.hover.point",
+                                                  slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        if (out_bounds != NULL)
+        {
+            out_bounds->min = slayer3d_properties_get_vec3(runtime->scene_state, "editor.hover.bounds_min", *out_pivot);
+            out_bounds->max = slayer3d_properties_get_vec3(runtime->scene_state, "editor.hover.bounds_max", *out_pivot);
+        }
+        return true;
+    }
+
+    if (!slayer3d_game_data_get_active_editor_selection(runtime, &selection) || !selection.has_bounds)
+        return false;
+
+    *out_pivot = slayer3d_vec3_scale(slayer3d_vec3_add(selection.bounds.min, selection.bounds.max), 0.5f);
+    if (out_bounds != NULL)
+        *out_bounds = selection.bounds;
+    return true;
+}
+
 void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson_val *component,
                                      slayer3d_registered_actor *actor, const slayer3d_input_manager *input, float dt)
 {
@@ -489,6 +525,13 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
     const int look_action = fps_controller_action_id(runtime, component, "look");
     const bool look_active =
         input != NULL && (look_action < 0 || fps_controller_action_value(runtime, input, look_action) > 0.0f);
+    const SDL_Keymod modifiers = SDL_GetModState();
+    const bool orbit_active = (modifiers & SDL_KMOD_ALT) != 0;
+    slayer3d_vec3 orbit_pivot = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const bool has_orbit_pivot =
+        orbit_active && editor_camera_hover_or_selection_pivot(runtime, false, &orbit_pivot, NULL);
+    const float orbit_radius =
+        has_orbit_pivot ? SDL_max(slayer3d_vec3_length(slayer3d_vec3_sub(actor->position, orbit_pivot)), 0.5f) : 0.0f;
     if (json_bool(component, "mouse_look", true) && look_active)
     {
         const float sensitivity = json_float(component, "mouse_sensitivity", 0.002f);
@@ -504,6 +547,26 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
         slayer3d_vec3_make(SDL_sinf(yaw) * cos_pitch, SDL_sinf(pitch), -SDL_cosf(yaw) * cos_pitch);
     const slayer3d_vec3 camera_right = slayer3d_vec3_make(SDL_cosf(yaw), 0.0f, SDL_sinf(yaw));
     const slayer3d_vec3 camera_up = slayer3d_vec3_normalize(slayer3d_vec3_cross(camera_right, camera_forward));
+
+    if (has_orbit_pivot && look_active &&
+        (SDL_fabsf(slayer3d_input_get_mouse_dx(input)) > 0.0f || SDL_fabsf(slayer3d_input_get_mouse_dy(input)) > 0.0f))
+    {
+        actor_set_position(actor, slayer3d_vec3_sub(orbit_pivot, slayer3d_vec3_scale(camera_forward, orbit_radius)));
+    }
+
+    const int frame_action = fps_controller_action_id(runtime, component, "frame_selected");
+    if (input != NULL && frame_action >= 0 && slayer3d_input_is_pressed(input, frame_action))
+    {
+        slayer3d_vec3 pivot;
+        slayer3d_bounding_box bounds;
+        if (editor_camera_hover_or_selection_pivot(runtime, true, &pivot, &bounds))
+        {
+            const slayer3d_vec3 extents = slayer3d_vec3_sub(bounds.max, bounds.min);
+            const float max_extent = SDL_max(SDL_max(extents.x, extents.y), extents.z);
+            const float distance = SDL_max(max_extent * 2.25f, 2.0f);
+            actor_set_position(actor, slayer3d_vec3_sub(pivot, slayer3d_vec3_scale(camera_forward, distance)));
+        }
+    }
 
     const int mouse_pan_action = fps_controller_action_id(runtime, component, "mouse_pan");
     if (input != NULL && mouse_pan_action >= 0 && fps_controller_action_value(runtime, input, mouse_pan_action) > 0.0f)

--- a/src/game_data_controller_runtime.c
+++ b/src/game_data_controller_runtime.c
@@ -527,14 +527,24 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
         input != NULL && (look_action < 0 || fps_controller_action_value(runtime, input, look_action) > 0.0f);
     const SDL_Keymod modifiers = SDL_GetModState();
     const bool orbit_active = (modifiers & SDL_KMOD_ALT) != 0;
-    slayer3d_vec3 orbit_pivot = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-    const bool has_orbit_pivot =
-        orbit_active && editor_camera_hover_or_selection_pivot(runtime, false, &orbit_pivot, NULL);
-    const float orbit_radius =
-        has_orbit_pivot ? SDL_max(slayer3d_vec3_length(slayer3d_vec3_sub(actor->position, orbit_pivot)), 0.5f) : 0.0f;
+    if (!look_active || !orbit_active)
+        runtime->editor_camera_orbit.active = false;
+    if (look_active && orbit_active && !runtime->editor_camera_orbit.active)
+    {
+        slayer3d_vec3 pivot = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        if (editor_camera_hover_or_selection_pivot(runtime, false, &pivot, NULL))
+        {
+            runtime->editor_camera_orbit.active = true;
+            runtime->editor_camera_orbit.pivot = pivot;
+            runtime->editor_camera_orbit.radius =
+                SDL_max(slayer3d_vec3_length(slayer3d_vec3_sub(actor->position, pivot)), 0.5f);
+        }
+    }
     if (json_bool(component, "mouse_look", true) && look_active)
     {
-        const float sensitivity = json_float(component, "mouse_sensitivity", 0.002f);
+        const float sensitivity = orbit_active ? json_float(component, "orbit_sensitivity",
+                                                            json_float(component, "mouse_sensitivity", 0.002f))
+                                               : json_float(component, "mouse_sensitivity", 0.002f);
         yaw += slayer3d_input_get_mouse_dx(input) * sensitivity;
         pitch -= slayer3d_input_get_mouse_dy(input) * sensitivity;
     }
@@ -548,10 +558,12 @@ void update_editor_camera_controller(slayer3d_game_data_runtime *runtime, yyjson
     const slayer3d_vec3 camera_right = slayer3d_vec3_make(SDL_cosf(yaw), 0.0f, SDL_sinf(yaw));
     const slayer3d_vec3 camera_up = slayer3d_vec3_normalize(slayer3d_vec3_cross(camera_right, camera_forward));
 
-    if (has_orbit_pivot && look_active &&
+    if (runtime->editor_camera_orbit.active && look_active && orbit_active &&
         (SDL_fabsf(slayer3d_input_get_mouse_dx(input)) > 0.0f || SDL_fabsf(slayer3d_input_get_mouse_dy(input)) > 0.0f))
     {
-        actor_set_position(actor, slayer3d_vec3_sub(orbit_pivot, slayer3d_vec3_scale(camera_forward, orbit_radius)));
+        actor_set_position(actor,
+                           slayer3d_vec3_sub(runtime->editor_camera_orbit.pivot,
+                                             slayer3d_vec3_scale(camera_forward, runtime->editor_camera_orbit.radius)));
     }
 
     const int frame_action = fps_controller_action_id(runtime, component, "frame_selected");

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -764,6 +764,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
         drag->scene = slayer3d_game_data_active_scene(runtime);
         drag->start_point = hover_selection->point;
         drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
+        (void)slayer3d_input_get_mouse_position(input, &drag->start_mouse_x, &drag->start_mouse_y);
         if (out_consumed != NULL)
             *out_consumed = true;
     }
@@ -773,7 +774,27 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
     if (out_consumed != NULL)
         *out_consumed = true;
 
-    if (hover_selection != NULL && hover_selection->hit)
+    const SDL_Keymod modifiers = SDL_GetModState();
+    const bool y_axis_lock = (modifiers & SDL_KMOD_ALT) != 0;
+    if (y_axis_lock)
+    {
+        float mouse_x = drag->start_mouse_x;
+        float mouse_y = drag->start_mouse_y;
+        (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
+        const float units_per_pixel = drag->grid_size / 48.0f;
+        const slayer3d_vec3 desired = slayer3d_vec3_make(
+            0.0f, editor_snap_delta((drag->start_mouse_y - mouse_y) * units_per_pixel, drag->grid_size), 0.0f);
+        const slayer3d_vec3 incremental = slayer3d_vec3_sub(desired, drag->applied_offset);
+        if (slayer3d_vec3_length_squared(incremental) > 0.0000001f)
+        {
+            if (slayer3d_game_data_translate_selected_editor_brushes(runtime, incremental))
+            {
+                drag->applied_offset = desired;
+                drag->moved = true;
+            }
+        }
+    }
+    else if (hover_selection != NULL && hover_selection->hit)
     {
         const slayer3d_vec3 desired =
             slayer3d_vec3_make(editor_snap_delta(hover_selection->point.x - drag->start_point.x, drag->grid_size), 0.0f,
@@ -1134,6 +1155,18 @@ void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *o
     editor_set_int_output(scene_state, outputs, "compiled_triangle_count_key",
                           resolved.hit && resolved.compiled_face != NULL ? resolved.compiled_face->triangle_count : 0);
     editor_set_float_output(scene_state, outputs, "fraction_key", resolved.hit ? resolved.fraction : 1.0f);
+    const slayer3d_vec3 bounds_min =
+        resolved.hit && resolved.has_bounds ? resolved.bounds.min : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const slayer3d_vec3 bounds_max =
+        resolved.hit && resolved.has_bounds ? resolved.bounds.max : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const slayer3d_vec3 dimensions = resolved.hit && resolved.has_bounds ? slayer3d_vec3_sub(bounds_max, bounds_min)
+                                                                         : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    editor_set_vec3_output(scene_state, outputs, "bounds_min_key", bounds_min);
+    editor_set_vec3_output(scene_state, outputs, "bounds_max_key", bounds_max);
+    editor_set_vec3_output(scene_state, outputs, "dimensions_key", dimensions);
+    editor_set_float_output(scene_state, outputs, "dimension_x_key", dimensions.x);
+    editor_set_float_output(scene_state, outputs, "dimension_y_key", dimensions.y);
+    editor_set_float_output(scene_state, outputs, "dimension_z_key", dimensions.z);
     editor_set_vec3_output(scene_state, outputs, "point_key",
                            resolved.hit ? resolved.point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
     editor_set_vec3_output(scene_state, outputs, "normal_key",

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -618,6 +618,38 @@ static bool editor_mode_is_select(const slayer3d_game_data_runtime *runtime)
            SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "select") == 0;
 }
 
+static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_select(runtime))
+        return true;
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    const float grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 16.0f);
+    if (input == NULL || grid_size <= 0.0f)
+        return true;
+
+    slayer3d_vec3 offset = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT))
+        offset.x = -grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT))
+        offset.x = grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP))
+        offset.z = -grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN))
+        offset.z = grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEUP) ||
+             slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_HOME))
+        offset.y = grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEDOWN) ||
+             slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_END))
+        offset.y = -grid_size;
+
+    if (slayer3d_vec3_length_squared(offset) <= 0.0000001f)
+        return true;
+    (void)slayer3d_game_data_translate_selected_editor_brushes(runtime, offset);
+    return true;
+}
+
 static const char *editor_metadata_stable_id(const slayer3d_game_data_editor_metadata *metadata)
 {
     return metadata != NULL && metadata->stable_id != NULL ? metadata->stable_id : "";
@@ -935,7 +967,19 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     }
 
     publish_editor_selection(runtime, obj_get(selection_json, "hover_outputs"), &hover_selection);
-    update_editor_placement_preview(runtime, editor, &hover_selection);
+    bool drag_consumed = false;
+    if (!update_editor_drag_create(runtime, editor, &hover_selection, &drag_consumed))
+        return false;
+    if (!drag_consumed)
+        update_editor_placement_preview(runtime, editor, &hover_selection);
+    if (!editor_handle_grid_nudge(runtime))
+        return false;
+    if (drag_consumed)
+    {
+        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+        publish_editor_selected_brush_count(runtime);
+        return true;
+    }
     const bool select_requested = editor_selection_button_requested(runtime, selection_json, "select_button", "LEFT");
     const bool secondary_select_requested =
         editor_selection_button_requested(runtime, selection_json, "secondary_select_button", NULL);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -460,6 +460,87 @@ static bool editor_selection_button_requested(const slayer3d_game_data_runtime *
     return button != 0 && slayer3d_input_get_pressed_mouse_button(input) == button;
 }
 
+static bool editor_mouse_in_rect(float mouse_x, float mouse_y, yyjson_val *rect)
+{
+    if (!yyjson_is_obj(rect))
+        return false;
+    const float x = json_float(rect, "x", 0.0f);
+    const float y = json_float(rect, "y", 0.0f);
+    const float w = json_float(rect, "w", 0.0f);
+    const float h = json_float(rect, "h", 0.0f);
+    return w > 0.0f && h > 0.0f && mouse_x >= x && mouse_y >= y && mouse_x < x + w && mouse_y < y + h;
+}
+
+static void editor_set_grid_value(slayer3d_game_data_runtime *runtime, yyjson_val *widget, float value)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    const char *grid_key = json_string(widget, "grid_key", "editor.grid.size");
+    const char *brush_grid_key = json_string(widget, "brush_grid_key", "editor.brush.grid_size");
+    slayer3d_properties_set_float(runtime->scene_state, grid_key, value);
+    if (brush_grid_key != NULL && brush_grid_key[0] != '\0')
+        slayer3d_properties_set_float(runtime->scene_state, brush_grid_key, value);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "grid size selected");
+}
+
+static bool editor_handle_grid_widget(slayer3d_game_data_runtime *runtime, yyjson_val *editor, bool *out_consumed)
+{
+    if (out_consumed != NULL)
+        *out_consumed = false;
+    yyjson_val *widget = obj_get(editor, "grid_widget");
+    yyjson_val *values = obj_get(widget, "values");
+    if (runtime == NULL || runtime->scene_state == NULL || !yyjson_is_obj(widget) || !yyjson_is_arr(values))
+        return true;
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    float mouse_x = 0.0f;
+    float mouse_y = 0.0f;
+    if (input == NULL || !slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+        return true;
+
+    const char *open_key = json_string(widget, "open_key", "editor.grid.menu.open");
+    const bool opened = slayer3d_properties_get_bool(runtime->scene_state, open_key, false);
+    const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool over_button = editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "button"));
+    const bool over_popup = editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "popup"));
+    if (!left_pressed)
+    {
+        if (out_consumed != NULL)
+            *out_consumed = over_button || (opened && over_popup);
+        return true;
+    }
+
+    if (over_button)
+    {
+        slayer3d_properties_set_bool(runtime->scene_state, open_key, !opened);
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    if (opened && over_popup)
+    {
+        yyjson_val *popup = obj_get(widget, "popup");
+        const float y = json_float(popup, "y", 0.0f);
+        const float row_height = SDL_max(json_float(widget, "row_height", 24.0f), 1.0f);
+        const int index = (int)SDL_floorf((mouse_y - y) / row_height);
+        if (index >= 0 && index < (int)yyjson_arr_size(values))
+        {
+            yyjson_val *value = yyjson_arr_get(values, (size_t)index);
+            if (yyjson_is_num(value))
+                editor_set_grid_value(runtime, widget, (float)yyjson_get_num(value));
+        }
+        slayer3d_properties_set_bool(runtime->scene_state, open_key, false);
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    if (opened)
+        slayer3d_properties_set_bool(runtime->scene_state, open_key, false);
+    return true;
+}
+
 slayer3d_game_data_editor_selection resolved_editor_selection(const slayer3d_game_data_runtime *runtime,
                                                               const slayer3d_game_data_editor_selection *selection);
 
@@ -618,6 +699,105 @@ static bool editor_mode_is_select(const slayer3d_game_data_runtime *runtime)
            SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "select") == 0;
 }
 
+static bool editor_selection_matches_brush(const slayer3d_game_data_editor_selection *selection, const char *world_name,
+                                           const char *element_name)
+{
+    return selection != NULL && selection->hit && selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD &&
+           selection->world_name != NULL && selection->element_name != NULL && world_name != NULL &&
+           element_name != NULL && SDL_strcmp(selection->world_name, world_name) == 0 &&
+           SDL_strcmp(selection->element_name, element_name) == 0;
+}
+
+static bool editor_hover_is_selected_brush(const slayer3d_game_data_runtime *runtime,
+                                           const slayer3d_game_data_editor_selection *hover_selection)
+{
+    if (runtime == NULL || hover_selection == NULL ||
+        hover_selection->type != SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
+        return false;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        if (editor_selection_matches_brush(&runtime->editor_selected_brushes[i], hover_selection->world_name,
+                                           hover_selection->element_name))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static float editor_snap_delta(float delta, float grid_size)
+{
+    const float grid = SDL_max(grid_size, 0.001f);
+    return SDL_roundf(delta / grid) * grid;
+}
+
+static void clear_editor_drag_move(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    SDL_zero(runtime->editor_drag_move);
+}
+
+static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
+                                    const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
+{
+    if (out_consumed != NULL)
+        *out_consumed = false;
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_select(runtime))
+    {
+        clear_editor_drag_move(runtime);
+        return true;
+    }
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input == NULL)
+        return true;
+
+    editor_drag_move_state *drag = &runtime->editor_drag_move;
+    const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
+    const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
+    if (!drag->active && left_pressed && editor_hover_is_selected_brush(runtime, hover_selection))
+    {
+        SDL_zero(*drag);
+        drag->active = true;
+        drag->scene = slayer3d_game_data_active_scene(runtime);
+        drag->start_point = hover_selection->point;
+        drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
+        if (out_consumed != NULL)
+            *out_consumed = true;
+    }
+
+    if (!drag->active)
+        return true;
+    if (out_consumed != NULL)
+        *out_consumed = true;
+
+    if (hover_selection != NULL && hover_selection->hit)
+    {
+        const slayer3d_vec3 desired =
+            slayer3d_vec3_make(editor_snap_delta(hover_selection->point.x - drag->start_point.x, drag->grid_size), 0.0f,
+                               editor_snap_delta(hover_selection->point.z - drag->start_point.z, drag->grid_size));
+        const slayer3d_vec3 incremental = slayer3d_vec3_sub(desired, drag->applied_offset);
+        if (slayer3d_vec3_length_squared(incremental) > 0.0000001f)
+        {
+            if (slayer3d_game_data_translate_selected_editor_brushes(runtime, incremental))
+            {
+                drag->applied_offset = desired;
+                drag->moved = true;
+            }
+        }
+    }
+
+    if (left_released || !left_down)
+    {
+        if (runtime->scene_state != NULL && drag->moved)
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "drag moved brush");
+        clear_editor_drag_move(runtime);
+    }
+    return true;
+}
+
 static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_select(runtime))
@@ -630,13 +810,13 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime)
 
     slayer3d_vec3 offset = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
     if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT))
-        offset.x = -grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT))
-        offset.x = grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP))
         offset.z = -grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN))
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT))
         offset.z = grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP))
+        offset.x = -grid_size;
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN))
+        offset.x = grid_size;
     else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEUP) ||
              slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_HOME))
         offset.y = grid_size;
@@ -967,6 +1147,24 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     }
 
     publish_editor_selection(runtime, obj_get(selection_json, "hover_outputs"), &hover_selection);
+    bool ui_consumed = false;
+    if (!editor_handle_grid_widget(runtime, editor, &ui_consumed))
+        return false;
+    if (ui_consumed)
+    {
+        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+        publish_editor_selected_brush_count(runtime);
+        return true;
+    }
+    bool drag_move_consumed = false;
+    if (!editor_handle_drag_move(runtime, &hover_selection, &drag_move_consumed))
+        return false;
+    if (drag_move_consumed)
+    {
+        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+        publish_editor_selected_brush_count(runtime);
+        return true;
+    }
     bool drag_consumed = false;
     if (!update_editor_drag_create(runtime, editor, &hover_selection, &drag_consumed))
         return false;

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -808,21 +808,48 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime)
     if (input == NULL || grid_size <= 0.0f)
         return true;
 
+    const SDL_Keymod modifiers = SDL_GetModState();
+    const bool transform_modifier = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_ALT)) != 0;
+    if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_HOME) ||
+        (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT)))
+    {
+        (void)slayer3d_game_data_rotate_selected_editor_brushes_y(runtime, 1);
+        return true;
+    }
+    if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_END) ||
+        (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT)))
+    {
+        (void)slayer3d_game_data_rotate_selected_editor_brushes_y(runtime, -1);
+        return true;
+    }
+
     slayer3d_vec3 offset = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-    if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT))
-        offset.z = -grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT))
-        offset.z = grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP))
-        offset.x = -grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN))
-        offset.x = grid_size;
-    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEUP) ||
-             slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_HOME))
+    if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEUP) ||
+        (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP)))
+    {
         offset.y = grid_size;
+    }
     else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_PAGEDOWN) ||
-             slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_END))
+             (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN)))
+    {
         offset.y = -grid_size;
+    }
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT) && !transform_modifier)
+    {
+        offset.z = -grid_size;
+    }
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT) && !transform_modifier)
+    {
+        offset.z = grid_size;
+    }
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP) && !transform_modifier)
+    {
+        offset.x = grid_size;
+    }
+    else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN) && !transform_modifier)
+    {
+        offset.x = -grid_size;
+    }
 
     if (slayer3d_vec3_length_squared(offset) <= 0.0000001f)
         return true;

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -648,10 +648,16 @@ static bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime
     const bool shift = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
     if (!editor_selection_is_selectable_brush(hover_selection))
     {
-        if (!shift)
+        if (hover_selection != NULL && hover_selection->hit &&
+            hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_PLAYER_START)
+        {
             clear_editor_selected_brushes(runtime);
-        runtime->editor_active_selection = *hover_selection;
-        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+            runtime->editor_active_selection = *hover_selection;
+            runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+            return true;
+        }
+        if (!shift)
+            clear_editor_active_selection(runtime);
         return true;
     }
 
@@ -757,26 +763,39 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
     const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
     const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
     const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
-    if (!drag->active && left_pressed && editor_hover_is_selected_brush(runtime, hover_selection))
+    const SDL_Keymod modifiers = SDL_GetModState();
+    const bool y_axis_lock = (modifiers & SDL_KMOD_ALT) != 0;
+    const bool can_start_from_hover = editor_selection_is_selectable_brush(hover_selection);
+    const bool can_start_y_axis_drag =
+        y_axis_lock && editor_selected_brushes_active_for_scene(runtime) && runtime->editor_selected_brush_count > 0;
+    bool just_started_without_consuming_click = false;
+    if (!drag->active && left_pressed && (can_start_from_hover || can_start_y_axis_drag))
     {
+        const bool hover_was_selected =
+            can_start_from_hover && editor_hover_is_selected_brush(runtime, hover_selection);
+        const bool consume_start_click = hover_was_selected || can_start_y_axis_drag;
         SDL_zero(*drag);
         drag->active = true;
+        drag->axis_lock_y = y_axis_lock;
         drag->scene = slayer3d_game_data_active_scene(runtime);
-        drag->start_point = hover_selection->point;
+        const slayer3d_game_data_editor_selection resolved = resolved_editor_selection(
+            runtime, can_start_from_hover ? hover_selection : &runtime->editor_active_selection);
+        drag->start_point = resolved.hit ? resolved.point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
         drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
         (void)slayer3d_input_get_mouse_position(input, &drag->start_mouse_x, &drag->start_mouse_y);
         if (out_consumed != NULL)
-            *out_consumed = true;
+            *out_consumed = consume_start_click;
+        just_started_without_consuming_click = !consume_start_click;
     }
 
     if (!drag->active)
         return true;
+    if (just_started_without_consuming_click)
+        return true;
     if (out_consumed != NULL)
         *out_consumed = true;
 
-    const SDL_Keymod modifiers = SDL_GetModState();
-    const bool y_axis_lock = (modifiers & SDL_KMOD_ALT) != 0;
-    if (y_axis_lock)
+    if (drag->axis_lock_y)
     {
         float mouse_x = drag->start_mouse_x;
         float mouse_y = drag->start_mouse_y;
@@ -791,6 +810,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
             {
                 drag->applied_offset = desired;
                 drag->moved = true;
+                update_active_editor_selection_from_selected_brushes(runtime);
             }
         }
     }
@@ -806,6 +826,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
             {
                 drag->applied_offset = desired;
                 drag->moved = true;
+                update_active_editor_selection_from_selected_brushes(runtime);
             }
         }
     }

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -599,6 +599,30 @@ static bool apply_editor_brush_translate(slayer3d_game_data_runtime *runtime,
     return false;
 }
 
+static bool apply_editor_brush_rotate_y(slayer3d_game_data_runtime *runtime,
+                                        const editor_command_transaction_entry *entry, int quarter_turns)
+{
+    if (runtime == NULL || entry == NULL || entry->world_name == NULL || entry->element_name == NULL)
+        return false;
+
+    const int normalized_turns = quarter_turns % 4;
+    if (normalized_turns == 0)
+        return true;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, entry->world_name);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+        return false;
+    const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                     ? entry->element_stable_id
+                                     : entry->element_name;
+    if (editor_brush_world_rotate_source_box_y_quarter_turns(world_runtime, brush_identity, normalized_turns, NULL, 0))
+    {
+        editor_brush_world_mark_dirty(world_runtime);
+        return true;
+    }
+    return false;
+}
+
 static bool apply_editor_brush_paint(slayer3d_game_data_runtime *runtime, const editor_command_transaction_entry *entry,
                                      bool forward)
 {
@@ -1047,6 +1071,7 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
         return false;
     }
     return (SDL_strcmp(entry->command, "translate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "create") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "delete") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
@@ -1086,6 +1111,14 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         if (!apply_editor_brush_face_resize(runtime, entry, forward))
             return false;
         resize_active_editor_selection_for_transaction(runtime, entry, forward, active_face_matches);
+        return true;
+    }
+    if (SDL_strcmp(entry->command, "rotate_y") == 0)
+    {
+        const int quarter_turns = forward ? entry->rotation_quarter_turns : -entry->rotation_quarter_turns;
+        if (!apply_editor_brush_rotate_y(runtime, entry, quarter_turns))
+            return false;
+        update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_element_matches);
         return true;
     }
 
@@ -1735,6 +1768,66 @@ bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_run
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
     (void)last_entry;
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
+}
+
+bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns)
+{
+    if (runtime == NULL || quarter_turns == 0 || runtime->editor_selected_brush_count <= 0 ||
+        runtime->editor_selected_brush_scene == NULL)
+    {
+        return false;
+    }
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+        return false;
+
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int applied_count = 0;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+        if (!transaction_editor_selection_is_selectable_brush(selection))
+            goto fail;
+
+        editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+        if (entry == NULL)
+            goto fail;
+        if (!editor_prepare_transaction_common(entry, active_scene, "rotate_y", "element", selection->world_name,
+                                               selection->element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+                                            &entry->element_stable_id))
+        {
+            goto fail;
+        }
+        entry->rotation_quarter_turns = quarter_turns;
+        entry->has_bounds = selection->has_bounds;
+        entry->bounds = selection->bounds;
+        SDL_snprintf(entry->message, sizeof(entry->message), "rotated %s", selection->element_name);
+
+        if (!apply_editor_transaction_mutation(runtime, entry, true))
+            goto fail;
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
+        applied_count++;
+    }
+
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "rotated 1 selected brush" : "rotated %d selected brushes", applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
     return applied_count > 0;
 
 fail:

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1767,7 +1767,11 @@ bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_run
                      applied_count == 1 ? "moved 1 selected brush" : "moved %d selected brushes", applied_count);
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
-    (void)last_entry;
+    if (last_entry != NULL && runtime->editor_selected_brush_count > 0)
+    {
+        runtime->editor_active_selection = runtime->editor_selected_brushes[runtime->editor_selected_brush_count - 1];
+        runtime->editor_selection_scene = active_scene;
+    }
     return applied_count > 0;
 
 fail:

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1142,6 +1142,13 @@ static bool copy_selected_editor_brush_delete_target(selected_editor_brush_delet
            (stable_id == NULL || target->element_stable_id != NULL);
 }
 
+static bool transaction_editor_selection_is_selectable_brush(const slayer3d_game_data_editor_selection *selection)
+{
+    return selection != NULL && selection->hit && selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD &&
+           selection->world_name != NULL && selection->world_name[0] != '\0' && selection->element_name != NULL &&
+           selection->element_name[0] != '\0';
+}
+
 static int editor_brush_top_y_face_index(const slayer3d_game_data_brush *brush)
 {
     int best_index = -1;
@@ -1572,6 +1579,172 @@ resize_record_fail: {
     publish_editor_transaction(runtime, outputs, "commit", false, NULL, error_message);
     return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "commit", false, NULL, error_message);
 }
+}
+
+bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                       const char *material_name, unsigned int contents,
+                                                       const int source_min[3], const int source_max[3],
+                                                       editor_brush_source_prefab_result *out_result)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || material_name == NULL ||
+        material_name[0] == '\0' || source_min == NULL || source_max == NULL)
+    {
+        return false;
+    }
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, world_name);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+        return false;
+
+    char brush_name[256];
+    if (!editor_brush_world_generate_brush_name(world_runtime, brush_name, sizeof(brush_name)))
+        return false;
+
+    editor_brush_source_prefab_desc desc;
+    SDL_zero(desc);
+    desc.prefab = "editor.box";
+    desc.material = material_name;
+    desc.contents = contents != 0u ? contents : SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+
+    editor_brush_source_prefab_result result;
+    char error_buffer[256] = {0};
+    if (!editor_brush_world_run_source_prefab_command(world_runtime, &desc, brush_name, source_min, source_max, false,
+                                                      &result, error_buffer, sizeof(error_buffer)) ||
+        !result.valid || result.no_op)
+    {
+        if (out_result != NULL)
+        {
+            *out_result = result;
+            if (error_buffer[0] != '\0')
+                SDL_strlcpy(out_result->warning, error_buffer, sizeof(out_result->warning));
+        }
+        return false;
+    }
+
+    editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+    if (entry == NULL)
+        return false;
+
+    if (!editor_prepare_transaction_common(entry, slayer3d_game_data_active_scene(runtime), "create", "element",
+                                           world_name, brush_name) ||
+        !copy_editor_transaction_string(brush_name, &entry->element_stable_id))
+    {
+        editor_command_history_state *history = &runtime->editor_command_history;
+        free_editor_command_transaction_entry(entry);
+        history->count--;
+        history->cursor = history->count;
+        return false;
+    }
+
+    editor_brush_source_box_runtime *box = &entry->source_box_snapshot;
+    SDL_zero(*box);
+    box->stable_id = SDL_strdup(brush_name);
+    box->name = SDL_strdup(brush_name);
+    box->prefab = SDL_strdup("editor.box");
+    box->material = SDL_strdup(material_name);
+    if (box->stable_id == NULL || box->name == NULL || box->prefab == NULL || box->material == NULL)
+    {
+        editor_command_history_state *history = &runtime->editor_command_history;
+        free_editor_command_transaction_entry(entry);
+        history->count--;
+        history->cursor = history->count;
+        return false;
+    }
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        box->min[axis] = source_min[axis];
+        box->max[axis] = source_max[axis];
+    }
+    box->contents = desc.contents;
+    entry->has_source_box_snapshot = true;
+    entry->brush_index = world_runtime->editor_source_box_count;
+    entry->has_bounds = true;
+    entry->bounds = result.bounds;
+    SDL_snprintf(entry->message, sizeof(entry->message), "created %s", brush_name);
+
+    if (!apply_editor_transaction_mutation(runtime, entry, true))
+    {
+        editor_command_history_state *history = &runtime->editor_command_history;
+        free_editor_command_transaction_entry(entry);
+        history->count--;
+        history->cursor = history->count;
+        return false;
+    }
+
+    if (out_result != NULL)
+        *out_result = result;
+    if (runtime->scene_state != NULL)
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", entry->message);
+    return true;
+}
+
+bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset)
+{
+    if (runtime == NULL || slayer3d_vec3_length_squared(offset) <= 0.0000001f ||
+        runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+    {
+        return false;
+    }
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+    {
+        return false;
+    }
+
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int applied_count = 0;
+    editor_command_transaction_entry *last_entry = NULL;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+        if (!transaction_editor_selection_is_selectable_brush(selection))
+            goto fail;
+
+        editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+        if (entry == NULL)
+            goto fail;
+        if (!editor_prepare_transaction_common(entry, active_scene, "translate", "element", selection->world_name,
+                                               selection->element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+                                            &entry->element_stable_id))
+        {
+            goto fail;
+        }
+        entry->offset = offset;
+        entry->has_bounds = selection->has_bounds;
+        entry->bounds = selection->has_bounds ? translated_bounds(selection->bounds, offset)
+                                              : (slayer3d_bounding_box){slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                                        slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
+        SDL_snprintf(entry->message, sizeof(entry->message), "moved %s", selection->element_name);
+
+        if (!apply_editor_transaction_mutation(runtime, entry, true))
+            goto fail;
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
+        last_entry = entry;
+        applied_count++;
+    }
+
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "moved 1 selected brush" : "moved %d selected brushes", applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
+    (void)last_entry;
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
 }
 
 bool slayer3d_game_data_commit_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -22,6 +22,10 @@ typedef struct editor_debug_iteration_context
 static bool emit_editor_selected_brush_bounds(const slayer3d_game_data_runtime *runtime,
                                               const slayer3d_game_data_editor_debug_desc *desc,
                                               slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata);
+static bool emit_editor_overlapping_source_brush_bounds(const slayer3d_game_data_runtime *runtime,
+                                                        const slayer3d_game_data_editor_debug_desc *desc,
+                                                        slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                        void *userdata);
 static bool emit_editor_debug_overlay_markers(const slayer3d_game_data_runtime *runtime,
                                               const slayer3d_game_data_editor_debug_desc *desc,
                                               slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata);
@@ -195,6 +199,8 @@ bool slayer3d_game_data_for_each_active_editor_debug_primitive(const slayer3d_ga
         return false;
     if (!emit_editor_selected_brush_bounds(runtime, &desc, callback, userdata))
         return false;
+    if (!emit_editor_overlapping_source_brush_bounds(runtime, &desc, callback, userdata))
+        return false;
 
     return emit_editor_debug_overlay_markers(runtime, &desc, callback, userdata);
 }
@@ -219,6 +225,28 @@ static bool emit_editor_debug_bounds(editor_debug_iteration_context *context, sl
             return false;
     }
     return true;
+}
+
+static bool editor_source_box_contents_are_structural(unsigned int contents)
+{
+    if (contents == 0u)
+        contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    return (contents & (SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP |
+                        SLAYER3D_GAME_DATA_BRUSH_CONTENT_PROJECTILE_CLIP | SLAYER3D_GAME_DATA_BRUSH_CONTENT_SKY)) != 0u;
+}
+
+static bool editor_source_intervals_overlap_positive(int a_min, int a_max, int b_min, int b_max)
+{
+    return SDL_max(a_min, b_min) < SDL_min(a_max, b_max);
+}
+
+static bool editor_source_boxes_overlap_positive(const editor_brush_source_box_runtime *a,
+                                                 const editor_brush_source_box_runtime *b)
+{
+    return a != NULL && b != NULL &&
+           editor_source_intervals_overlap_positive(a->min[0], a->max[0], b->min[0], b->max[0]) &&
+           editor_source_intervals_overlap_positive(a->min[1], a->max[1], b->min[1], b->max[1]) &&
+           editor_source_intervals_overlap_positive(a->min[2], a->max[2], b->min[2], b->max[2]);
 }
 
 static bool emit_editor_selected_brush_bounds(const slayer3d_game_data_runtime *runtime,
@@ -263,6 +291,61 @@ static bool emit_editor_selected_brush_bounds(const slayer3d_game_data_runtime *
         context.face_index = selection.face_index;
         if (!emit_editor_debug_bounds(&context, selection.bounds))
             return false;
+    }
+    return true;
+}
+
+static bool emit_editor_overlapping_source_brush_bounds(const slayer3d_game_data_runtime *runtime,
+                                                        const slayer3d_game_data_editor_debug_desc *desc,
+                                                        slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                        void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL)
+        return true;
+    const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS) == 0u)
+        return true;
+
+    for (int world_index = 0; world_index < runtime->brush_world_count; ++world_index)
+    {
+        const brush_world_runtime *world = &runtime->brush_worlds[world_index];
+        if (!world->editor_has_source_model || world->editor_source_box_count <= 1)
+            continue;
+
+        for (int a = 0; a < world->editor_source_box_count; ++a)
+        {
+            const editor_brush_source_box_runtime *box = &world->editor_source_boxes[a];
+            if (!editor_source_box_contents_are_structural(box->contents))
+                continue;
+
+            bool overlaps = false;
+            for (int b = 0; b < world->editor_source_box_count; ++b)
+            {
+                if (a == b)
+                    continue;
+                const editor_brush_source_box_runtime *other = &world->editor_source_boxes[b];
+                if (editor_source_box_contents_are_structural(other->contents) &&
+                    editor_source_boxes_overlap_positive(box, other))
+                {
+                    overlaps = true;
+                    break;
+                }
+            }
+            if (!overlaps)
+                continue;
+
+            editor_debug_iteration_context context;
+            SDL_zero(context);
+            context.callback = callback;
+            context.userdata = userdata;
+            context.color = editor_debug_selection_flash_color((slayer3d_color){255, 48, 48, 255});
+            context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_BOUNDS_EDGE;
+            context.world_name = world->desc.name;
+            context.element_name = box->name != NULL ? box->name : box->stable_id;
+            context.face_index = -1;
+            if (!emit_editor_debug_bounds(&context, editor_brush_source_box_bounds_meters(world, box)))
+                return false;
+        }
     }
     return true;
 }

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -7,6 +7,13 @@ void clear_editor_placement_preview(slayer3d_game_data_runtime *runtime)
     SDL_zero(runtime->editor_placement_preview);
 }
 
+static void clear_editor_drag_create(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    SDL_zero(runtime->editor_drag_create);
+}
+
 bool editor_placement_preview_active_for_scene(const slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL || !runtime->editor_placement_preview.active)
@@ -26,6 +33,12 @@ static yyjson_val *find_editor_placement_preview_json(yyjson_val *placement, con
             return preview;
     }
     return NULL;
+}
+
+static yyjson_val *editor_drag_create_json(yyjson_val *placement)
+{
+    yyjson_val *drag = obj_get(placement, "drag_create");
+    return yyjson_is_obj(drag) ? drag : NULL;
 }
 
 static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,
@@ -83,6 +96,110 @@ static float editor_placement_grid_size(slayer3d_game_data_runtime *runtime, yyj
                                              authored_grid_size);
     }
     return authored_grid_size;
+}
+
+static int editor_source_units_from_meters_public(const brush_world_runtime *world_runtime, float value)
+{
+    const float meters_per_unit = world_runtime != NULL && world_runtime->editor_source_meters_per_unit > 0.0f
+                                      ? world_runtime->editor_source_meters_per_unit
+                                      : 0.001f;
+    return (int)SDL_lroundf(value / meters_per_unit);
+}
+
+static int editor_drag_cell(float value, float grid_size)
+{
+    return (int)SDL_floorf(value / SDL_max(grid_size, 0.001f));
+}
+
+static void editor_drag_source_bounds(const brush_world_runtime *world_runtime, const editor_drag_create_state *drag,
+                                      int out_min[3], int out_max[3])
+{
+    const int min_cell[3] = {SDL_min(drag->start_cell[0], drag->current_cell[0]),
+                             SDL_min(drag->start_cell[1], drag->current_cell[1]),
+                             SDL_min(drag->start_cell[2], drag->current_cell[2])};
+    const int max_cell[3] = {SDL_max(drag->start_cell[0], drag->current_cell[0]) + 1,
+                             SDL_max(drag->start_cell[1], drag->current_cell[1]) + 1,
+                             SDL_max(drag->start_cell[2], drag->current_cell[2]) + 1};
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        out_min[axis] = editor_source_units_from_meters_public(world_runtime, (float)min_cell[axis] * drag->grid_size);
+        out_max[axis] = editor_source_units_from_meters_public(world_runtime, (float)max_cell[axis] * drag->grid_size);
+    }
+}
+
+static void editor_drag_update_current_cell(editor_drag_create_state *drag,
+                                            const slayer3d_game_data_editor_selection *hover_selection)
+{
+    if (drag == NULL || hover_selection == NULL || !hover_selection->hit)
+        return;
+    const int x = editor_drag_cell(hover_selection->point.x, drag->grid_size);
+    const int y = drag->start_cell[1];
+    const int z = editor_drag_cell(hover_selection->point.z, drag->grid_size);
+    if (drag->current_cell[0] != x || drag->current_cell[1] != y || drag->current_cell[2] != z)
+        drag->moved = true;
+    drag->current_cell[0] = x;
+    drag->current_cell[1] = y;
+    drag->current_cell[2] = z;
+}
+
+static bool editor_drag_preview_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *drag_json,
+                                           editor_drag_create_state *drag,
+                                           editor_brush_source_prefab_result *out_result)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, drag->world_name);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+        return false;
+
+    editor_drag_source_bounds(world_runtime, drag, drag->source_min, drag->source_max);
+
+    editor_brush_source_prefab_desc desc;
+    SDL_zero(desc);
+    desc.prefab = json_string(drag_json, "prefab", "editor.box");
+    desc.material = drag->material_name;
+    desc.contents = drag->contents;
+
+    char error_buffer[256] = {0};
+    const bool ok =
+        editor_brush_world_run_source_prefab_command(world_runtime, &desc, NULL, drag->source_min, drag->source_max,
+                                                     false, out_result, error_buffer, sizeof(error_buffer));
+    if (!ok && out_result != NULL && error_buffer[0] != '\0')
+        SDL_strlcpy(out_result->warning, error_buffer, sizeof(out_result->warning));
+    return ok && (out_result == NULL || out_result->valid);
+}
+
+static void editor_drag_publish_preview(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                        yyjson_val *drag_json, editor_drag_create_state *drag,
+                                        const editor_brush_source_prefab_result *result, const char *message,
+                                        bool valid)
+{
+    yyjson_val *outputs = obj_get(placement, "outputs");
+    editor_placement_preview_state *preview = &runtime->editor_placement_preview;
+    SDL_zero(*preview);
+    if (valid && drag != NULL && result != NULL)
+    {
+        preview->active = true;
+        preview->scene = slayer3d_game_data_active_scene(runtime);
+        preview->mode = json_string(drag_json, "mode", "drag_box");
+        preview->kind = json_string(drag_json, "kind", "box");
+        preview->axis = "xyz";
+        preview->world_name = drag->world_name;
+        preview->material_name = drag->material_name;
+        preview->contents = drag->contents;
+        preview->snap = drag->grid_size;
+        preview->has_bounds = true;
+        preview->bounds = result->bounds;
+        preview->has_source_candidate = true;
+        for (int axis = 0; axis < 3; ++axis)
+        {
+            preview->source_min[axis] = drag->source_min[axis];
+            preview->source_max[axis] = drag->source_max[axis];
+        }
+        preview->source_positive_overlap_count = result->positive_overlap_count;
+        SDL_strlcpy(preview->source_warning, result->warning, sizeof(preview->source_warning));
+    }
+    publish_editor_placement_preview(runtime, outputs, valid, drag_json, valid ? preview : NULL, message);
 }
 
 static float editor_placement_elevation(slayer3d_game_data_runtime *runtime, yyjson_val *placement)
@@ -284,6 +401,102 @@ static bool editor_placement_preview_validate_source_box(slayer3d_game_data_runt
         }
     }
     return ok;
+}
+
+bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                               const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
+{
+    if (out_consumed != NULL)
+        *out_consumed = false;
+    if (runtime == NULL || editor == NULL)
+        return false;
+
+    const char *mode = scene_state_string(runtime, "editor.mode", "select");
+    if (SDL_strcmp(mode, "select") != 0)
+    {
+        clear_editor_drag_create(runtime);
+        return true;
+    }
+
+    yyjson_val *placement = obj_get(editor, "placement");
+    yyjson_val *drag_json = editor_drag_create_json(placement);
+    if (drag_json == NULL)
+        return true;
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
+    const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
+    editor_drag_create_state *drag = &runtime->editor_drag_create;
+
+    if (!drag->active && left_pressed && hover_selection != NULL && hover_selection->hit &&
+        hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID)
+    {
+        const float grid_size = editor_placement_grid_size(runtime, placement, drag_json,
+                                                           json_float(placement, "default_grid_size", 16.0f));
+        if (grid_size <= 0.0f)
+            return true;
+        SDL_zero(*drag);
+        drag->active = true;
+        drag->scene = slayer3d_game_data_active_scene(runtime);
+        drag->world_name = json_string(drag_json, "world", "brush.editor_shell.target");
+        drag->material_name =
+            scene_state_string(runtime, json_string(drag_json, "material_key", "editor.brush.material"),
+                               json_string(drag_json, "material", "mat.editor.floor"));
+        drag->contents = brush_flags_from_json(obj_get(drag_json, "contents"), brush_content_flag_from_string,
+                                               SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
+        drag->grid_size = grid_size;
+        drag->start_cell[0] = editor_drag_cell(hover_selection->point.x, grid_size);
+        drag->start_cell[1] = editor_drag_cell(hover_selection->point.y, grid_size);
+        drag->start_cell[2] = editor_drag_cell(hover_selection->point.z, grid_size);
+        drag->current_cell[0] = drag->start_cell[0];
+        drag->current_cell[1] = drag->start_cell[1];
+        drag->current_cell[2] = drag->start_cell[2];
+        if (out_consumed != NULL)
+            *out_consumed = true;
+    }
+
+    if (!drag->active)
+        return true;
+    if (out_consumed != NULL)
+        *out_consumed = true;
+
+    editor_drag_update_current_cell(drag, hover_selection);
+    if (SDL_fabsf(slayer3d_input_get_mouse_dx(input)) > 0.0f || SDL_fabsf(slayer3d_input_get_mouse_dy(input)) > 0.0f)
+        drag->moved = true;
+
+    editor_brush_source_prefab_result result;
+    const bool valid = editor_drag_preview_source_box(runtime, drag_json, drag, &result);
+    const char *base_message = json_string(drag_json, "message", "drag brush preview");
+    char message[256];
+    if (valid && result.warning[0] != '\0')
+        SDL_snprintf(message, sizeof(message), "%s; %s", base_message, result.warning);
+    else if (!valid && result.warning[0] != '\0')
+        SDL_strlcpy(message, result.warning, sizeof(message));
+    else
+        SDL_strlcpy(message, base_message, sizeof(message));
+    editor_drag_publish_preview(runtime, placement, drag_json, drag, &result, message, valid);
+
+    if (left_released || !left_down)
+    {
+        const bool should_commit = valid && drag->moved;
+        if (should_commit)
+        {
+            editor_brush_source_prefab_result commit_result;
+            if (slayer3d_game_data_create_editor_source_box_brush(runtime, drag->world_name, drag->material_name,
+                                                                  drag->contents, drag->source_min, drag->source_max,
+                                                                  &commit_result) &&
+                runtime->scene_state != NULL)
+            {
+                slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "drag brush created");
+            }
+        }
+        clear_editor_drag_create(runtime);
+        clear_editor_placement_preview(runtime);
+        publish_editor_placement_preview(runtime, obj_get(placement, "outputs"), false, drag_json, NULL,
+                                         should_commit ? "drag brush created" : "drag cancelled");
+    }
+    return true;
 }
 
 void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *editor,

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -463,8 +463,6 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         *out_consumed = true;
 
     editor_drag_update_current_cell(drag, hover_selection);
-    if (SDL_fabsf(slayer3d_input_get_mouse_dx(input)) > 0.0f || SDL_fabsf(slayer3d_input_get_mouse_dy(input)) > 0.0f)
-        drag->moved = true;
 
     editor_brush_source_prefab_result result;
     const bool valid = editor_drag_preview_source_box(runtime, drag_json, drag, &result);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -436,6 +436,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
                                                            json_float(placement, "default_grid_size", 16.0f));
         if (grid_size <= 0.0f)
             return true;
+        (void)slayer3d_game_data_clear_active_editor_selection(runtime);
         SDL_zero(*drag);
         drag->active = true;
         drag->scene = slayer3d_game_data_active_scene(runtime);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -203,6 +203,16 @@ typedef struct editor_drag_create_state
     int source_max[3];
 } editor_drag_create_state;
 
+typedef struct editor_drag_move_state
+{
+    bool active;
+    bool moved;
+    const char *scene;
+    slayer3d_vec3 start_point;
+    slayer3d_vec3 applied_offset;
+    float grid_size;
+} editor_drag_move_state;
+
 typedef struct editor_brush_source_box_runtime
 {
     char *stable_id;
@@ -812,6 +822,7 @@ typedef struct slayer3d_game_data_runtime
     editor_command_preview_state editor_command_preview;
     editor_placement_preview_state editor_placement_preview;
     editor_drag_create_state editor_drag_create;
+    editor_drag_move_state editor_drag_move;
     editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -271,6 +271,7 @@ typedef struct editor_command_transaction_entry
     int material_index;
     int previous_material_index;
     slayer3d_vec3 offset;
+    int rotation_quarter_turns;
     bool has_bounds;
     slayer3d_bounding_box bounds;
     int brush_index;
@@ -1179,6 +1180,7 @@ bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtim
                                                        const int source_min[3], const int source_max[3],
                                                        editor_brush_source_prefab_result *out_result);
 bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
+bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);
 void editor_set_string_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, const char *value);
 void editor_set_bool_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, bool value);
 void editor_set_int_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, int value);
@@ -1235,6 +1237,8 @@ bool editor_brush_world_remove_source_box_at_index(brush_world_runtime *world_ru
                                                    char *error_buffer, int error_buffer_size);
 bool editor_brush_world_translate_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                              slayer3d_vec3 offset, char *error_buffer, int error_buffer_size);
+bool editor_brush_world_rotate_source_box_y_quarter_turns(brush_world_runtime *world_runtime, const char *brush_name,
+                                                          int quarter_turns, char *error_buffer, int error_buffer_size);
 int editor_brush_world_source_box_face_index_for_identity(const brush_world_runtime *world_runtime,
                                                           const char *brush_identity, int fallback_face_index,
                                                           const char *face_identity);

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -211,6 +211,8 @@ typedef struct editor_drag_move_state
     slayer3d_vec3 start_point;
     slayer3d_vec3 applied_offset;
     float grid_size;
+    float start_mouse_x;
+    float start_mouse_y;
 } editor_drag_move_state;
 
 typedef struct editor_brush_source_box_runtime

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -207,6 +207,7 @@ typedef struct editor_drag_move_state
 {
     bool active;
     bool moved;
+    bool axis_lock_y;
     const char *scene;
     slayer3d_vec3 start_point;
     slayer3d_vec3 applied_offset;
@@ -214,6 +215,13 @@ typedef struct editor_drag_move_state
     float start_mouse_x;
     float start_mouse_y;
 } editor_drag_move_state;
+
+typedef struct editor_camera_orbit_state
+{
+    bool active;
+    slayer3d_vec3 pivot;
+    float radius;
+} editor_camera_orbit_state;
 
 typedef struct editor_brush_source_box_runtime
 {
@@ -826,6 +834,7 @@ typedef struct slayer3d_game_data_runtime
     editor_placement_preview_state editor_placement_preview;
     editor_drag_create_state editor_drag_create;
     editor_drag_move_state editor_drag_move;
+    editor_camera_orbit_state editor_camera_orbit;
     editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -188,6 +188,21 @@ typedef struct editor_placement_preview_state
     char source_warning[256];
 } editor_placement_preview_state;
 
+typedef struct editor_drag_create_state
+{
+    bool active;
+    bool moved;
+    const char *scene;
+    const char *world_name;
+    const char *material_name;
+    unsigned int contents;
+    float grid_size;
+    int start_cell[3];
+    int current_cell[3];
+    int source_min[3];
+    int source_max[3];
+} editor_drag_create_state;
+
 typedef struct editor_brush_source_box_runtime
 {
     char *stable_id;
@@ -796,6 +811,7 @@ typedef struct slayer3d_game_data_runtime
     const char *editor_selected_brush_scene;
     editor_command_preview_state editor_command_preview;
     editor_placement_preview_state editor_placement_preview;
+    editor_drag_create_state editor_drag_create;
     editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;
@@ -1142,9 +1158,16 @@ void clear_editor_command_preview(slayer3d_game_data_runtime *runtime);
 void clear_editor_placement_preview(slayer3d_game_data_runtime *runtime);
 void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
                                      const slayer3d_game_data_editor_selection *hover_selection);
+bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                               const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed);
 void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
                               const slayer3d_game_data_editor_selection *selection);
 bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                       const char *material_name, unsigned int contents,
+                                                       const int source_min[3], const int source_max[3],
+                                                       editor_brush_source_prefab_result *out_result);
+bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
 void editor_set_string_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, const char *value);
 void editor_set_bool_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, bool value);
 void editor_set_int_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, int value);

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -8132,8 +8132,20 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         const char *player_start = json_string(action, "player_start");
         if (player_start == NULL || player_start[0] == '\0')
             return validation_error(ctx, json_path, "editor.brush_world.validate_enclosure requires a player_start");
-        if (!require_ref(ctx, &names->editor_player_starts, "editor player start", player_start, json_path))
+        yyjson_val *allow_missing_player_start = obj_get(action, "allow_missing_player_start");
+        if (allow_missing_player_start != NULL && !yyjson_is_bool(allow_missing_player_start))
+        {
+            return validation_error(ctx, json_path,
+                                    "editor.brush_world.validate_enclosure allow_missing_player_start must be a "
+                                    "boolean");
+        }
+        const bool permits_missing_player_start =
+            allow_missing_player_start != NULL && yyjson_get_bool(allow_missing_player_start);
+        if (!permits_missing_player_start &&
+            !require_ref(ctx, &names->editor_player_starts, "editor player start", player_start, json_path))
+        {
             return false;
+        }
         yyjson_val *message = obj_get(action, "message");
         if (message != NULL && !yyjson_is_str(message))
             return validation_error(ctx, json_path, "editor.brush_world.validate_enclosure message must be a string");
@@ -8300,8 +8312,19 @@ static bool validate_one_action(validation_context *ctx, yyjson_val *action, con
         if (!is_non_empty_string(action, "name"))
             return validation_error(ctx, json_path, "editor.player_start.apply requires a non-empty name");
         const char *name = json_string(action, "name");
-        if (!require_ref(ctx, &names->editor_player_starts, "editor player start", name, json_path))
+        yyjson_val *allow_missing_player_start = obj_get(action, "allow_missing_player_start");
+        if (allow_missing_player_start != NULL && !yyjson_is_bool(allow_missing_player_start))
+        {
+            return validation_error(ctx, json_path,
+                                    "editor.player_start.apply allow_missing_player_start must be a boolean");
+        }
+        const bool permits_missing_player_start =
+            allow_missing_player_start != NULL && yyjson_get_bool(allow_missing_player_start);
+        if (!permits_missing_player_start &&
+            !require_ref(ctx, &names->editor_player_starts, "editor player start", name, json_path))
+        {
             return false;
+        }
         yyjson_val *outputs = obj_get(action, "outputs");
         if (outputs != NULL && !yyjson_is_obj(outputs))
             return validation_error(ctx, json_path, "editor.player_start.apply outputs must be an object");

--- a/src/game_data_validation_brush_worlds.c
+++ b/src/game_data_validation_brush_worlds.c
@@ -127,9 +127,9 @@ bool validate_brush_worlds(validation_context *ctx, yyjson_val *root, validation
             ok = validation_error(ctx, world_path, "brush world materials must be a non-empty array");
             goto done;
         }
-        if (!yyjson_is_arr(brushes) || yyjson_arr_size(brushes) <= 0)
+        if (!yyjson_is_arr(brushes))
         {
-            ok = validation_error(ctx, world_path, "brush world brushes must be a non-empty array");
+            ok = validation_error(ctx, world_path, "brush world brushes must be an array");
             goto done;
         }
 

--- a/src/game_data_validation_controller_components.c
+++ b/src/game_data_validation_controller_components.c
@@ -122,9 +122,9 @@ bool validate_editor_camera_component(validation_context *ctx, yyjson_val *compo
     if (!yyjson_is_obj(actions))
         return validation_error(ctx, path, "controller.editor_camera requires an actions object");
 
-    const char *action_keys[] = {"forward",  "back",      "left",     "right",     "up",        "down",
-                                 "look",     "mouse_pan", "fast",     "pan_left",  "pan_right", "pan_up",
-                                 "pan_down", "zoom_in",   "zoom_out", "zoom_wheel"};
+    const char *action_keys[] = {
+        "forward",  "back",      "left",   "right",    "up",      "down",     "look",       "mouse_pan",     "fast",
+        "pan_left", "pan_right", "pan_up", "pan_down", "zoom_in", "zoom_out", "zoom_wheel", "frame_selected"};
     bool has_action = false;
     for (size_t i = 0; i < SDL_arraysize(action_keys); ++i)
     {

--- a/src/input.c
+++ b/src/input.c
@@ -90,6 +90,7 @@ struct slayer3d_input_manager
     bool prev_held[SLAYER3D_INPUT_MAX_ACTIONS];
     SDL_Scancode pressed_scancode;
     Uint8 pressed_mouse_button;
+    Uint8 released_mouse_button;
     SDL_GamepadButton pressed_gamepad_button;
     char pending_text_input[SLAYER3D_INPUT_TEXT_MAX];
     char current_text_input[SLAYER3D_INPUT_TEXT_MAX];
@@ -791,6 +792,23 @@ static Uint8 slayer3d_input_first_pressed_mouse_button(const slayer3d_input_mana
     return 0;
 }
 
+static Uint8 slayer3d_input_first_released_mouse_button(const slayer3d_input_manager *input)
+{
+    if (input == NULL)
+    {
+        return 0;
+    }
+
+    for (int i = 0; i < SLAYER3D_INPUT_MAX_MOUSE_BUTTONS; ++i)
+    {
+        if (input->mouse_released_this_frame[i])
+        {
+            return (Uint8)i;
+        }
+    }
+    return 0;
+}
+
 static bool slayer3d_demo_recorder_append(slayer3d_demo_recorder *recorder, const slayer3d_input_snapshot *snapshot)
 {
     slayer3d_input_snapshot *grown;
@@ -1420,6 +1438,7 @@ const slayer3d_input_snapshot *slayer3d_input_update(slayer3d_input_manager *inp
             input->has_mouse_position = false;
             input->pressed_scancode = SDL_SCANCODE_UNKNOWN;
             input->pressed_mouse_button = 0;
+            input->released_mouse_button = 0;
             input->pressed_gamepad_button = SDL_GAMEPAD_BUTTON_INVALID;
             input->current_text_input[0] = '\0';
             SDL_memset(input->prev_held, 0, sizeof(input->prev_held));
@@ -1451,6 +1470,7 @@ const slayer3d_input_snapshot *slayer3d_input_update(slayer3d_input_manager *inp
     next.any_pressed = slayer3d_input_physical_any_pressed(input);
     input->pressed_scancode = slayer3d_input_first_pressed_scancode(input);
     input->pressed_mouse_button = slayer3d_input_first_pressed_mouse_button(input);
+    input->released_mouse_button = slayer3d_input_first_released_mouse_button(input);
     input->pressed_gamepad_button = slayer3d_input_first_pressed_gamepad_button(input);
     SDL_strlcpy(input->current_text_input, input->pending_text_input, sizeof(input->current_text_input));
 
@@ -1531,6 +1551,26 @@ SDL_GamepadButton slayer3d_input_get_pressed_gamepad_button(const slayer3d_input
 Uint8 slayer3d_input_get_pressed_mouse_button(const slayer3d_input_manager *input)
 {
     return input != NULL ? input->pressed_mouse_button : 0;
+}
+
+bool slayer3d_input_is_scancode_pressed(const slayer3d_input_manager *input, SDL_Scancode scancode)
+{
+    return input != NULL && scancode >= 0 && scancode < SDL_SCANCODE_COUNT && input->pressed_scancode == scancode;
+}
+
+bool slayer3d_input_is_mouse_button_down(const slayer3d_input_manager *input, Uint8 button)
+{
+    return input != NULL && slayer3d_input_mouse_button_valid(button) && input->mouse_down[button];
+}
+
+bool slayer3d_input_is_mouse_button_pressed(const slayer3d_input_manager *input, Uint8 button)
+{
+    return input != NULL && slayer3d_input_mouse_button_valid(button) && input->pressed_mouse_button == button;
+}
+
+bool slayer3d_input_is_mouse_button_released(const slayer3d_input_manager *input, Uint8 button)
+{
+    return input != NULL && slayer3d_input_mouse_button_valid(button) && input->released_mouse_button == button;
 }
 
 bool slayer3d_input_any_pressed(const slayer3d_input_manager *input)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -48,6 +48,9 @@ extern "C"
                                                                 slayer3d_vec3 *out_normal);
     bool editor_brush_world_translate_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                                  slayer3d_vec3 offset, char *error_buffer, int error_buffer_size);
+    bool editor_brush_world_rotate_source_box_y_quarter_turns(brush_world_runtime *world_runtime,
+                                                              const char *brush_name, int quarter_turns,
+                                                              char *error_buffer, int error_buffer_size);
     bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                    slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                    int error_buffer_size);
@@ -17146,29 +17149,47 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
 
     const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
     SDL_Event key{};
-    key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_RIGHT;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 7);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    key.type = SDL_EVENT_KEY_UP;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 8);
+    Uint64 key_frame = 7;
+    auto press_key = [&](SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
+        SDL_SetModState(modifiers);
+        key.type = SDL_EVENT_KEY_DOWN;
+        key.key.scancode = scancode;
+        key.key.mod = modifiers;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, key_frame++);
+        EXPECT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+        key.type = SDL_EVENT_KEY_UP;
+        slayer3d_input_process_event(input, &key);
+        SDL_SetModState(SDL_KMOD_NONE);
+        slayer3d_input_update(input, key_frame++);
+    };
+
+    press_key(SDL_SCANCODE_RIGHT);
     slayer3d_bounding_box after_nudge = find_brush_bounds(created_name);
     EXPECT_NEAR(after_nudge.min.z, before_nudge.min.z + 1.0f, 0.001f);
     EXPECT_NEAR(after_nudge.max.z, before_nudge.max.z + 1.0f, 0.001f);
 
-    key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_PAGEUP;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 9);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    key.type = SDL_EVENT_KEY_UP;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 10);
+    press_key(SDL_SCANCODE_PAGEUP);
     after_nudge = find_brush_bounds(created_name);
     EXPECT_NEAR(after_nudge.min.y, before_nudge.min.y + 1.0f, 0.001f);
     EXPECT_NEAR(after_nudge.max.y, before_nudge.max.y + 1.0f, 0.001f);
+
+    const slayer3d_bounding_box before_up = after_nudge;
+    press_key(SDL_SCANCODE_UP);
+    after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.x, before_up.min.x + 1.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.x, before_up.max.x + 1.0f, 0.001f);
+
+    press_key(SDL_SCANCODE_DOWN);
+    after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.x, before_up.min.x, 0.001f);
+    EXPECT_NEAR(after_nudge.max.x, before_up.max.x, 0.001f);
+
+    const slayer3d_bounding_box before_vertical_modifier = after_nudge;
+    press_key(SDL_SCANCODE_UP, SDL_KMOD_CTRL);
+    after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.y, before_vertical_modifier.min.y + 1.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.y, before_vertical_modifier.max.y + 1.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -19859,6 +19880,66 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordi
     ASSERT_TRUE(world.brushes[0].has_bounds);
     EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.1f, 0.001f);
     EXPECT_NEAR(world.brushes[0].bounds.max.x, 8.2f, 0.001f);
+
+    const char rotate_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [{ "name": "mat.editor.floor", "albedo": [0.25, 0.5, 0.75, 1.0] }],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "snap_units": 100,
+      "boxes": [
+        {
+          "stable_id": "source.box.rotate",
+          "name": "brush.source.box.rotate",
+          "kind": "box",
+          "prefab": "wall",
+          "material": "mat.editor.floor",
+          "min": [0, 0, 0],
+          "max": [4000, 1000, 8000],
+          "contents": ["solid"]
+        }
+      ]
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", rotate_json,
+                                                                     sizeof(rotate_json) - 1u,
+                                                                     "/tmp/source-rotate.json", error, sizeof(error)))
+        << error;
+    world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_rotate_source_box_y_quarter_turns(world_runtime, "source.box.rotate", 1, error,
+                                                                     sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.min.x, -2.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 6.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.min.z, 2.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.z, 6.0f, 0.001f);
+
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_rotate_source_box_y_quarter_turns(world_runtime, "source.box.rotate", -1, error,
+                                                                     sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 4.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.min.z, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.z, 8.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16381,8 +16381,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.prefab", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.material", ""), "mat.editor.floor");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 16.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.height", 0.0f), 16.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 1.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.height", 0.0f), 1.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.elevation", 1.0f), 0.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.thickness", 0.0f), 0.2f, 0.001f);
 
@@ -16433,17 +16433,29 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
                  "mat.editor.floor");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 16.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
     std::vector<std::string> grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 1"));
+    click_editor(790.0f, 54.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 4);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 16"));
+    click_editor(790.0f, 208.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", true));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 4.0f, 0.001f);
+    slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 8.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 8.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 1.0f, 0.001f);
+    slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 0.5f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 0.5f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.5f, 0.001f);
     grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
-    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 8"));
-    for (int i = 0; i < 6; ++i)
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 0.5"));
+    for (int i = 0; i < 2; ++i)
         slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 0.125f, 0.001f);
@@ -16456,6 +16468,10 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 256"));
     for (int i = 0; i < 7; ++i)
         slayer3d_signal_emit(bus, grid_increase_signal, nullptr);
+    motion.motion.x = click.button.x;
+    motion.motion.y = click.button.y;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 6);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 8.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 8.0f, 0.001f);
@@ -17029,7 +17045,7 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 16.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 1.0f, 0.001f);
 
     auto world = [&]() {
         slayer3d_game_data_brush_world brush_world{};
@@ -17099,31 +17115,60 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     yyjson_doc_free(select_doc);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
 
+    const slayer3d_bounding_box before_drag_move = find_brush_bounds(created_name);
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    motion.motion.x = 820.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 40.0f;
+    motion.motion.yrel = 0.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 5);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const slayer3d_bounding_box after_drag_move = find_brush_bounds(created_name);
+    const float drag_dx = after_drag_move.min.x - before_drag_move.min.x;
+    const float drag_dz = after_drag_move.min.z - before_drag_move.min.z;
+    EXPECT_GT(SDL_fabsf(drag_dx) + SDL_fabsf(drag_dz), 0.001f);
+    EXPECT_NEAR(drag_dx, SDL_roundf(drag_dx), 0.001f);
+    EXPECT_NEAR(drag_dz, SDL_roundf(drag_dz), 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag moved brush");
+
     const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
     SDL_Event key{};
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_RIGHT;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 4);
+    slayer3d_input_update(input, 7);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     key.type = SDL_EVENT_KEY_UP;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 5);
+    slayer3d_input_update(input, 8);
     slayer3d_bounding_box after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.x, before_nudge.min.x + 16.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.x, before_nudge.max.x + 16.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.min.z, before_nudge.min.z + 1.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.z, before_nudge.max.z + 1.0f, 0.001f);
 
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_PAGEUP;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 6);
+    slayer3d_input_update(input, 9);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     key.type = SDL_EVENT_KEY_UP;
     slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 7);
+    slayer3d_input_update(input, 10);
     after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.y, before_nudge.min.y + 16.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.y, before_nudge.max.y + 16.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.min.y, before_nudge.min.y + 1.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.y, before_nudge.max.y + 1.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -17133,6 +17133,8 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     motion.type = SDL_EVENT_MOUSE_MOTION;
     motion.motion.x = 660.0f;
     motion.motion.y = 360.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = 0.0f;
     SDL_Event mouse{};
     mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     mouse.button.button = SDL_BUTTON_LEFT;
@@ -17142,13 +17144,23 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_input_process_event(input, &mouse);
     slayer3d_input_update(input, 1);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
 
     motion.motion.x = 780.0f;
     motion.motion.y = 430.0f;
     motion.motion.xrel = 120.0f;
     motion.motion.yrel = 70.0f;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 2);
+    slayer3d_input_update(input, 4);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
@@ -17157,7 +17169,7 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     mouse.button.x = motion.motion.x;
     mouse.button.y = motion.motion.y;
     slayer3d_input_process_event(input, &mouse);
-    slayer3d_input_update(input, 3);
+    slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     slayer3d_game_data_brush_world brush_world = world();
     ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
@@ -17175,6 +17187,13 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     ASSERT_TRUE(slayer3d_game_data_select_editor_brush_action(runtime, yyjson_doc_get_root(select_doc)));
     yyjson_doc_free(select_doc);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_x", 0.0f),
+                created_brush.bounds.max.x - created_brush.bounds.min.x, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_y", 0.0f),
+                created_brush.bounds.max.y - created_brush.bounds.min.y, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_z", 0.0f),
+                created_brush.bounds.max.z - created_brush.bounds.min.z, 0.001f);
+    EXPECT_STRNE(slayer3d_properties_get_string(scene_state, "editor.selection.element_stable_id", ""), "");
 
     const slayer3d_bounding_box before_drag_move = find_brush_bounds(created_name);
     mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
@@ -17182,20 +17201,20 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     mouse.button.x = motion.motion.x;
     mouse.button.y = motion.motion.y;
     slayer3d_input_process_event(input, &mouse);
-    slayer3d_input_update(input, 4);
+    slayer3d_input_update(input, 6);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     motion.motion.x = 820.0f;
     motion.motion.y = 430.0f;
     motion.motion.xrel = 40.0f;
     motion.motion.yrel = 0.0f;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 5);
+    slayer3d_input_update(input, 7);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;
     mouse.button.y = motion.motion.y;
     slayer3d_input_process_event(input, &mouse);
-    slayer3d_input_update(input, 6);
+    slayer3d_input_update(input, 8);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     const slayer3d_bounding_box after_drag_move = find_brush_bounds(created_name);
     const float drag_dx = after_drag_move.min.x - before_drag_move.min.x;
@@ -17207,7 +17226,7 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
 
     const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
     SDL_Event key{};
-    Uint64 key_frame = 7;
+    Uint64 key_frame = 9;
     auto press_key = [&](SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
         SDL_SetModState(modifiers);
         key.type = SDL_EVENT_KEY_DOWN;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -51,6 +51,7 @@ extern "C"
     bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                    slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                    int error_buffer_size);
+    bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 }
 
 namespace
@@ -16291,7 +16292,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     click.button.x = motion.motion.x;
     click.button.y = motion.motion.y;
     slayer3d_input_process_event(input, &motion);
-    slayer3d_input_process_event(input, &click);
     slayer3d_input_update(input, 1);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     SDL_Event release{};
@@ -16299,8 +16299,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     release.button.button = SDL_BUTTON_LEFT;
     release.button.x = click.button.x;
     release.button.y = click.button.y;
-    slayer3d_input_process_event(input, &release);
-    slayer3d_input_update(input, 2);
     auto click_editor = [&](float x, float y, Uint8 button, SDL_Keymod modifiers, Uint64 frame) {
         SDL_SetModState(modifiers);
         SDL_Event click_motion{};
@@ -16321,13 +16319,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         slayer3d_input_update(input, frame + 1U);
         SDL_SetModState(SDL_KMOD_NONE);
     };
-    slayer3d_game_data_editor_selection placement_selection{};
-    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &placement_selection));
-    ASSERT_TRUE(placement_selection.hit);
-    EXPECT_EQ(placement_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID);
-    const slayer3d_vec3 placement_origin = slayer3d_vec3_make(SDL_floorf(placement_selection.point.x / 8.0f) * 8.0f,
-                                                              SDL_floorf(placement_selection.point.y / 8.0f) * 8.0f,
-                                                              SDL_floorf(placement_selection.point.z / 8.0f) * 8.0f);
+    slayer3d_vec3 placement_origin = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
     slayer3d_vec3 player_start_origin = placement_origin;
     auto world = [&]() {
         slayer3d_game_data_brush_world brush_world{};
@@ -16389,8 +16381,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.prefab", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.material", ""), "mat.editor.floor");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 8.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.height", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 16.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.height", 0.0f), 16.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.elevation", 1.0f), 0.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.thickness", 0.0f), 0.2f, 0.001f);
 
@@ -16441,17 +16433,17 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.material", ""),
                  "mat.editor.floor");
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 16.0f, 0.001f);
     std::vector<std::string> grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
-    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 8"));
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 16"));
     slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 4.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 4.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 8.0f, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 8.0f, 0.001f);
     grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
-    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 4"));
-    for (int i = 0; i < 5; ++i)
+    EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 8"));
+    for (int i = 0; i < 6; ++i)
         slayer3d_signal_emit(bus, grid_decrease_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 0.125f, 0.001f);
@@ -16478,6 +16470,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_NE(placement_max, nullptr);
     ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
     ASSERT_EQ(placement_max->type, SLAYER3D_VALUE_VEC3);
+    placement_origin = slayer3d_vec3_make(placement_min->as_vec3.x, placement_max->as_vec3.y, placement_min->as_vec3.z);
+    player_start_origin = placement_origin;
     EXPECT_NEAR(placement_min->as_vec3.x, placement_origin.x, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.y, placement_origin.y - 0.2f, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.z, placement_origin.z, 0.001f);
@@ -17007,6 +17001,129 @@ TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_EQ(world().brush_count, initial_brush_count + 3);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 16.0f, 0.001f);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    auto find_brush_bounds = [&](const std::string &name) {
+        const slayer3d_game_data_brush_world brush_world = world();
+        for (int i = 0; i < brush_world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = brush_world.brushes[i];
+            if (brush.name != nullptr && name == brush.name)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush not found: " << name;
+        return slayer3d_bounding_box{slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
+    };
+
+    const int initial_brush_count = world().brush_count;
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 660.0f;
+    motion.motion.y = 360.0f;
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    slayer3d_game_data_brush_world brush_world = world();
+    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
+    const slayer3d_game_data_brush &created_brush = brush_world.brushes[brush_world.brush_count - 1];
+    ASSERT_NE(created_brush.name, nullptr);
+    const std::string created_name = created_brush.name;
+    EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
+
+    char select_action_json[512];
+    SDL_snprintf(select_action_json, sizeof(select_action_json),
+                 R"json({"world":"brush.editor_shell.target","element":"%s"})json", created_name.c_str());
+    yyjson_doc *select_doc = yyjson_read(select_action_json, SDL_strlen(select_action_json), 0);
+    ASSERT_NE(select_doc, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_select_editor_brush_action(runtime, yyjson_doc_get_root(select_doc)));
+    yyjson_doc_free(select_doc);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+
+    const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RIGHT;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    key.type = SDL_EVENT_KEY_UP;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 5);
+    slayer3d_bounding_box after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.x, before_nudge.min.x + 16.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.x, before_nudge.max.x + 16.0f, 0.001f);
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_PAGEUP;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    key.type = SDL_EVENT_KEY_UP;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 7);
+    after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.y, before_nudge.min.y + 16.0f, 0.001f);
+    EXPECT_NEAR(after_nudge.max.y, before_nudge.max.y + 16.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -18526,14 +18643,14 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxPlacementPreviewUsesSourceVa
     ASSERT_EQ(overlap_min->type, SLAYER3D_VALUE_VEC3);
     EXPECT_NEAR(overlap_min->as_vec3.x, 0.0f, 0.001f);
 
-    hover.point = slayer3d_vec3_make(8.0f, 0.0f, 0.0f);
+    hover.point = slayer3d_vec3_make(16.0f, 0.0f, 0.0f);
     update_editor_placement_preview(runtime, editor, &hover);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
     const slayer3d_value *placement_min =
         slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
     ASSERT_NE(placement_min, nullptr);
     ASSERT_EQ(placement_min->type, SLAYER3D_VALUE_VEC3);
-    EXPECT_NEAR(placement_min->as_vec3.x, 8.0f, 0.001f);
+    EXPECT_NEAR(placement_min->as_vec3.x, 16.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -20312,9 +20429,11 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     const int mode_select_action = slayer3d_game_data_find_action(runtime, "action.editor.mode.select");
     const int camera_up_action = slayer3d_game_data_find_action(runtime, "action.editor.camera.up");
     const int camera_down_action = slayer3d_game_data_find_action(runtime, "action.editor.camera.down");
+    const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
     ASSERT_GE(mode_select_action, 0);
     ASSERT_GE(camera_up_action, 0);
     ASSERT_GE(camera_down_action, 0);
+    ASSERT_GE(clear_selection_signal, 0);
     auto press_editor_key = [&](SDL_Scancode scancode, int action_id, Uint64 frame, float dt = 0.016f) {
         SDL_Event key_event{};
         key_event.type = SDL_EVENT_KEY_DOWN;
@@ -20671,8 +20790,11 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
         "brush.target.cube");
     flyby_click.type = SDL_EVENT_MOUSE_BUTTON_UP;
     slayer3d_input_process_event(input, &flyby_click);
+    slayer3d_input_update(input, 14);
+    slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
 
     slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.tool.mode", "floor");
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.mode", "brush");
     slayer3d_properties_set_float(camera_actor->props, "yaw", -1.0f);
     slayer3d_properties_set_float(camera_actor->props, "pitch", -0.25f);
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -591,6 +591,53 @@ std::filesystem::path editor_shell_dojo_data_path()
     return demo_data_path("editor_shell_dojo", "editor_shell_dojo.game.json");
 }
 
+void seed_editor_shell_test_cube(slayer3d_game_data_runtime *runtime)
+{
+    ASSERT_NE(runtime, nullptr);
+    char error[512]{};
+    slayer3d_game_data_create_box_brush_desc desc{};
+    desc.world_name = "brush.editor_shell.target";
+    desc.brush_name = "brush.target.cube";
+    desc.material_name = "mat.editor.wall";
+    desc.min = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    desc.max = slayer3d_vec3_make(2.0f, 2.0f, 2.0f);
+    desc.contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID | SLAYER3D_GAME_DATA_BRUSH_CONTENT_PLAYER_CLIP;
+    ASSERT_TRUE(slayer3d_game_data_create_box_brush(runtime, &desc, nullptr, 0, error, sizeof(error))) << error;
+}
+
+void seed_editor_shell_player_start(slayer3d_game_data_runtime *runtime)
+{
+    ASSERT_NE(runtime, nullptr);
+    char error[512]{};
+    slayer3d_game_data_place_player_start_desc start{};
+    start.name = "player_start.editor_shell";
+    start.scene = "scene.editor_shell.test_run";
+    start.target = "entity.editor_shell.player";
+    start.position = slayer3d_vec3_make(0.0f, 1.6f, 4.0f);
+    start.has_position = true;
+    start.yaw = 3.14159f;
+    start.has_yaw = true;
+    start.pitch = 0.0f;
+    start.has_pitch = true;
+    ASSERT_TRUE(slayer3d_game_data_place_editor_player_start(runtime, &start, error, sizeof(error))) << error;
+}
+
+void select_editor_shell_test_cube(slayer3d_game_data_runtime *runtime)
+{
+    ASSERT_NE(runtime, nullptr);
+    const char *json = R"json({
+          "type": "editor.selection.select_brush",
+          "world": "brush.editor_shell.target",
+          "element": "brush.target.cube",
+          "face": "nx"
+        })json";
+    yyjson_doc *doc = yyjson_read(json, SDL_strlen(json), 0);
+    ASSERT_NE(doc, nullptr);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    ASSERT_TRUE(slayer3d_game_data_select_editor_brush_action(runtime, root));
+    yyjson_doc_free(doc);
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -15772,6 +15819,11 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_data_runtime *runtime = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(
+        slayer3d_game_data_mark_brush_world_saved(runtime, "brush.editor_shell.target", nullptr, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
 
     SDL_Event motion{};
     motion.type = SDL_EVENT_MOUSE_MOTION;
@@ -15791,15 +15843,18 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_input_update(input, 1);
 
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    select_editor_shell_test_cube(runtime);
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
     slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
     ASSERT_NE(bus, nullptr);
     const int preview_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.preview");
     const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
+    const int mode_select_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.select");
     ASSERT_GE(preview_signal, 0);
     ASSERT_GE(clear_selection_signal, 0);
-    const char *target_cube_left_face_stable_id = "editor.brush.target_cube.face.nx";
+    ASSERT_GE(mode_select_signal, 0);
+    const char *target_cube_left_face_stable_id = "brush.target.cube.face.nx";
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.type", ""), "brush_world");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.world", ""),
@@ -15815,10 +15870,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_GE(slayer3d_properties_get_int(scene_state, "editor.selection.compiled_first_vertex", -1), 0);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.compiled_vertex_count", 0), 6);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.compiled_triangle_count", 0), 2);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.hover.element", ""), "brush.target.cube");
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.hover.face_rendered", false));
-    EXPECT_GE(slayer3d_properties_get_int(scene_state, "editor.hover.compiled_face_index", -1), 0);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
 
     slayer3d_game_data_editor_selection active_selection{};
@@ -15835,8 +15887,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(editor_state.world_name, "brush.editor_shell.target");
     EXPECT_EQ(editor_state.source_path, nullptr);
     EXPECT_FALSE(editor_state.dirty);
-    EXPECT_EQ(editor_state.revision, 0U);
-    EXPECT_EQ(editor_state.saved_revision, 0U);
+    EXPECT_EQ(editor_state.revision, 1U);
+    EXPECT_EQ(editor_state.saved_revision, 1U);
 
     auto press_key = [&](SDL_Scancode scancode, Uint64 frame) {
         SDL_Event key{};
@@ -15923,7 +15975,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.command", ""), "translate");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.target", ""), "element");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.element_stable_id", ""),
-                 "editor.brush.target_cube");
+                 "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.message", ""),
                  "preview translate brush.target.cube");
     const slayer3d_value *preview_min = slayer3d_properties_get_value(scene_state, "editor.command_preview.bounds_min");
@@ -16006,15 +16058,15 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.element", ""), "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.element_stable_id", ""),
-                 "editor.brush.target_cube");
+                 "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "commit translate #1");
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 1);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 2);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 1);
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &editor_state));
     EXPECT_TRUE(editor_state.dirty);
-    EXPECT_EQ(editor_state.revision, 1U);
-    EXPECT_EQ(editor_state.saved_revision, 0U);
+    EXPECT_EQ(editor_state.revision, 2U);
+    EXPECT_EQ(editor_state.saved_revision, 1U);
     EXPECT_NEAR(target_cube_min_y(), 0.35f, 0.001f);
     ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
     ASSERT_TRUE(active_selection.has_bounds);
@@ -16052,7 +16104,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.command", ""), "paint");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.target", ""), "face");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.element_stable_id", ""),
-                 "editor.brush.target_cube");
+                 "brush.target.cube");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.face_stable_id", ""),
                  target_cube_left_face_stable_id);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.command_preview.message", ""),
@@ -16097,8 +16149,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_NE(std::string(export_json).find("\"material\": \"mat.editor.floor\""), std::string::npos);
     EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.export.size", 0), 0);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.brush_world.dirty", false));
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 6);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.revision", 0), 7);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.brush_world.saved_revision", -1), 1);
 
     const std::filesystem::path export_dir = unique_test_dir("editor_brush_export");
     size_t saved_size = 0U;
@@ -16111,8 +16163,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_TRUE(std::filesystem::exists(saved_path));
     ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &editor_state));
     EXPECT_FALSE(editor_state.dirty);
-    EXPECT_EQ(editor_state.revision, 6U);
-    EXPECT_EQ(editor_state.saved_revision, 6U);
+    EXPECT_EQ(editor_state.revision, 7U);
+    EXPECT_EQ(editor_state.saved_revision, 7U);
     ASSERT_NE(editor_state.source_path, nullptr);
     EXPECT_EQ(std::string(editor_state.source_path), saved_path_string);
     write_text(export_dir / "scenes" / "play.scene.json",
@@ -16156,16 +16208,12 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_input_process_event(input, &release);
     slayer3d_input_update(input, 2);
 
-    SDL_Event center_click{};
-    center_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
-    center_click.button.button = SDL_BUTTON_LEFT;
-    center_click.button.x = 640.0f;
-    center_click.button.y = 360.0f;
-    slayer3d_input_process_event(input, &center_click);
-    slayer3d_input_update(input, 3);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
+    select_editor_shell_test_cube(runtime);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.hover.hit", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.type", ""), "brush_world");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.world", ""),
                  "brush.editor_shell.target");
@@ -16175,6 +16223,25 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(active_selection.type, SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
     EXPECT_STREQ(active_selection.world_name, "brush.editor_shell.target");
     EXPECT_STREQ(active_selection.element_name, "brush.target.cube");
+
+    SDL_Event empty_motion{};
+    empty_motion.type = SDL_EVENT_MOUSE_MOTION;
+    empty_motion.motion.x = 1180.0f;
+    empty_motion.motion.y = 580.0f;
+    empty_motion.motion.xrel = 0.0f;
+    empty_motion.motion.yrel = 0.0f;
+    slayer3d_input_process_event(input, &empty_motion);
+    SDL_Event empty_click{};
+    empty_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    empty_click.button.button = SDL_BUTTON_LEFT;
+    empty_click.button.x = empty_motion.motion.x;
+    empty_click.button.y = empty_motion.motion.y;
+    slayer3d_input_process_event(input, &empty_click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
+    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -16380,7 +16447,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         return false;
     };
     const int initial_brush_count = world().brush_count;
-    EXPECT_EQ(initial_brush_count, 1);
+    EXPECT_EQ(initial_brush_count, 0);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.prefab", ""), "floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.brush.material", ""), "mat.editor.floor");
@@ -16543,17 +16610,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(placement_min->as_vec3.x, original_preview_min.x, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.y, original_preview_min.y, 0.001f);
     EXPECT_NEAR(placement_min->as_vec3.z, original_preview_min.z, 0.001f);
-    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
-    slayer3d_input_process_event(input, &click);
-    slayer3d_input_update(input, 5);
+    slayer3d_signal_emit(bus, commit_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    release.type = SDL_EVENT_MOUSE_BUTTON_UP;
-    slayer3d_input_process_event(input, &release);
-    slayer3d_input_update(input, 6);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "floor prefab created");
-    const std::string floor_brush_name = "brush.editor_shell.target.box." + std::to_string(initial_brush_count);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""), floor_brush_name.c_str());
+    const std::string floor_brush_name = slayer3d_properties_get_string(scene_state, "editor.create.brush", "");
+    EXPECT_FALSE(floor_brush_name.empty());
     slayer3d_game_data_brush_world brush_world = world();
     ASSERT_GT(brush_world.brush_count, 0);
     const slayer3d_game_data_brush *brush = &brush_world.brushes[brush_world.brush_count - 1];
@@ -16572,10 +16634,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     release.type = SDL_EVENT_MOUSE_BUTTON_UP;
     slayer3d_input_process_event(input, &release);
     slayer3d_input_update(input, 8);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
-    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.create.message", ""))
-                  .find("already occupies this prefab cell"),
-              std::string::npos);
     EXPECT_EQ(world().brush_count, brush_count_after_first_floor);
 
     auto press_editor_key = [&](SDL_Scancode scancode, Uint64 frame) {
@@ -16707,8 +16765,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "wall prefab created");
-    const std::string wall_brush_name = "brush.editor_shell.target.box." + std::to_string(initial_brush_count + 1);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""), wall_brush_name.c_str());
+    const std::string wall_brush_name = slayer3d_properties_get_string(scene_state, "editor.create.brush", "");
+    EXPECT_FALSE(wall_brush_name.empty());
     brush_world = world();
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
@@ -16732,8 +16790,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.create.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.message", ""), "ceiling prefab created");
-    const std::string ceiling_brush_name = "brush.editor_shell.target.box." + std::to_string(initial_brush_count + 2);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.create.brush", ""), ceiling_brush_name.c_str());
+    const std::string ceiling_brush_name = slayer3d_properties_get_string(scene_state, "editor.create.brush", "");
+    EXPECT_FALSE(ceiling_brush_name.empty());
     brush_world = world();
     ASSERT_GT(brush_world.brush_count, 0);
     brush = &brush_world.brushes[brush_world.brush_count - 1];
@@ -17270,6 +17328,8 @@ TEST(GameDataRuntime, EditableLevelFragmentLoadsIntoEditorRuntime)
                                                                      error, sizeof(error)))
         << error;
 #else
+    seed_editor_shell_test_cube(runtime);
+    seed_editor_shell_player_start(runtime);
     char *export_json = nullptr;
     size_t export_size = 0u;
     ASSERT_TRUE(slayer3d_game_data_export_editable_level_fragment_json(
@@ -19719,7 +19779,7 @@ TEST(GameDataRuntime, EditableLevelFragmentRejectsOffSnapSourceCoordinates)
 
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
-    EXPECT_GT(world.brush_count, 0);
+    EXPECT_EQ(world.brush_count, 0);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -20484,7 +20544,7 @@ TEST(GameDataRuntime, EditorShellDojoOpenLoadsEditableLevelOnEnter)
 
     slayer3d_game_data_brush_world world{};
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(data, "brush.editor_shell.target", &world));
-    ASSERT_GT(world.brush_count, 1);
+    ASSERT_EQ(world.brush_count, 1);
     ASSERT_NE(world.render_model, nullptr);
     EXPECT_GT(world.render_model->mesh_count, 0);
     if (world.render_model->root_count > 0)
@@ -20859,9 +20919,15 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     EXPECT_FALSE(slayer3d_game_data_active_scene_mouse_capture(runtime, true));
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    slayer3d_game_data_brush_world empty_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &empty_world));
+    EXPECT_EQ(empty_world.brush_count, 0);
+    slayer3d_game_data_player_start_editor_state empty_starts{};
+    ASSERT_TRUE(slayer3d_game_data_get_player_start_editor_state(runtime, &empty_starts));
+    EXPECT_EQ(empty_starts.count, 0);
     EXPECT_TRUE(slayer3d_properties_get_bool(slayer3d_game_data_scene_state(runtime), "editor.hover.hit", false));
     EXPECT_STREQ(slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.hover.element", ""),
-                 "brush.target.cube");
+                 "");
 
     slayer3d_properties *mutable_scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     slayer3d_properties_set_string(mutable_scene_state, "editor.mode", "brush");
@@ -20912,8 +20978,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     slayer3d_input_update(input, 13);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_STREQ(
-        slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.selection.element", ""),
-        "brush.target.cube");
+        slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), "editor.selection.element", ""), "");
+    EXPECT_EQ(slayer3d_properties_get_int(slayer3d_game_data_scene_state(runtime), "editor.selection.count", -1), 0);
     flyby_click.type = SDL_EVENT_MOUSE_BUTTON_UP;
     slayer3d_input_process_event(input, &flyby_click);
     slayer3d_input_update(input, 14);
@@ -21022,7 +21088,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoDirectStartsPlayableSceneFromPlayerStart)
+TEST(GameDataRuntime, EditorShellDojoRejectsMissingDirectPlayerStart)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -21044,30 +21110,9 @@ TEST(GameDataRuntime, EditorShellDojoDirectStartsPlayableSceneFromPlayerStart)
 
     char error[512]{};
     slayer3d_data_game_runtime *runtime = nullptr;
-    ASSERT_TRUE(slayer3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error))) << error;
-    slayer3d_game_data_runtime *data = slayer3d_data_game_runtime_data(runtime);
-    ASSERT_NE(data, nullptr);
-    EXPECT_STREQ(slayer3d_game_data_active_scene(data), "scene.editor_shell.test_run");
-    EXPECT_STREQ(slayer3d_game_data_active_camera(data), "camera.editor_shell.player");
-    EXPECT_TRUE(slayer3d_game_data_active_scene_updates_game(data));
-    EXPECT_TRUE(slayer3d_game_data_active_scene_renders_world(data));
-    EXPECT_TRUE(slayer3d_game_data_active_scene_has_entity(data, "entity.editor_shell.player"));
-
-    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(data, "entity.editor_shell.player");
-    ASSERT_NE(player, nullptr);
-    EXPECT_NEAR(player->position.x, 0.0f, 0.001f);
-    EXPECT_NEAR(player->position.y, 1.6f, 0.001f);
-    EXPECT_NEAR(player->position.z, 4.0f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "yaw", 0.0f), 3.14159f, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(player->props, "pitch", 1.0f), 0.0f, 0.001f);
-
-    slayer3d_camera3d camera{};
-    ASSERT_TRUE(slayer3d_game_data_get_camera(data, "camera.editor_shell.player", &camera));
-    EXPECT_NEAR(camera.position.x, player->position.x, 0.001f);
-    EXPECT_NEAR(camera.position.y, player->position.y, 0.001f);
-    EXPECT_NEAR(camera.position.z, player->position.z, 0.001f);
-
-    slayer3d_data_game_runtime_destroy(runtime);
+    EXPECT_FALSE(slayer3d_data_game_runtime_create(&desc, &runtime, error, sizeof(error)));
+    EXPECT_EQ(runtime, nullptr);
+    EXPECT_NE(std::string(error).find("initial player start"), std::string::npos) << error;
     slayer3d_game_session_destroy(session);
 }
 

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16224,25 +16224,6 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_STREQ(active_selection.world_name, "brush.editor_shell.target");
     EXPECT_STREQ(active_selection.element_name, "brush.target.cube");
 
-    SDL_Event empty_motion{};
-    empty_motion.type = SDL_EVENT_MOUSE_MOTION;
-    empty_motion.motion.x = 1180.0f;
-    empty_motion.motion.y = 580.0f;
-    empty_motion.motion.xrel = 0.0f;
-    empty_motion.motion.yrel = 0.0f;
-    slayer3d_input_process_event(input, &empty_motion);
-    SDL_Event empty_click{};
-    empty_click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
-    empty_click.button.button = SDL_BUTTON_LEFT;
-    empty_click.button.x = empty_motion.motion.x;
-    empty_click.button.y = empty_motion.motion.y;
-    slayer3d_input_process_event(input, &empty_click);
-    slayer3d_input_update(input, 3);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", true));
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
-    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
-
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
@@ -17194,6 +17175,13 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_z", 0.0f),
                 created_brush.bounds.max.z - created_brush.bounds.min.z, 0.001f);
     EXPECT_STRNE(slayer3d_properties_get_string(scene_state, "editor.selection.element_stable_id", ""), "");
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
+    ASSERT_GE(clear_selection_signal, 0);
+    slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
 
     const slayer3d_bounding_box before_drag_move = find_brush_bounds(created_name);
     mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
@@ -17203,6 +17191,8 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_input_process_event(input, &mouse);
     slayer3d_input_update(input, 6);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), created_name.c_str());
     motion.motion.x = 820.0f;
     motion.motion.y = 430.0f;
     motion.motion.xrel = 40.0f;
@@ -17267,6 +17257,48 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     after_nudge = find_brush_bounds(created_name);
     EXPECT_NEAR(after_nudge.min.y, before_vertical_modifier.min.y + 1.0f, 0.001f);
     EXPECT_NEAR(after_nudge.max.y, before_vertical_modifier.max.y + 1.0f, 0.001f);
+
+    const slayer3d_bounding_box before_alt_drag = after_nudge;
+    SDL_SetModState(SDL_KMOD_ALT);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LALT;
+    key.key.mod = SDL_KMOD_ALT;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, key_frame++);
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = 820.0f;
+    mouse.button.y = 430.0f;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, key_frame++);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    motion.motion.x = 820.0f;
+    motion.motion.y = 330.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = -100.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, key_frame++);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    key.type = SDL_EVENT_KEY_UP;
+    key.key.scancode = SDL_SCANCODE_LALT;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_input_update(input, key_frame++);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    after_nudge = find_brush_bounds(created_name);
+    EXPECT_NEAR(after_nudge.min.x, before_alt_drag.min.x, 0.001f);
+    EXPECT_NEAR(after_nudge.min.z, before_alt_drag.min.z, 0.001f);
+    EXPECT_GT(after_nudge.min.y, before_alt_drag.min.y + 0.5f);
+    const slayer3d_value *selection_bounds_min =
+        slayer3d_properties_get_value(scene_state, "editor.selection.bounds_min");
+    ASSERT_NE(selection_bounds_min, nullptr);
+    ASSERT_EQ(selection_bounds_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(selection_bounds_min->as_vec3.y, after_nudge.min.y, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_input.cpp
+++ b/tests/test_input.cpp
@@ -393,12 +393,32 @@ TEST(Input, MouseButtonPressAndRelease)
     EXPECT_TRUE(slayer3d_input_is_pressed(input.input, fire));
     EXPECT_TRUE(slayer3d_input_is_held(input.input, fire));
     EXPECT_EQ(slayer3d_input_get_pressed_mouse_button(input.input), SDL_BUTTON_LEFT);
+    EXPECT_TRUE(slayer3d_input_is_mouse_button_pressed(input.input, SDL_BUTTON_LEFT));
+    EXPECT_TRUE(slayer3d_input_is_mouse_button_down(input.input, SDL_BUTTON_LEFT));
+    EXPECT_FALSE(slayer3d_input_is_mouse_button_released(input.input, SDL_BUTTON_LEFT));
 
     push_mouse_button(input.input, SDL_EVENT_MOUSE_BUTTON_UP, SDL_BUTTON_LEFT);
     slayer3d_input_update(input.input, 2);
     EXPECT_TRUE(slayer3d_input_is_released(input.input, fire));
     EXPECT_FALSE(slayer3d_input_is_held(input.input, fire));
     EXPECT_EQ(slayer3d_input_get_pressed_mouse_button(input.input), 0);
+    EXPECT_FALSE(slayer3d_input_is_mouse_button_pressed(input.input, SDL_BUTTON_LEFT));
+    EXPECT_FALSE(slayer3d_input_is_mouse_button_down(input.input, SDL_BUTTON_LEFT));
+    EXPECT_TRUE(slayer3d_input_is_mouse_button_released(input.input, SDL_BUTTON_LEFT));
+}
+
+TEST(Input, ReportsRawScancodePressed)
+{
+    InputPtr input;
+
+    push_key(input.input, SDL_EVENT_KEY_DOWN, SDL_SCANCODE_RIGHT);
+    slayer3d_input_update(input.input, 1);
+
+    EXPECT_TRUE(slayer3d_input_is_scancode_pressed(input.input, SDL_SCANCODE_RIGHT));
+    EXPECT_FALSE(slayer3d_input_is_scancode_pressed(input.input, SDL_SCANCODE_LEFT));
+
+    slayer3d_input_update(input.input, 2);
+    EXPECT_FALSE(slayer3d_input_is_scancode_pressed(input.input, SDL_SCANCODE_RIGHT));
 }
 
 TEST(Input, GamepadButtonPressAndRelease)


### PR DESCRIPTION
## Summary
- add Select Mode left-drag brush creation using the same source command for preview and commit
- default the editor grid and blockout brush size to 1 unit
- add an authored grid-size dropdown widget in the second toolbar
- add selected-brush grid nudging with switched arrow-key axes plus PageUp/PageDown / Fn+Up/Fn+Down vertical movement
- add selected-brush mouse dragging with snap-to-grid movement
- expose raw input pressed/down/released helpers for editor tooling
- update editor test-drive and JSON authoring docs

## Tests
- cmake --build build/debug -j4
- ctest --test-dir build/debug --output-on-failure -R "(Input\.|EditorShellDojoCreatesBlockoutPrefabTools|EditorShellDojoDragCreatesAndNudgesSourceBrush|EditorShellDojoCameraNavigation|EditableLevelFragmentSourceBoxPlacementPreviewUsesSourceValidator)"
- ctest --test-dir build/debug --output-on-failure -R "GameDataRuntime\.(Editor|EditableLevelFragment)|Input\."
- ctest --test-dir build/debug --output-on-failure

## Manual verification
Run:
```sh
./build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/slayer3d-drag-test.fragment.json --overwrite
```
Verify the editor starts in Select Mode with Grid 1, the Grid widget opens and changes the active grid size, left-dragging in empty space expands a box preview and creates a brush on release, selected brushes move by the active grid size with arrow keys, selected brushes can be dragged with the mouse while staying snapped to the grid, and PageUp/PageDown (or macOS Fn+Up/Fn+Down) moves selected brushes vertically.
