### PR TITLE
Add source vertex move transaction core

### DIFF
--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -87,6 +87,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_HANDLE = 11,
         /** @brief Active source vertex drag guide line. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_DRAG_GUIDE = 12,
+        /** @brief Pending add-vertex preview handle line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_ADD_PREVIEW = 13,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum

--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -85,6 +85,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SELECTION_FACE_EDGE = 10,
         /** @brief Selected source brush vertex handle line. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_HANDLE = 11,
+        /** @brief Active source vertex drag guide line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_DRAG_GUIDE = 12,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -1730,6 +1730,87 @@ static bool source_vertex_operation_delete(const brush_world_runtime *world_runt
 }
 
 static bool source_vertex_operation_desc_has_index(const editor_brush_source_vertex_operation_desc *desc, int index);
+static int source_vertex_operation_desc_index_offset(const editor_brush_source_vertex_operation_desc *desc, int index);
+
+static bool source_vertex_operation_move(const brush_world_runtime *world_runtime,
+                                         const editor_brush_source_vertex_operation_desc *desc,
+                                         int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3],
+                                         int *vertex_count, char *error_buffer, int error_buffer_size)
+{
+    if (world_runtime == NULL || desc == NULL || vertices == NULL || vertex_count == NULL)
+        return false;
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, desc->brush_identity);
+    editor_brush_source_vertex_model model;
+    if (source_index < 0 || !editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model,
+                                                                        error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (desc->vertex_index < 0 || desc->vertex_index >= model.vertex_count)
+    {
+        set_error(error_buffer, error_buffer_size, "source vertex move index out of range");
+        return false;
+    }
+
+    *vertex_count = 0;
+    for (int i = 0; i < model.vertex_count; ++i)
+    {
+        const int *coord = i == desc->vertex_index ? desc->coord : model.vertices[i].coord;
+        if (!source_vertex_operation_append_unique(vertices, vertex_count, coord, error_buffer, error_buffer_size))
+            return false;
+    }
+    return true;
+}
+
+static bool source_vertex_operation_move_many(const brush_world_runtime *world_runtime,
+                                              const editor_brush_source_vertex_operation_desc *desc,
+                                              int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3],
+                                              int *vertex_count, char *error_buffer, int error_buffer_size)
+{
+    if (world_runtime == NULL || desc == NULL || vertices == NULL || vertex_count == NULL)
+        return false;
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, desc->brush_identity);
+    editor_brush_source_vertex_model model;
+    if (source_index < 0 || !editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model,
+                                                                        error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (desc->vertex_index_count <= 0 || desc->vertex_index_count > SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY)
+    {
+        set_error(error_buffer, error_buffer_size, "source vertex move requires at least one vertex");
+        return false;
+    }
+    for (int i = 0; i < desc->vertex_index_count; ++i)
+    {
+        const int vertex_index = desc->vertex_indices[i];
+        if (vertex_index < 0 || vertex_index >= model.vertex_count)
+        {
+            set_error(error_buffer, error_buffer_size, "source vertex move index out of range");
+            return false;
+        }
+        for (int j = i + 1; j < desc->vertex_index_count; ++j)
+        {
+            if (desc->vertex_indices[j] == vertex_index)
+            {
+                set_error(error_buffer, error_buffer_size, "source vertex move indices must be unique");
+                return false;
+            }
+        }
+    }
+
+    *vertex_count = 0;
+    for (int i = 0; i < model.vertex_count; ++i)
+    {
+        const int move_offset = source_vertex_operation_desc_index_offset(desc, i);
+        const int *coord = move_offset >= 0 ? desc->coords[move_offset] : model.vertices[i].coord;
+        if (!source_vertex_operation_append_unique(vertices, vertex_count, coord, error_buffer, error_buffer_size))
+            return false;
+    }
+    return true;
+}
 
 static bool source_vertex_operation_merge_many_to_target(const brush_world_runtime *world_runtime,
                                                          const editor_brush_source_vertex_operation_desc *desc,
@@ -1796,6 +1877,18 @@ static bool source_vertex_operation_desc_has_index(const editor_brush_source_ver
             return true;
     }
     return false;
+}
+
+static int source_vertex_operation_desc_index_offset(const editor_brush_source_vertex_operation_desc *desc, int index)
+{
+    if (desc == NULL || index < 0)
+        return -1;
+    for (int i = 0; i < desc->vertex_index_count; ++i)
+    {
+        if (desc->vertex_indices[i] == index)
+            return i;
+    }
+    return -1;
 }
 
 static bool source_vertex_operation_delete_many(const brush_world_runtime *world_runtime,
@@ -1913,6 +2006,24 @@ static bool source_vertex_operation_snap(const brush_world_runtime *world_runtim
     return true;
 }
 
+typedef struct editor_brush_source_vertex_transaction
+{
+    int source_index;
+    editor_brush_source_box_runtime rollback_box;
+    bool rollback_captured;
+    editor_brush_source_vertex_operation_result preview;
+} editor_brush_source_vertex_transaction;
+
+static void source_vertex_transaction_dispose(editor_brush_source_vertex_transaction *transaction)
+{
+    if (transaction == NULL)
+        return;
+    if (transaction->rollback_captured)
+        free_editor_brush_source_box(&transaction->rollback_box);
+    editor_brush_source_free_runtime_brush(&transaction->preview.brush);
+    SDL_zero(*transaction);
+}
+
 bool editor_brush_world_preview_source_vertex_operation(const brush_world_runtime *world_runtime,
                                                         const editor_brush_source_vertex_operation_desc *desc,
                                                         editor_brush_source_vertex_operation_result *out_result,
@@ -1928,6 +2039,13 @@ bool editor_brush_world_preview_source_vertex_operation(const brush_world_runtim
         return false;
     }
 
+    if (find_editor_source_box_index_by_identity(world_runtime, desc->brush_identity) < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        source_vertex_operation_set_failure(out_result, "source brush not found");
+        return false;
+    }
+
     int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
     SDL_zeroa(vertices);
     int vertex_count = 0;
@@ -1938,6 +2056,16 @@ bool editor_brush_world_preview_source_vertex_operation(const brush_world_runtim
     case EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD:
         ok = source_vertex_operation_add(world_runtime, desc, vertices, &vertex_count, error_buffer, error_buffer_size);
         changed_count = ok ? 1 : 0;
+        break;
+    case EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE:
+        ok =
+            source_vertex_operation_move(world_runtime, desc, vertices, &vertex_count, error_buffer, error_buffer_size);
+        changed_count = ok ? 1 : 0;
+        break;
+    case EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY:
+        ok = source_vertex_operation_move_many(world_runtime, desc, vertices, &vertex_count, error_buffer,
+                                               error_buffer_size);
+        changed_count = ok ? desc->vertex_index_count : 0;
         break;
     case EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_DELETE:
         ok = source_vertex_operation_delete(world_runtime, desc, vertices, &vertex_count, error_buffer,
@@ -2012,38 +2140,40 @@ bool editor_brush_world_apply_source_vertex_operation(brush_world_runtime *world
         return false;
     }
 
-    editor_brush_source_vertex_operation_result preview;
-    if (!editor_brush_world_preview_source_vertex_operation(world_runtime, desc, &preview, error_buffer,
+    editor_brush_source_vertex_transaction transaction;
+    SDL_zero(transaction);
+    if (!editor_brush_world_preview_source_vertex_operation(world_runtime, desc, &transaction.preview, error_buffer,
                                                             error_buffer_size))
     {
         if (out_result != NULL)
-            *out_result = preview;
+            *out_result = transaction.preview;
         return false;
     }
 
-    const int source_index = find_editor_source_box_index_by_identity(world_runtime, desc->brush_identity);
-    if (source_index < 0)
+    transaction.source_index = find_editor_source_box_index_by_identity(world_runtime, desc->brush_identity);
+    if (transaction.source_index < 0)
     {
-        editor_brush_source_free_runtime_brush(&preview.brush);
+        source_vertex_transaction_dispose(&transaction);
         set_error(error_buffer, error_buffer_size, "source brush not found");
         return false;
     }
 
-    editor_brush_source_box_runtime old_box;
-    if (!copy_editor_brush_source_box_runtime(&world_runtime->editor_source_boxes[source_index], &old_box))
+    if (!copy_editor_brush_source_box_runtime(&world_runtime->editor_source_boxes[transaction.source_index],
+                                              &transaction.rollback_box))
     {
-        editor_brush_source_free_runtime_brush(&preview.brush);
+        source_vertex_transaction_dispose(&transaction);
         set_error(error_buffer, error_buffer_size, "failed to copy source brush rollback state");
         return false;
     }
+    transaction.rollback_captured = true;
 
-    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
-    box->vertex_count = preview.vertex_count;
-    for (int i = 0; i < preview.vertex_count; ++i)
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[transaction.source_index];
+    box->vertex_count = transaction.preview.vertex_count;
+    for (int i = 0; i < transaction.preview.vertex_count; ++i)
     {
-        box->vertices[i][0] = preview.vertices[i][0];
-        box->vertices[i][1] = preview.vertices[i][1];
-        box->vertices[i][2] = preview.vertices[i][2];
+        box->vertices[i][0] = transaction.preview.vertices[i][0];
+        box->vertices[i][1] = transaction.preview.vertices[i][1];
+        box->vertices[i][2] = transaction.preview.vertices[i][2];
     }
     source_box_update_bounds_from_vertices(box);
     if (box->prefab == NULL || SDL_strcmp(box->prefab, "box") == 0 || SDL_strcmp(box->prefab, "editor.box") == 0)
@@ -2053,29 +2183,30 @@ bool editor_brush_world_apply_source_vertex_operation(brush_world_runtime *world
         if (box->prefab == NULL)
         {
             box->prefab = old_prefab;
-            free_editor_brush_source_box(&old_box);
-            editor_brush_source_free_runtime_brush(&preview.brush);
+            source_vertex_transaction_dispose(&transaction);
             set_error(error_buffer, error_buffer_size, "failed to allocate source convex prefab metadata");
             return false;
         }
         SDL_free(old_prefab);
     }
 
-    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
+    if (!source_box_candidate_valid(world_runtime, box, transaction.source_index, error_buffer, error_buffer_size) ||
         !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
     {
         free_editor_brush_source_box(box);
-        *box = old_box;
+        *box = transaction.rollback_box;
+        transaction.rollback_captured = false;
         (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
-        editor_brush_source_free_runtime_brush(&preview.brush);
+        editor_brush_source_free_runtime_brush(&transaction.preview.brush);
         return false;
     }
 
-    free_editor_brush_source_box(&old_box);
+    free_editor_brush_source_box(&transaction.rollback_box);
+    transaction.rollback_captured = false;
     if (out_result != NULL)
-        *out_result = preview;
+        *out_result = transaction.preview;
     else
-        editor_brush_source_free_runtime_brush(&preview.brush);
+        editor_brush_source_free_runtime_brush(&transaction.preview.brush);
     return true;
 }
 

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -112,6 +112,15 @@ bool editor_brush_world_build_source_convex_brush_from_vertices(const brush_worl
                                                                 int vertex_count, slayer3d_game_data_brush *out_brush,
                                                                 char *error_buffer, int error_buffer_size);
 void editor_brush_source_free_runtime_brush(slayer3d_game_data_brush *brush);
+
+/*
+ * Shared source-vertex mutation boundary for editor tools.
+ *
+ * Vertex mode, face/edge tools, clip tools, and future CSG tooling should route source-brush edits through this
+ * preview/apply pair instead of mutating editor_source_boxes directly. Preview and apply use the same validation and
+ * convex rebuild path, so callers can render diagnostics/handles from dry-run output and then commit the exact same
+ * operation when the user accepts it.
+ */
 bool editor_brush_world_preview_source_vertex_operation(const brush_world_runtime *world_runtime,
                                                         const editor_brush_source_vertex_operation_desc *desc,
                                                         editor_brush_source_vertex_operation_result *out_result,

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -35,6 +35,10 @@ static bool emit_editor_source_vertex_drag_guides(const slayer3d_game_data_runti
                                                   const slayer3d_game_data_editor_debug_desc *desc,
                                                   slayer3d_game_data_editor_debug_primitive_fn callback,
                                                   void *userdata);
+static bool emit_editor_source_vertex_add_preview(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_editor_debug_desc *desc,
+                                                  slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                  void *userdata);
 static bool emit_editor_debug_overlay_markers(const slayer3d_game_data_runtime *runtime,
                                               const slayer3d_game_data_editor_debug_desc *desc,
                                               slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata);
@@ -216,6 +220,8 @@ bool slayer3d_game_data_for_each_active_editor_debug_primitive(const slayer3d_ga
         return false;
     if (!emit_editor_source_vertex_drag_guides(runtime, &desc, callback, userdata))
         return false;
+    if (!emit_editor_source_vertex_add_preview(runtime, &desc, callback, userdata))
+        return false;
     if (!emit_editor_overlapping_source_brush_bounds(runtime, &desc, callback, userdata))
         return false;
 
@@ -385,6 +391,38 @@ static bool emit_editor_source_vertex_drag_guides(const slayer3d_game_data_runti
             return false;
     }
     return true;
+}
+
+static bool emit_editor_source_vertex_add_preview(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_editor_debug_desc *desc,
+                                                  slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL || runtime->scene_state == NULL ||
+        !editor_debug_mode_is_vertex(runtime) ||
+        !slayer3d_properties_get_bool(runtime->scene_state, "editor.vertex.add.preview.active", false))
+    {
+        return true;
+    }
+
+    const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_VERTEX_HANDLES) == 0u)
+        return true;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.color = slayer3d_properties_get_bool(runtime->scene_state, "editor.vertex.add.preview.valid", false)
+                        ? (slayer3d_color){96, 255, 160, 200}
+                        : (slayer3d_color){255, 80, 80, 220};
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_ADD_PREVIEW;
+    context.world_name = slayer3d_properties_get_string(runtime->scene_state, "editor.vertex.add.preview.world", "");
+    context.element_name = "editor.vertex.add.preview";
+    context.face_index = -1;
+
+    const slayer3d_vec3 position = slayer3d_properties_get_vec3(
+        runtime->scene_state, "editor.vertex.add.preview.position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return emit_editor_debug_marker_cross(&context, position, 0.16f);
 }
 
 static bool emit_editor_debug_bounds(editor_debug_iteration_context *context, slayer3d_bounding_box bounds)

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -31,6 +31,10 @@ static bool emit_editor_selected_source_vertex_handles(const slayer3d_game_data_
                                                        const slayer3d_game_data_editor_debug_desc *desc,
                                                        slayer3d_game_data_editor_debug_primitive_fn callback,
                                                        void *userdata);
+static bool emit_editor_source_vertex_drag_guides(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_editor_debug_desc *desc,
+                                                  slayer3d_game_data_editor_debug_primitive_fn callback,
+                                                  void *userdata);
 static bool emit_editor_debug_overlay_markers(const slayer3d_game_data_runtime *runtime,
                                               const slayer3d_game_data_editor_debug_desc *desc,
                                               slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata);
@@ -210,6 +214,8 @@ bool slayer3d_game_data_for_each_active_editor_debug_primitive(const slayer3d_ga
         return false;
     if (!emit_editor_selected_source_vertex_handles(runtime, &desc, callback, userdata))
         return false;
+    if (!emit_editor_source_vertex_drag_guides(runtime, &desc, callback, userdata))
+        return false;
     if (!emit_editor_overlapping_source_brush_bounds(runtime, &desc, callback, userdata))
         return false;
 
@@ -297,6 +303,86 @@ static bool emit_editor_selected_source_vertex_handles(const slayer3d_game_data_
             if (!emit_editor_debug_marker_cross(&context, center, 0.12f))
                 return false;
         }
+    }
+    return true;
+}
+
+static slayer3d_vec3 editor_drag_origin_coord_meters(const brush_world_runtime *world,
+                                                     const editor_drag_vertex_origin *origin)
+{
+    const float meters_per_unit =
+        world != NULL && world->editor_source_meters_per_unit > 0.0f ? world->editor_source_meters_per_unit : 0.001f;
+    return slayer3d_vec3_make((float)origin->coord[0] * meters_per_unit, (float)origin->coord[1] * meters_per_unit,
+                              (float)origin->coord[2] * meters_per_unit);
+}
+
+static bool editor_drag_origin_world_position(const slayer3d_game_data_runtime *runtime,
+                                              const editor_drag_vertex_origin *origin, slayer3d_vec3 *out_position)
+{
+    if (out_position != NULL)
+        *out_position = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (runtime == NULL || origin == NULL || out_position == NULL || !editor_selected_brushes_active_for_scene(runtime))
+        return false;
+
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        slayer3d_game_data_editor_selection selection =
+            resolved_editor_selection(runtime, &runtime->editor_selected_brushes[i]);
+        if (!selection.hit || selection.world_name == NULL || selection.element_name == NULL ||
+            SDL_strcmp(selection.world_name, origin->world_name) != 0)
+        {
+            continue;
+        }
+        const bool name_match = SDL_strcmp(selection.element_name, origin->brush_name) == 0;
+        const bool stable_match = selection.element_editor != NULL && selection.element_editor->stable_id != NULL &&
+                                  SDL_strcmp(selection.element_editor->stable_id, origin->brush_name) == 0;
+        if (name_match || stable_match)
+        {
+            *out_position = selection.world_position;
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool emit_editor_source_vertex_drag_guides(const slayer3d_game_data_runtime *runtime,
+                                                  const slayer3d_game_data_editor_debug_desc *desc,
+                                                  slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL || !editor_debug_mode_is_vertex(runtime))
+        return true;
+
+    const editor_drag_move_state *drag = &runtime->editor_drag_move;
+    if (!drag->active || !drag->vertex_drag || drag->vertex_origin_count <= 0 ||
+        slayer3d_vec3_length_squared(drag->applied_offset) <= 0.0000001f)
+    {
+        return true;
+    }
+
+    const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_VERTEX_HANDLES) == 0u)
+        return true;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.color = drag->axis_lock_y ? (slayer3d_color){255, 96, 72, 255} : (slayer3d_color){255, 224, 64, 255};
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_DRAG_GUIDE;
+    context.face_index = -1;
+
+    for (int i = 0; i < drag->vertex_origin_count; ++i)
+    {
+        const editor_drag_vertex_origin *origin = &drag->vertex_origins[i];
+        const brush_world_runtime *world = find_brush_world_runtime(runtime, origin->world_name);
+        slayer3d_vec3 world_position = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        (void)editor_drag_origin_world_position(runtime, origin, &world_position);
+        const slayer3d_vec3 start = slayer3d_vec3_add(world_position, editor_drag_origin_coord_meters(world, origin));
+        const slayer3d_vec3 end = slayer3d_vec3_add(start, drag->applied_offset);
+        context.world_name = origin->world_name;
+        context.element_name = origin->vertex_stable_id;
+        if (!emit_editor_debug_line(&context, start, end))
+            return false;
     }
     return true;
 }

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -373,7 +373,8 @@ static bool emit_editor_source_vertex_drag_guides(const slayer3d_game_data_runti
     SDL_zero(context);
     context.callback = callback;
     context.userdata = userdata;
-    context.color = drag->axis_lock_y ? (slayer3d_color){255, 96, 72, 255} : (slayer3d_color){255, 224, 64, 255};
+    context.color = (drag->axis_lock_y || drag->axis_lock_dominant) ? (slayer3d_color){255, 96, 72, 255}
+                                                                    : (slayer3d_color){255, 224, 64, 255};
     context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_DRAG_GUIDE;
     context.face_index = -1;
 

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -221,6 +221,8 @@ typedef struct editor_source_box_bounds_update
 typedef enum editor_brush_source_vertex_operation_type
 {
     EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD,
+    EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE,
+    EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY,
     EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_DELETE,
     EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_DELETE_MANY,
     EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MERGE,
@@ -237,6 +239,7 @@ typedef struct editor_brush_source_vertex_operation_desc
     int vertex_indices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
     int vertex_index_count;
     int coord[3];
+    int coords[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
     int snap_units;
 } editor_brush_source_vertex_operation_desc;
 

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -73,6 +73,7 @@ typedef struct editor_drag_move_state
     bool active;
     bool moved;
     bool axis_lock_y;
+    bool axis_lock_dominant;
     bool face_resize;
     bool vertex_drag;
     bool vertex_lasso;

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -58,18 +58,31 @@ typedef struct editor_drag_create_state
     int source_max[3];
 } editor_drag_create_state;
 
+#define SLAYER3D_EDITOR_DRAG_VERTEX_ORIGIN_CAPACITY 512
+
+typedef struct editor_drag_vertex_origin
+{
+    char world_name[SLAYER3D_GAME_DATA_EDITOR_DIAGNOSTIC_TEXT_MAX];
+    char brush_name[SLAYER3D_GAME_DATA_EDITOR_DIAGNOSTIC_TEXT_MAX];
+    char vertex_stable_id[SLAYER3D_GAME_DATA_EDITOR_DIAGNOSTIC_TEXT_MAX];
+    int coord[3];
+} editor_drag_vertex_origin;
+
 typedef struct editor_drag_move_state
 {
     bool active;
     bool moved;
     bool axis_lock_y;
     bool face_resize;
+    bool vertex_drag;
     bool vertex_lasso;
     bool lasso_additive;
     const char *scene;
     slayer3d_vec3 start_point;
     slayer3d_vec3 applied_offset;
     slayer3d_game_data_editor_selection face_selection;
+    int vertex_origin_count;
+    editor_drag_vertex_origin vertex_origins[SLAYER3D_EDITOR_DRAG_VERTEX_ORIGIN_CAPACITY];
     float grid_size;
     float start_mouse_x;
     float start_mouse_y;

--- a/src/game_data_editor_vertex_mode.c
+++ b/src/game_data_editor_vertex_mode.c
@@ -604,7 +604,7 @@ static int editor_select_vertices_in_lasso(slayer3d_game_data_runtime *runtime, 
             }
             editor_source_vertex_selection candidate;
             if (editor_source_vertex_selection_from_model(world_runtime, &model, v, &candidate))
-                (void)add_editor_selected_vertex(runtime, &candidate);
+                (void)editor_add_shared_vertex_selection_group(runtime, &candidate);
         }
     }
 
@@ -681,13 +681,6 @@ bool editor_handle_vertex_lasso(slayer3d_game_data_runtime *runtime, yyjson_val 
     return true;
 }
 
-typedef struct editor_vertex_bounds_accumulator
-{
-    editor_source_box_bounds_update update;
-    bool min_touched[3];
-    bool max_touched[3];
-} editor_vertex_bounds_accumulator;
-
 static int editor_source_units_from_meters(const brush_world_runtime *world_runtime, float meters)
 {
     const float meters_per_unit = world_runtime != NULL && world_runtime->editor_source_meters_per_unit > 0.0f
@@ -696,15 +689,79 @@ static int editor_source_units_from_meters(const brush_world_runtime *world_runt
     return (int)SDL_roundf(meters / meters_per_unit);
 }
 
-static editor_vertex_bounds_accumulator *editor_find_vertex_bounds_accumulator(
-    editor_vertex_bounds_accumulator *accumulators, int count, int source_index)
+typedef struct editor_source_vertex_move_target
 {
+    brush_world_runtime *world_runtime;
+    int source_index;
+    int vertex_indices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
+    int coords[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    int vertex_index_count;
+} editor_source_vertex_move_target;
+
+static editor_source_vertex_move_target *editor_find_vertex_move_target(editor_source_vertex_move_target *targets,
+                                                                        int count,
+                                                                        const brush_world_runtime *world_runtime,
+                                                                        int source_index)
+{
+    if (targets == NULL || world_runtime == NULL || source_index < 0)
+        return NULL;
     for (int i = 0; i < count; ++i)
     {
-        if (accumulators[i].update.source_index == source_index)
-            return &accumulators[i];
+        if (targets[i].world_runtime == world_runtime && targets[i].source_index == source_index)
+            return &targets[i];
     }
     return NULL;
+}
+
+static bool editor_vertex_move_target_add(editor_source_vertex_move_target *target,
+                                          const editor_source_vertex_selection *selection, const int delta[3])
+{
+    if (target == NULL || selection == NULL || delta == NULL || selection->vertex_index < 0)
+        return false;
+
+    for (int i = 0; i < target->vertex_index_count; ++i)
+    {
+        if (target->vertex_indices[i] == selection->vertex_index)
+            return true;
+    }
+    if (target->vertex_index_count >= SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY)
+        return false;
+
+    const int index = target->vertex_index_count++;
+    target->vertex_indices[index] = selection->vertex_index;
+    for (int axis = 0; axis < 3; ++axis)
+        target->coords[index][axis] = selection->coord[axis] + delta[axis];
+    return true;
+}
+
+static const char *editor_source_move_target_identity(const editor_source_vertex_move_target *target)
+{
+    if (target == NULL || target->world_runtime == NULL || target->source_index < 0 ||
+        target->source_index >= target->world_runtime->editor_source_box_count)
+    {
+        return NULL;
+    }
+    const editor_brush_source_box_runtime *box = &target->world_runtime->editor_source_boxes[target->source_index];
+    return box->stable_id != NULL && box->stable_id[0] != '\0' ? box->stable_id : box->name;
+}
+
+static void editor_init_vertex_move_desc(const editor_source_vertex_move_target *target,
+                                         editor_brush_source_vertex_operation_desc *desc)
+{
+    if (desc == NULL)
+        return;
+    SDL_zero(*desc);
+    desc->brush_identity = editor_source_move_target_identity(target);
+    desc->type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY;
+    if (target == NULL)
+        return;
+    desc->vertex_index_count = target->vertex_index_count;
+    for (int i = 0; i < target->vertex_index_count; ++i)
+    {
+        desc->vertex_indices[i] = target->vertex_indices[i];
+        for (int axis = 0; axis < 3; ++axis)
+            desc->coords[i][axis] = target->coords[i][axis];
+    }
 }
 
 static void editor_refresh_selected_brushes_after_source_edit(slayer3d_game_data_runtime *runtime)
@@ -770,9 +827,9 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
     if (delta[0] == 0 && delta[1] == 0 && delta[2] == 0)
         return false;
 
-    editor_vertex_bounds_accumulator accumulators[SLAYER3D_EDITOR_SELECTED_VERTEX_CAPACITY];
-    SDL_zeroa(accumulators);
-    int accumulator_count = 0;
+    editor_source_vertex_move_target targets[SLAYER3D_EDITOR_SELECTED_VERTEX_CAPACITY];
+    SDL_zeroa(targets);
+    int target_count = 0;
     for (int i = 0; i < runtime->editor_selected_vertex_count; ++i)
     {
         const editor_source_vertex_selection *selection = &runtime->editor_selected_vertices[i];
@@ -784,58 +841,74 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
             return false;
         }
 
-        editor_vertex_bounds_accumulator *accumulator =
-            editor_find_vertex_bounds_accumulator(accumulators, accumulator_count, selection->source_index);
-        if (accumulator == NULL)
+        editor_source_vertex_move_target *target =
+            editor_find_vertex_move_target(targets, target_count, world_runtime, selection->source_index);
+        if (target == NULL)
         {
-            if (accumulator_count >= (int)SDL_arraysize(accumulators))
+            if (target_count >= (int)SDL_arraysize(targets))
                 return false;
-            accumulator = &accumulators[accumulator_count++];
-            accumulator->update.source_index = selection->source_index;
-            const editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[selection->source_index];
-            for (int axis = 0; axis < 3; ++axis)
-            {
-                accumulator->update.min[axis] = box->min[axis];
-                accumulator->update.max[axis] = box->max[axis];
-            }
+            target = &targets[target_count++];
+            target->world_runtime = world_runtime;
+            target->source_index = selection->source_index;
         }
 
-        const editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[selection->source_index];
-        for (int axis = 0; axis < 3; ++axis)
+        if (!editor_vertex_move_target_add(target, selection, delta))
         {
-            if (delta[axis] == 0)
-                continue;
-            if (selection->coord[axis] == box->min[axis] && !accumulator->min_touched[axis])
-            {
-                accumulator->update.min[axis] += delta[axis];
-                accumulator->min_touched[axis] = true;
-            }
-            if (selection->coord[axis] == box->max[axis] && !accumulator->max_touched[axis])
-            {
-                accumulator->update.max[axis] += delta[axis];
-                accumulator->max_touched[axis] = true;
-            }
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
+                                           "vertex move blocked: too many selected vertices");
+            return false;
         }
     }
-
-    editor_source_box_bounds_update updates[SLAYER3D_EDITOR_SELECTED_VERTEX_CAPACITY];
-    for (int i = 0; i < accumulator_count; ++i)
-        updates[i] = accumulators[i].update;
 
     char error[256];
-    if (!editor_brush_world_update_source_box_bounds_batch(world_runtime, updates, accumulator_count, error,
-                                                           sizeof(error)))
+    SDL_zeroa(error);
+    for (int i = 0; i < target_count; ++i)
     {
-        char message[320];
-        SDL_snprintf(message, sizeof(message), "vertex move blocked: %s", error[0] != '\0' ? error : "invalid edit");
-        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
-        editor_refresh_selected_vertices_after_source_edit(runtime, world_runtime);
-        editor_refresh_selected_brushes_after_source_edit(runtime);
-        return false;
+        editor_brush_source_vertex_operation_desc desc;
+        editor_init_vertex_move_desc(&targets[i], &desc);
+        editor_brush_source_vertex_operation_result preview;
+        SDL_zero(preview);
+        if (!editor_brush_world_preview_source_vertex_operation(targets[i].world_runtime, &desc, &preview, error,
+                                                                sizeof(error)))
+        {
+            char message[320];
+            SDL_snprintf(message, sizeof(message), "vertex move blocked: %s",
+                         error[0] != '\0' ? error : "invalid source edit");
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+            editor_brush_source_free_runtime_brush(&preview.brush);
+            editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
+            editor_refresh_selected_brushes_after_source_edit(runtime);
+            return false;
+        }
+        editor_brush_source_free_runtime_brush(&preview.brush);
     }
 
-    editor_refresh_selected_vertices_after_source_edit(runtime, world_runtime);
-    editor_refresh_selected_brushes_after_source_edit(runtime);
+    for (int i = 0; i < target_count; ++i)
+    {
+        editor_brush_source_vertex_operation_desc desc;
+        editor_init_vertex_move_desc(&targets[i], &desc);
+        editor_brush_source_vertex_operation_result result;
+        SDL_zero(result);
+        if (!editor_brush_world_apply_source_vertex_operation(targets[i].world_runtime, &desc, &result, error,
+                                                              sizeof(error)))
+        {
+            char message[320];
+            SDL_snprintf(message, sizeof(message), "vertex move blocked: %s",
+                         error[0] != '\0' ? error : "invalid source edit");
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+            editor_brush_source_free_runtime_brush(&result.brush);
+            editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
+            editor_refresh_selected_brushes_after_source_edit(runtime);
+            return false;
+        }
+        editor_brush_source_free_runtime_brush(&result.brush);
+    }
+
+    for (int i = 0; i < target_count; ++i)
+    {
+        editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
+        editor_refresh_selected_brushes_after_source_edit(runtime);
+    }
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "moved selected vertices");
     return true;
 }

--- a/src/game_data_editor_vertex_mode.c
+++ b/src/game_data_editor_vertex_mode.c
@@ -20,6 +20,18 @@ static float editor_snap_delta(float delta, float grid_size)
     return SDL_roundf(delta / grid) * grid;
 }
 
+static slayer3d_vec3 editor_lock_offset_to_dominant_axis(slayer3d_vec3 offset)
+{
+    const float abs_x = SDL_fabsf(offset.x);
+    const float abs_y = SDL_fabsf(offset.y);
+    const float abs_z = SDL_fabsf(offset.z);
+    if (abs_x >= abs_y && abs_x >= abs_z)
+        return slayer3d_vec3_make(offset.x, 0.0f, 0.0f);
+    if (abs_y >= abs_z)
+        return slayer3d_vec3_make(0.0f, offset.y, 0.0f);
+    return slayer3d_vec3_make(0.0f, 0.0f, offset.z);
+}
+
 static void publish_editor_vertex_drag_state(slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag)
 {
     if (runtime == NULL || runtime->scene_state == NULL)
@@ -30,10 +42,24 @@ static void publish_editor_vertex_drag_state(slayer3d_game_data_runtime *runtime
     slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.moved", active ? drag->moved : false);
     slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.axis_lock_y",
                                  active ? drag->axis_lock_y : false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.axis_lock_dominant",
+                                 active ? drag->axis_lock_dominant : false);
     slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.drag.guide_count",
                                 active ? drag->vertex_origin_count : 0);
     slayer3d_properties_set_vec3(runtime->scene_state, "editor.vertex.drag.offset",
                                  active ? drag->applied_offset : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+}
+
+static void publish_editor_vertex_move_result(slayer3d_game_data_runtime *runtime, bool valid, int source_count,
+                                              int changed_count, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.move.valid", valid);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.move.source_count", source_count);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.move.changed_count", changed_count);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.vertex.move.message", message != NULL ? message : "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message != NULL ? message : "");
 }
 
 static void clear_editor_drag_move(slayer3d_game_data_runtime *runtime)
@@ -766,6 +792,90 @@ typedef struct editor_source_vertex_move_target
     int vertex_index_count;
 } editor_source_vertex_move_target;
 
+typedef struct editor_source_vertex_move_rollback
+{
+    brush_world_runtime *world_runtime;
+    int source_index;
+    editor_brush_source_box_runtime source_box;
+    bool captured;
+} editor_source_vertex_move_rollback;
+
+static void editor_dispose_vertex_move_rollbacks(editor_source_vertex_move_rollback *rollbacks, int count)
+{
+    if (rollbacks == NULL || count <= 0)
+        return;
+    for (int i = 0; i < count; ++i)
+    {
+        if (rollbacks[i].captured)
+            free_editor_brush_source_box_runtime(&rollbacks[i].source_box);
+    }
+}
+
+static bool editor_capture_vertex_move_rollbacks(const editor_source_vertex_move_target *targets, int target_count,
+                                                 editor_source_vertex_move_rollback *rollbacks, int rollback_capacity,
+                                                 char *error_buffer, int error_buffer_size)
+{
+    if (targets == NULL || rollbacks == NULL || target_count < 0 || rollback_capacity < target_count)
+    {
+        set_error(error_buffer, error_buffer_size, "vertex move rollback capture requires valid targets");
+        return false;
+    }
+
+    for (int i = 0; i < target_count; ++i)
+    {
+        if (targets[i].world_runtime == NULL || targets[i].source_index < 0 ||
+            targets[i].source_index >= targets[i].world_runtime->editor_source_box_count)
+        {
+            set_error(error_buffer, error_buffer_size, "vertex move rollback source not found");
+            return false;
+        }
+        rollbacks[i].world_runtime = targets[i].world_runtime;
+        rollbacks[i].source_index = targets[i].source_index;
+        if (!copy_editor_brush_source_box_runtime(
+                &targets[i].world_runtime->editor_source_boxes[targets[i].source_index], &rollbacks[i].source_box))
+        {
+            set_error(error_buffer, error_buffer_size, "vertex move rollback copy failed");
+            return false;
+        }
+        rollbacks[i].captured = true;
+    }
+    return true;
+}
+
+static void editor_restore_vertex_move_rollbacks(editor_source_vertex_move_rollback *rollbacks, int count)
+{
+    if (rollbacks == NULL || count <= 0)
+        return;
+
+    for (int i = 0; i < count; ++i)
+    {
+        if (!rollbacks[i].captured || rollbacks[i].world_runtime == NULL || rollbacks[i].source_index < 0 ||
+            rollbacks[i].source_index >= rollbacks[i].world_runtime->editor_source_box_count)
+        {
+            continue;
+        }
+        free_editor_brush_source_box_runtime(
+            &rollbacks[i].world_runtime->editor_source_boxes[rollbacks[i].source_index]);
+        rollbacks[i].world_runtime->editor_source_boxes[rollbacks[i].source_index] = rollbacks[i].source_box;
+        SDL_zero(rollbacks[i].source_box);
+        rollbacks[i].captured = false;
+    }
+
+    for (int i = 0; i < count; ++i)
+    {
+        if (rollbacks[i].world_runtime == NULL)
+            continue;
+        bool already_rebuilt = false;
+        for (int j = 0; j < i; ++j)
+        {
+            if (rollbacks[j].world_runtime == rollbacks[i].world_runtime)
+                already_rebuilt = true;
+        }
+        if (!already_rebuilt)
+            (void)editor_brush_world_rebuild_from_source(rollbacks[i].world_runtime, NULL, 0);
+    }
+}
+
 static editor_source_vertex_move_target *editor_find_vertex_move_target(editor_source_vertex_move_target *targets,
                                                                         int count,
                                                                         const brush_world_runtime *world_runtime,
@@ -904,8 +1014,8 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
         if (SDL_strcmp(selection->world_name, world_runtime->desc.name) != 0 || selection->source_index < 0 ||
             selection->source_index >= world_runtime->editor_source_box_count)
         {
-            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
-                                           "vertex move blocked: invalid source selection");
+            publish_editor_vertex_move_result(runtime, false, target_count, 0,
+                                              "vertex move blocked: invalid source selection");
             return false;
         }
 
@@ -922,14 +1032,15 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
 
         if (!editor_vertex_move_target_add(target, selection, delta))
         {
-            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
-                                           "vertex move blocked: too many selected vertices");
+            publish_editor_vertex_move_result(runtime, false, target_count, 0,
+                                              "vertex move blocked: too many selected vertices");
             return false;
         }
     }
 
     char error[256];
     SDL_zeroa(error);
+    int total_changed = 0;
     for (int i = 0; i < target_count; ++i)
     {
         editor_brush_source_vertex_operation_desc desc;
@@ -942,13 +1053,27 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
             char message[320];
             SDL_snprintf(message, sizeof(message), "vertex move blocked: %s",
                          error[0] != '\0' ? error : "invalid source edit");
-            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+            publish_editor_vertex_move_result(runtime, false, target_count, total_changed, message);
             editor_brush_source_free_runtime_brush(&preview.brush);
             editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
             editor_refresh_selected_brushes_after_source_edit(runtime);
             return false;
         }
+        total_changed += preview.changed_count;
         editor_brush_source_free_runtime_brush(&preview.brush);
+    }
+
+    editor_source_vertex_move_rollback rollbacks[SLAYER3D_EDITOR_SELECTED_VERTEX_CAPACITY];
+    SDL_zeroa(rollbacks);
+    if (!editor_capture_vertex_move_rollbacks(targets, target_count, rollbacks, SDL_arraysize(rollbacks), error,
+                                              sizeof(error)))
+    {
+        char message[320];
+        SDL_snprintf(message, sizeof(message), "vertex move blocked: %s",
+                     error[0] != '\0' ? error : "rollback capture failed");
+        publish_editor_vertex_move_result(runtime, false, target_count, total_changed, message);
+        editor_dispose_vertex_move_rollbacks(rollbacks, target_count);
+        return false;
     }
 
     for (int i = 0; i < target_count; ++i)
@@ -963,7 +1088,8 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
             char message[320];
             SDL_snprintf(message, sizeof(message), "vertex move blocked: %s",
                          error[0] != '\0' ? error : "invalid source edit");
-            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+            editor_restore_vertex_move_rollbacks(rollbacks, target_count);
+            publish_editor_vertex_move_result(runtime, false, target_count, total_changed, message);
             editor_brush_source_free_runtime_brush(&result.brush);
             editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
             editor_refresh_selected_brushes_after_source_edit(runtime);
@@ -971,13 +1097,14 @@ bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, sla
         }
         editor_brush_source_free_runtime_brush(&result.brush);
     }
+    editor_dispose_vertex_move_rollbacks(rollbacks, target_count);
 
     for (int i = 0; i < target_count; ++i)
     {
         editor_refresh_selected_vertices_after_source_edit(runtime, targets[i].world_runtime);
         editor_refresh_selected_brushes_after_source_edit(runtime);
     }
-    slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "moved selected vertices");
+    publish_editor_vertex_move_result(runtime, true, target_count, total_changed, "moved selected vertices");
     return true;
 }
 
@@ -2121,7 +2248,9 @@ bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
     {
         const SDL_Keymod modifiers = SDL_GetModState();
         const bool y_axis_lock = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_ALT)) != 0;
+        const bool dominant_axis_lock = !y_axis_lock && (modifiers & SDL_KMOD_SHIFT) != 0;
         drag->axis_lock_y = y_axis_lock;
+        drag->axis_lock_dominant = dominant_axis_lock;
         slayer3d_vec3 desired = drag->applied_offset;
         if (y_axis_lock)
         {
@@ -2135,6 +2264,8 @@ bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
                 editor_snap_delta(hover_selection->point.x - drag->start_point.x, drag->grid_size), 0.0f,
                 editor_snap_delta(hover_selection->point.z - drag->start_point.z, drag->grid_size));
         }
+        if (dominant_axis_lock)
+            desired = editor_lock_offset_to_dominant_axis(desired);
 
         const slayer3d_vec3 incremental = slayer3d_vec3_sub(desired, drag->applied_offset);
         if (slayer3d_vec3_length_squared(incremental) > 0.0000001f &&

--- a/src/game_data_editor_vertex_mode.c
+++ b/src/game_data_editor_vertex_mode.c
@@ -357,6 +357,11 @@ static void editor_begin_vertex_drag(slayer3d_game_data_runtime *runtime, slayer
                                      const slayer3d_game_data_editor_selection *hover_selection);
 static void publish_editor_vertex_add_result(slayer3d_game_data_runtime *runtime, yyjson_val *action, bool valid,
                                              int vertex_count, int added_count, const char *message);
+static void publish_editor_vertex_add_preview(slayer3d_game_data_runtime *runtime,
+                                              const slayer3d_game_data_editor_selection *selection, const int coord[3],
+                                              bool active, bool valid, const char *message);
+static bool editor_preview_add_vertex_to_source_coord(brush_world_runtime *world, int source_index, const int coord[3],
+                                                      int *out_vertex_count, char *message, size_t message_size);
 static bool editor_add_vertex_to_source_coord(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                               brush_world_runtime *world_runtime, int source_index, const int coord[3]);
 static int editor_source_units_from_meters(const brush_world_runtime *world_runtime, float meters);
@@ -490,10 +495,13 @@ bool editor_handle_vertex_add_to_source(slayer3d_game_data_runtime *runtime,
 {
     if (out_consumed != NULL)
         *out_consumed = false;
-    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_vertex(runtime) || !select_requested ||
-        (SDL_GetModState() & SDL_KMOD_SHIFT) == 0 || !editor_selection_is_selectable_brush(hover_selection) ||
-        hover_selection->face_index < 0)
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return true;
+
+    if (!editor_mode_is_vertex(runtime) || (SDL_GetModState() & SDL_KMOD_SHIFT) == 0 ||
+        !editor_selection_is_selectable_brush(hover_selection) || hover_selection->face_index < 0)
     {
+        publish_editor_vertex_add_preview(runtime, NULL, NULL, false, false, NULL);
         return true;
     }
 
@@ -504,18 +512,44 @@ bool editor_handle_vertex_add_to_source(slayer3d_game_data_runtime *runtime,
         SDL_max(slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f), 0.001f);
     const float handle_radius = SDL_max(grid_size * 0.75f, 0.05f);
     if (nearest_distance_sq <= handle_radius * handle_radius)
+    {
+        publish_editor_vertex_add_preview(runtime, NULL, NULL, false, false, NULL);
         return true;
+    }
 
     const slayer3d_game_data_editor_selection resolved = resolved_editor_selection(runtime, hover_selection);
     if (editor_selected_brush_index(runtime, &resolved) < 0)
+    {
+        publish_editor_vertex_add_preview(runtime, NULL, NULL, false, false, NULL);
         return true;
+    }
     brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, resolved.world_name);
     const int source_index = editor_source_index_for_selection(world_runtime, &resolved);
     int coord[3] = {0, 0, 0};
     if (world_runtime == NULL || source_index < 0 ||
         !editor_vertex_add_coord_from_selection(world_runtime, runtime, &resolved, coord))
     {
-        publish_editor_vertex_add_result(runtime, NULL, false, 0, 0, "vertex add requires a source face");
+        publish_editor_vertex_add_preview(runtime, &resolved, coord, true, false, "vertex add requires a source face");
+        if (select_requested)
+        {
+            publish_editor_vertex_add_result(runtime, NULL, false, 0, 0, "vertex add requires a source face");
+            if (out_consumed != NULL)
+                *out_consumed = true;
+        }
+        return true;
+    }
+
+    int preview_vertex_count = 0;
+    char preview_message[256];
+    SDL_zeroa(preview_message);
+    const bool preview_valid = editor_preview_add_vertex_to_source_coord(
+        world_runtime, source_index, coord, &preview_vertex_count, preview_message, sizeof(preview_message));
+    publish_editor_vertex_add_preview(runtime, &resolved, coord, true, preview_valid, preview_message);
+    if (!select_requested)
+        return true;
+    if (!preview_valid)
+    {
+        publish_editor_vertex_add_result(runtime, NULL, false, preview_vertex_count, 0, preview_message);
         if (out_consumed != NULL)
             *out_consumed = true;
         return true;
@@ -524,6 +558,7 @@ bool editor_handle_vertex_add_to_source(slayer3d_game_data_runtime *runtime,
     if (!editor_add_vertex_to_source_coord(runtime, NULL, world_runtime, source_index, coord))
         return false;
     clear_editor_vertex_hover_state(runtime);
+    publish_editor_vertex_add_preview(runtime, NULL, NULL, false, false, NULL);
     if (out_consumed != NULL)
         *out_consumed = true;
     return true;
@@ -1575,6 +1610,88 @@ static void publish_editor_vertex_add_result(slayer3d_game_data_runtime *runtime
         slayer3d_properties_set_int(runtime->scene_state, vertex_count_key, vertex_count);
     if (added_count_key != NULL)
         slayer3d_properties_set_int(runtime->scene_state, added_count_key, added_count);
+}
+
+static slayer3d_vec3 editor_source_coord_to_world_position(const brush_world_runtime *world_runtime,
+                                                           const slayer3d_game_data_editor_selection *selection,
+                                                           const int coord[3])
+{
+    const float meters_per_unit = world_runtime != NULL && world_runtime->editor_source_meters_per_unit > 0.0f
+                                      ? world_runtime->editor_source_meters_per_unit
+                                      : 0.001f;
+    const slayer3d_vec3 local =
+        coord != NULL ? slayer3d_vec3_make((float)coord[0] * meters_per_unit, (float)coord[1] * meters_per_unit,
+                                           (float)coord[2] * meters_per_unit)
+                      : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const slayer3d_vec3 world_position =
+        selection != NULL ? selection->world_position : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    return slayer3d_vec3_add(world_position, local);
+}
+
+static void publish_editor_vertex_add_preview(slayer3d_game_data_runtime *runtime,
+                                              const slayer3d_game_data_editor_selection *selection, const int coord[3],
+                                              bool active, bool valid, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    const brush_world_runtime *world_runtime =
+        selection != NULL ? find_brush_world_runtime(runtime, selection->world_name) : NULL;
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.add.preview.active", active);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.add.preview.valid", active ? valid : false);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.vertex.add.preview.world",
+                                   active && selection != NULL && selection->world_name != NULL ? selection->world_name
+                                                                                                : "");
+    slayer3d_properties_set_string(
+        runtime->scene_state, "editor.vertex.add.preview.brush",
+        active && selection != NULL && selection->element_name != NULL ? selection->element_name : "");
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.add.preview.x",
+                                active && coord != NULL ? coord[0] : 0);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.add.preview.y",
+                                active && coord != NULL ? coord[1] : 0);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.add.preview.z",
+                                active && coord != NULL ? coord[2] : 0);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.vertex.add.preview.position",
+                                 active ? editor_source_coord_to_world_position(world_runtime, selection, coord)
+                                        : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_string(runtime->scene_state, "editor.vertex.add.preview.message",
+                                   active && message != NULL ? message : "");
+}
+
+static bool editor_preview_add_vertex_to_source_coord(brush_world_runtime *world, int source_index, const int coord[3],
+                                                      int *out_vertex_count, char *message, size_t message_size)
+{
+    if (out_vertex_count != NULL)
+        *out_vertex_count = 0;
+    if (message != NULL && message_size > 0)
+        message[0] = '\0';
+    if (world == NULL || coord == NULL || source_index < 0 || source_index >= world->editor_source_box_count)
+    {
+        if (message != NULL && message_size > 0)
+            SDL_strlcpy(message, "vertex add requires a source brush", message_size);
+        return false;
+    }
+
+    const editor_brush_source_box_runtime *box = &world->editor_source_boxes[source_index];
+    const char *identity = box->stable_id != NULL && box->stable_id[0] != '\0' ? box->stable_id : box->name;
+    editor_brush_source_vertex_operation_desc desc;
+    SDL_zero(desc);
+    desc.brush_identity = identity;
+    desc.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD;
+    for (int axis = 0; axis < 3; ++axis)
+        desc.coord[axis] = coord[axis];
+
+    char error[256];
+    SDL_zeroa(error);
+    editor_brush_source_vertex_operation_result preview;
+    SDL_zero(preview);
+    const bool valid = editor_brush_world_preview_source_vertex_operation(world, &desc, &preview, error, sizeof(error));
+    if (out_vertex_count != NULL)
+        *out_vertex_count = preview.vertex_count;
+    if (message != NULL && message_size > 0)
+        SDL_strlcpy(message, valid ? "vertex add preview" : (error[0] != '\0' ? error : "invalid source edit"),
+                    message_size);
+    editor_brush_source_free_runtime_brush(&preview.brush);
+    return valid;
 }
 
 static bool editor_add_vertex_to_source_coord(slayer3d_game_data_runtime *runtime, yyjson_val *action,

--- a/src/game_data_editor_vertex_mode.c
+++ b/src/game_data_editor_vertex_mode.c
@@ -364,6 +364,8 @@ static bool editor_preview_add_vertex_to_source_coord(brush_world_runtime *world
                                                       int *out_vertex_count, char *message, size_t message_size);
 static bool editor_add_vertex_to_source_coord(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                               brush_world_runtime *world_runtime, int source_index, const int coord[3]);
+static bool editor_merge_selected_vertices_to_target(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                     const editor_source_vertex_selection *target);
 static int editor_source_units_from_meters(const brush_world_runtime *world_runtime, float meters);
 
 static bool editor_hover_source_vertex_selection_with_distance(
@@ -422,6 +424,20 @@ bool editor_handle_vertex_selection(slayer3d_game_data_runtime *runtime,
     {
         if ((SDL_GetModState() & SDL_KMOD_SHIFT) == 0)
             clear_editor_selected_vertices(runtime);
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    const bool quick_merge =
+        (SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT)) != 0 && (SDL_GetModState() & SDL_KMOD_SHIFT) == 0 &&
+        editor_selected_vertices_active_for_scene(runtime) && runtime->editor_selected_vertex_count > 0;
+    if (quick_merge && editor_selected_vertex_index(runtime, &hovered) < 0)
+    {
+        if (!editor_merge_selected_vertices_to_target(runtime, NULL, &hovered))
+            return false;
+        publish_editor_selected_vertex_count(runtime);
+        publish_editor_vertex_hover_state(runtime, hover_selection);
         if (out_consumed != NULL)
             *out_consumed = true;
         return true;
@@ -1439,10 +1455,22 @@ bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_da
         return true;
     }
 
+    return editor_merge_selected_vertices_to_target(runtime, action, &target);
+}
+
+static bool editor_merge_selected_vertices_to_target(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                     const editor_source_vertex_selection *target)
+{
+    if (runtime == NULL || target == NULL)
+    {
+        publish_editor_vertex_merge_result(runtime, action, false, 0, "vertex merge requires a target vertex");
+        return true;
+    }
+
     int vertex_indices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
     SDL_zeroa(vertex_indices);
     const int vertex_index_count =
-        editor_collect_vertex_merge_indices(runtime, &target, vertex_indices, SDL_arraysize(vertex_indices));
+        editor_collect_vertex_merge_indices(runtime, target, vertex_indices, SDL_arraysize(vertex_indices));
     if (vertex_index_count <= 0)
     {
         publish_editor_vertex_merge_result(runtime, action, false, 0,
@@ -1450,27 +1478,40 @@ bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_da
         return true;
     }
 
-    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, target.world_name);
-    if (world_runtime == NULL || target.source_index < 0 ||
-        target.source_index >= world_runtime->editor_source_box_count)
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, target->world_name);
+    if (world_runtime == NULL || target->source_index < 0 ||
+        target->source_index >= world_runtime->editor_source_box_count)
     {
         publish_editor_vertex_merge_result(runtime, action, false, 0, "vertex merge source brush not found");
         return true;
     }
-    const editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[target.source_index];
+    const editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[target->source_index];
     const char *identity = box->stable_id != NULL && box->stable_id[0] != '\0' ? box->stable_id : box->name;
 
     editor_brush_source_vertex_operation_desc desc;
     SDL_zero(desc);
     desc.brush_identity = identity;
     desc.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MERGE_MANY_TO_TARGET;
-    desc.target_vertex_index = target.vertex_index;
+    desc.target_vertex_index = target->vertex_index;
     desc.vertex_index_count = vertex_index_count;
     for (int i = 0; i < vertex_index_count; ++i)
         desc.vertex_indices[i] = vertex_indices[i];
 
     char error[256];
     SDL_zeroa(error);
+    editor_brush_source_vertex_operation_result preview;
+    SDL_zero(preview);
+    if (!editor_brush_world_preview_source_vertex_operation(world_runtime, &desc, &preview, error, sizeof(error)))
+    {
+        char message[320];
+        SDL_snprintf(message, sizeof(message), "vertex merge blocked: %s",
+                     error[0] != '\0' ? error : "invalid source edit");
+        publish_editor_vertex_merge_result(runtime, action, false, 0, message);
+        editor_brush_source_free_runtime_brush(&preview.brush);
+        return true;
+    }
+    editor_brush_source_free_runtime_brush(&preview.brush);
+
     editor_brush_source_vertex_operation_result result;
     SDL_zero(result);
     if (!editor_brush_world_apply_source_vertex_operation(world_runtime, &desc, &result, error, sizeof(error)))
@@ -1488,6 +1529,8 @@ bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_da
     editor_refresh_selected_vertices_after_source_edit(runtime, world_runtime);
     editor_refresh_selected_brushes_after_source_edit(runtime);
     clear_editor_selected_vertices(runtime);
+    (void)editor_add_shared_vertex_selection_group(runtime, target);
+    publish_editor_selected_vertex_count(runtime);
 
     char message[160];
     SDL_snprintf(message, sizeof(message), "merged %d selected source vert%s", merged_count,

--- a/src/game_data_editor_vertex_mode.c
+++ b/src/game_data_editor_vertex_mode.c
@@ -20,11 +20,28 @@ static float editor_snap_delta(float delta, float grid_size)
     return SDL_roundf(delta / grid) * grid;
 }
 
+static void publish_editor_vertex_drag_state(slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+
+    const bool active = drag != NULL && drag->active && drag->vertex_drag;
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.active", active);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.moved", active ? drag->moved : false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.vertex.drag.axis_lock_y",
+                                 active ? drag->axis_lock_y : false);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.vertex.drag.guide_count",
+                                active ? drag->vertex_origin_count : 0);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.vertex.drag.offset",
+                                 active ? drag->applied_offset : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+}
+
 static void clear_editor_drag_move(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
         return;
     SDL_zero(runtime->editor_drag_move);
+    publish_editor_vertex_drag_state(runtime, NULL);
 }
 
 static const char *editor_metadata_stable_id(const slayer3d_game_data_editor_metadata *metadata)
@@ -1876,6 +1893,26 @@ static bool editor_try_merge_selected_vertices_to_hover(slayer3d_game_data_runti
     return slayer3d_game_data_merge_selected_editor_vertices_to_hover(runtime, NULL);
 }
 
+static void editor_capture_vertex_drag_origins(slayer3d_game_data_runtime *runtime, editor_drag_move_state *drag)
+{
+    if (runtime == NULL || drag == NULL || !editor_selected_vertices_active_for_scene(runtime))
+        return;
+
+    const int count = SDL_min(runtime->editor_selected_vertex_count, SLAYER3D_EDITOR_DRAG_VERTEX_ORIGIN_CAPACITY);
+    drag->vertex_origin_count = count;
+    for (int i = 0; i < count; ++i)
+    {
+        const editor_source_vertex_selection *selection = &runtime->editor_selected_vertices[i];
+        editor_drag_vertex_origin *origin = &drag->vertex_origins[i];
+        SDL_strlcpy(origin->world_name, selection->world_name, sizeof(origin->world_name));
+        SDL_strlcpy(origin->brush_name, selection->brush_name, sizeof(origin->brush_name));
+        SDL_strlcpy(origin->vertex_stable_id, selection->vertex_stable_id, sizeof(origin->vertex_stable_id));
+        origin->coord[0] = selection->coord[0];
+        origin->coord[1] = selection->coord[1];
+        origin->coord[2] = selection->coord[2];
+    }
+}
+
 static void editor_begin_vertex_drag(slayer3d_game_data_runtime *runtime, slayer3d_input_manager *input,
                                      const slayer3d_game_data_editor_selection *hover_selection)
 {
@@ -1887,7 +1924,12 @@ static void editor_begin_vertex_drag(slayer3d_game_data_runtime *runtime, slayer
     drag->scene = slayer3d_game_data_active_scene(runtime);
     drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
     drag->start_point = hover_selection->hit ? hover_selection->point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    drag->vertex_drag = true;
+    editor_capture_vertex_drag_origins(runtime, drag);
     (void)slayer3d_input_get_mouse_position(input, &drag->start_mouse_x, &drag->start_mouse_y);
+    drag->current_mouse_x = drag->start_mouse_x;
+    drag->current_mouse_y = drag->start_mouse_y;
+    publish_editor_vertex_drag_state(runtime, drag);
 }
 
 bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
@@ -1919,6 +1961,7 @@ bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
     {
         const SDL_Keymod modifiers = SDL_GetModState();
         const bool y_axis_lock = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_ALT)) != 0;
+        drag->axis_lock_y = y_axis_lock;
         slayer3d_vec3 desired = drag->applied_offset;
         if (y_axis_lock)
         {
@@ -1940,6 +1983,7 @@ bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
             drag->applied_offset = desired;
             drag->moved = true;
         }
+        publish_editor_vertex_drag_state(runtime, drag);
     }
 
     if (left_released || !left_down)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -187,6 +187,9 @@ extern "C"
     bool editor_handle_vertex_selection(slayer3d_game_data_runtime *runtime,
                                         const slayer3d_game_data_editor_selection *hover_selection,
                                         bool select_requested, bool *out_consumed);
+    bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
+                                   const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed);
+    bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
 }
 
 namespace
@@ -16718,6 +16721,81 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeEmitsDragGuides)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoVertexModeDominantAxisDragLocksHorizontalMovement)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    select_editor_shell_test_cube(runtime);
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int vertex_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.vertex");
+    ASSERT_GE(vertex_signal, 0);
+    slayer3d_signal_emit(bus, vertex_signal, nullptr);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    SDL_Event click{};
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    click.button.button = SDL_BUTTON_LEFT;
+    click.button.x = motion.motion.x;
+    click.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    ASSERT_GT(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", 0), 0);
+    const int selected_x = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1);
+    const int selected_y = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.y", -1);
+    const int selected_z = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1);
+
+    slayer3d_game_data_editor_selection drag_hover{};
+    drag_hover.hit = true;
+    drag_hover.point = slayer3d_vec3_make((float)selected_x * 0.001f + 3.0f, (float)selected_y * 0.001f,
+                                          (float)selected_z * 0.001f + 1.0f);
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    bool consumed = false;
+    ASSERT_TRUE(editor_handle_vertex_drag(runtime, &drag_hover, &consumed));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_TRUE(consumed);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.axis_lock_dominant", false));
+    const slayer3d_vec3 drag_offset =
+        slayer3d_properties_get_vec3(scene_state, "editor.vertex.drag.offset", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(drag_offset.x, 3.0f, 0.001f);
+    EXPECT_NEAR(drag_offset.y, 0.0f, 0.001f);
+    EXPECT_NEAR(drag_offset.z, 0.0f, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1), selected_x + 3000);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.y", -1), selected_y);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1), selected_z);
+
+    click.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoVertexModeSelectsSharedPositionVertices)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
@@ -17025,6 +17103,25 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeMovesSelectedVerticesOnGrid)
     const int selected_z = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1);
     const slayer3d_bounding_box before_move = brush_bounds();
 
+    const slayer3d_vec3 invalid_offset = slayer3d_vec3_make(
+        1.0f - (float)selected_x * 0.001f, 1.0f - (float)selected_y * 0.001f, 1.0f - (float)selected_z * 0.001f);
+    EXPECT_FALSE(editor_translate_selected_vertices(runtime, invalid_offset));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.vertex.move.valid", true));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.move.source_count", 0), 1);
+    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.vertex.move.message", ""))
+                  .find("vertex move blocked"),
+              std::string::npos);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1), selected_x);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.y", -1), selected_y);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1), selected_z);
+    const slayer3d_bounding_box after_invalid_move = brush_bounds();
+    EXPECT_NEAR(after_invalid_move.min.x, before_move.min.x, 0.001f);
+    EXPECT_NEAR(after_invalid_move.min.y, before_move.min.y, 0.001f);
+    EXPECT_NEAR(after_invalid_move.min.z, before_move.min.z, 0.001f);
+    EXPECT_NEAR(after_invalid_move.max.x, before_move.max.x, 0.001f);
+    EXPECT_NEAR(after_invalid_move.max.y, before_move.max.y, 0.001f);
+    EXPECT_NEAR(after_invalid_move.max.z, before_move.max.z, 0.001f);
+
     SDL_Event key{};
     key.type = SDL_EVENT_KEY_DOWN;
     key.key.scancode = SDL_SCANCODE_UP;
@@ -17058,6 +17155,9 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeMovesSelectedVerticesOnGrid)
     }
     EXPECT_TRUE(found_moved_vertex);
     EXPECT_FALSE(found_original_vertex);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.move.valid", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.move.source_count", 0), 1);
+    EXPECT_GT(slayer3d_properties_get_int(scene_state, "editor.vertex.move.changed_count", 0), 0);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "moved selected vertices");
 
     slayer3d_game_data_destroy(runtime);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16673,6 +16673,9 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeSelectsSharedPositionVertices)
     ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.hover.hit", false));
     const int shared_count = slayer3d_properties_get_int(scene_state, "editor.vertex.hover.shared_count", 0);
     ASSERT_GE(shared_count, 2);
+    const int shared_x = slayer3d_properties_get_int(scene_state, "editor.vertex.hover.x", -1);
+    const int shared_y = slayer3d_properties_get_int(scene_state, "editor.vertex.hover.y", -1);
+    const int shared_z = slayer3d_properties_get_int(scene_state, "editor.vertex.hover.z", -1);
 
     SDL_Event click{};
     click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
@@ -16684,6 +16687,40 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeSelectsSharedPositionVertices)
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", 0), shared_count);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.selection.multiple", false));
+
+    click.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_UP;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1), shared_x + 1000);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.y", -1), shared_y);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1), shared_z);
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    const int source_indices[] = {0, 1, 2};
+    editor_brush_source_shared_vertex shared[12]{};
+    int moved_shared_count = 0;
+    ASSERT_TRUE(editor_brush_world_find_shared_source_vertices(world_runtime, source_indices, 3, shared, 12,
+                                                               &moved_shared_count, error, sizeof(error)))
+        << error;
+    bool found_moved_clump = false;
+    for (int i = 0; i < moved_shared_count; ++i)
+    {
+        if (shared[i].coord[0] == shared_x + 1000 && shared[i].coord[1] == shared_y && shared[i].coord[2] == shared_z)
+        {
+            found_moved_clump = true;
+            EXPECT_EQ(shared[i].reference_count, shared_count);
+        }
+    }
+    EXPECT_TRUE(found_moved_clump);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -16885,6 +16922,8 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeMovesSelectedVerticesOnGrid)
     ASSERT_NE(scene_state, nullptr);
     ASSERT_GT(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", 0), 0);
     const int selected_x = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1);
+    const int selected_y = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.y", -1);
+    const int selected_z = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.z", -1);
     const slayer3d_bounding_box before_move = brush_bounds();
 
     SDL_Event key{};
@@ -16900,23 +16939,33 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeMovesSelectedVerticesOnGrid)
     const slayer3d_bounding_box after_move = brush_bounds();
     const int moved_x = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.x", -1);
     EXPECT_EQ(moved_x, selected_x + 1000);
-    if (selected_x == 0)
+    EXPECT_NEAR(after_move.min.x, before_move.min.x, 0.001f);
+    EXPECT_NEAR(after_move.max.x, selected_x == 2000 ? before_move.max.x + 1.0f : before_move.max.x, 0.001f);
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_model model{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &model, error, sizeof(error))) << error;
+    bool found_moved_vertex = false;
+    bool found_original_vertex = false;
+    for (int i = 0; i < model.vertex_count; ++i)
     {
-        EXPECT_NEAR(after_move.min.x, before_move.min.x + 1.0f, 0.001f);
-        EXPECT_NEAR(after_move.max.x, before_move.max.x, 0.001f);
+        found_moved_vertex = found_moved_vertex ||
+                             (model.vertices[i].coord[0] == selected_x + 1000 &&
+                              model.vertices[i].coord[1] == selected_y && model.vertices[i].coord[2] == selected_z);
+        found_original_vertex = found_original_vertex ||
+                                (model.vertices[i].coord[0] == selected_x && model.vertices[i].coord[1] == selected_y &&
+                                 model.vertices[i].coord[2] == selected_z);
     }
-    else
-    {
-        EXPECT_NEAR(after_move.min.x, before_move.min.x, 0.001f);
-        EXPECT_NEAR(after_move.max.x, before_move.max.x + 1.0f, 0.001f);
-    }
+    EXPECT_TRUE(found_moved_vertex);
+    EXPECT_FALSE(found_original_vertex);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "moved selected vertices");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoVertexModeRejectsDegenerateVertexMove)
+TEST(GameDataRuntime, EditorShellDojoVertexModeAllowsConvexNonCuboidVertexMove)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -16982,11 +17031,18 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeRejectsDegenerateVertexMove)
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &after_world));
     ASSERT_EQ(after_world.brush_count, 1);
     const slayer3d_bounding_box after = after_world.brushes[0].bounds;
-    EXPECT_NEAR(after.min.x, before.min.x, 0.001f);
-    EXPECT_NEAR(after.max.x, before.max.x, 0.001f);
-    EXPECT_NE(std::string(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""))
-                  .find("vertex move blocked"),
-              std::string::npos);
+    EXPECT_NEAR(after.min.x, selected_x <= 1000 ? before.min.x : before.min.x - 2.0f, 0.001f);
+    EXPECT_NEAR(after.max.x, selected_x <= 1000 ? before.max.x + 2.0f : before.max.x, 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "moved selected vertices");
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_diagnostics diagnostics{};
+    ASSERT_TRUE(
+        editor_brush_world_validate_source_vertex_model(world_runtime, nullptr, 0, &diagnostics, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(diagnostics.valid) << diagnostics.first_issue;
+    EXPECT_GT(diagnostics.face_count, 6);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -184,6 +184,9 @@ extern "C"
                                                                     yyjson_val *action);
     bool slayer3d_game_data_add_editor_vertex_to_source(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_validate_editor_vertex_source(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+    bool editor_handle_vertex_selection(slayer3d_game_data_runtime *runtime,
+                                        const slayer3d_game_data_editor_selection *hover_selection,
+                                        bool select_requested, bool *out_consumed);
 }
 
 namespace
@@ -17285,13 +17288,105 @@ TEST(GameDataRuntime, EditorVertexMergeSelectedToTargetUsesSourceValidation)
 
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "test.merge.valid", false));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "test.merge.count", 0), 1);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", -1), 0);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", -1), 1);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
                  "merged 1 selected source vertex");
 
     brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
     ASSERT_NE(world_runtime, nullptr);
     editor_brush_source_vertex_model model{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &model, error, sizeof(error))) << error;
+    EXPECT_EQ(model.vertex_count, 7);
+    EXPECT_GT(model.face_count, 4);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoVertexModeModifierClickFusesSelectedVertex)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    select_editor_shell_test_cube(runtime);
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int vertex_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.vertex");
+    ASSERT_GE(vertex_signal, 0);
+    slayer3d_signal_emit(bus, vertex_signal, nullptr);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    SDL_Event click{};
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    click.button.button = SDL_BUTTON_LEFT;
+    click.button.x = motion.motion.x;
+    click.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    click.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    const int selected_index = slayer3d_properties_get_int(scene_state, "editor.vertex.selection.index", -1);
+    ASSERT_GE(selected_index, 0);
+    const int target_index = selected_index ^ 1;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_model model{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &model, error, sizeof(error))) << error;
+    ASSERT_GT(model.vertex_count, target_index);
+
+    slayer3d_game_data_editor_selection target_hover{};
+    target_hover.hit = true;
+    target_hover.type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+    target_hover.world_name = "brush.editor_shell.target";
+    target_hover.element_name = "brush.target.cube";
+    target_hover.element_index = 0;
+    target_hover.face_index = 0;
+    target_hover.fraction = 0.25f;
+    target_hover.world_position = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    target_hover.point = slayer3d_vec3_make((float)model.vertices[target_index].coord[0] * 0.001f,
+                                            (float)model.vertices[target_index].coord[1] * 0.001f,
+                                            (float)model.vertices[target_index].coord[2] * 0.001f);
+    target_hover.normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    target_hover.bounds.min = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    target_hover.bounds.max = slayer3d_vec3_make(2.0f, 2.0f, 2.0f);
+    target_hover.has_bounds = true;
+
+    SDL_SetModState(SDL_KMOD_CTRL);
+    bool consumed = false;
+    ASSERT_TRUE(editor_handle_vertex_selection(runtime, &target_hover, true, &consumed));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_TRUE(consumed);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.merge.valid", false));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.merge.merged_count", 0), 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", -1), 1);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "merged 1 selected source vertex");
+
     ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &model, error, sizeof(error))) << error;
     EXPECT_EQ(model.vertex_count, 7);
     EXPECT_GT(model.face_count, 4);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16899,6 +16899,46 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeSelectsSharedPositionVertices)
     }
     EXPECT_TRUE(found_moved_clump);
 
+    char *export_json = nullptr;
+    size_t export_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_export_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", &export_json, &export_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(export_json, nullptr);
+
+    slayer3d_game_data_destroy(runtime);
+    runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", export_json,
+                                                                     export_size, "/tmp/source-shared-roundtrip.json",
+                                                                     error, sizeof(error)))
+        << error;
+    SDL_free(export_json);
+
+    world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    ASSERT_TRUE(editor_brush_world_find_shared_source_vertices(world_runtime, source_indices, 3, shared, 12,
+                                                               &moved_shared_count, error, sizeof(error)))
+        << error;
+    found_moved_clump = false;
+    for (int i = 0; i < moved_shared_count; ++i)
+    {
+        if (shared[i].coord[0] == shared_x + 1000 && shared[i].coord[1] == shared_y && shared[i].coord[2] == shared_z)
+        {
+            found_moved_clump = true;
+            EXPECT_EQ(shared[i].reference_count, shared_count);
+        }
+    }
+    EXPECT_TRUE(found_moved_clump);
+
+    slayer3d_game_data_brush_world public_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &public_world));
+    EXPECT_EQ(public_world.brush_count, 3);
+    EXPECT_EQ(public_world.compile_invalid_brush_count, 0);
+    EXPECT_GT(public_world.compile_rendered_face_count, 0);
+    EXPECT_NE(public_world.render_model, nullptr);
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
@@ -20378,6 +20418,198 @@ TEST(GameDataRuntime, EditorBrushSourceVertexOperationApplyPersistsConvexSource)
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &public_world));
     ASSERT_EQ(public_world.brush_count, 1);
     EXPECT_NEAR(public_world.brushes[0].bounds.max.y, 12.0f, 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorBrushSourceVertexEditedSourceRoundTripsCompilesAndSupportsTestRun)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "compile": { "hidden_face_culling": true },
+      "materials": [{ "name": "mat.editor.wall", "albedo": [0.5, 0.5, 0.5, 1.0] }],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": [
+        {
+          "stable_id": "source.box.vertex_roundtrip",
+          "name": "brush.source.vertex_roundtrip",
+          "kind": "box",
+          "prefab": "box",
+          "material": "mat.editor.wall",
+          "min": [0, 0, 0],
+          "max": [8000, 8000, 8000],
+          "contents": ["solid", "player_clip"]
+        }
+      ]
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u,
+        "/tmp/source-vertex-roundtrip.json", error, sizeof(error)))
+        << error;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_operation_desc add_vertex{};
+    add_vertex.brush_identity = "source.box.vertex_roundtrip";
+    add_vertex.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD;
+    add_vertex.coord[0] = 4000;
+    add_vertex.coord[1] = 12000;
+    add_vertex.coord[2] = 4000;
+    editor_brush_source_vertex_operation_result result{};
+    ASSERT_TRUE(
+        editor_brush_world_apply_source_vertex_operation(world_runtime, &add_vertex, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.valid);
+    EXPECT_EQ(result.vertex_count, 9);
+    editor_brush_source_free_runtime_brush(&result.brush);
+
+    slayer3d_game_data_brush_world public_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &public_world));
+    ASSERT_EQ(public_world.brush_count, 1);
+    EXPECT_EQ(public_world.compile_invalid_brush_count, 0);
+    EXPECT_GT(public_world.compile_rendered_face_count, 0);
+    ASSERT_NE(public_world.render_model, nullptr);
+    EXPECT_NEAR(public_world.brushes[0].bounds.max.y, 12.0f, 0.001f);
+
+    slayer3d_game_data_brush_trace_desc trace{};
+    slayer3d_game_data_brush_trace_result trace_result{};
+    trace.shape = SLAYER3D_GAME_DATA_BRUSH_TRACE_POINT;
+    trace.contents_mask = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+    trace.start = slayer3d_vec3_make(4.0f, 16.0f, 4.0f);
+    trace.end = slayer3d_vec3_make(4.0f, -2.0f, 4.0f);
+    ASSERT_TRUE(slayer3d_game_data_trace_brush_world(runtime, "brush.editor_shell.target", &trace, &trace_result));
+    EXPECT_TRUE(trace_result.hit);
+    EXPECT_STREQ(trace_result.brush_name, "brush.source.vertex_roundtrip");
+
+    seed_editor_shell_player_start(runtime);
+
+    char *export_json = nullptr;
+    size_t export_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_export_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", &export_json, &export_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(export_json, nullptr);
+    std::string exported(export_json, export_size);
+    EXPECT_NE(exported.find("\"kind\": \"convex\""), std::string::npos);
+    EXPECT_NE(exported.find("\"vertices\""), std::string::npos);
+    EXPECT_EQ(exported.find("\"min\""), std::string::npos);
+    EXPECT_EQ(exported.find("\"max\""), std::string::npos);
+    yyjson_doc *export_doc = yyjson_read(export_json, export_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(export_doc, nullptr);
+    yyjson_val *export_root = yyjson_doc_get_root(export_doc);
+    ASSERT_NE(export_root, nullptr);
+    yyjson_val *export_sources = yyjson_obj_get(export_root, "editor_brush_sources");
+    ASSERT_TRUE(yyjson_is_arr(export_sources));
+    yyjson_val *export_boxes = yyjson_obj_get(yyjson_arr_get(export_sources, 0), "boxes");
+    ASSERT_TRUE(yyjson_is_arr(export_boxes));
+    yyjson_val *export_vertices = yyjson_obj_get(yyjson_arr_get(export_boxes, 0), "vertices");
+    ASSERT_TRUE(yyjson_is_arr(export_vertices));
+    bool exported_apex = false;
+    for (size_t i = 0; i < yyjson_arr_size(export_vertices); ++i)
+    {
+        yyjson_val *vertex = yyjson_arr_get(export_vertices, i);
+        if (yyjson_is_arr(vertex) && yyjson_arr_size(vertex) >= 3u &&
+            yyjson_get_int(yyjson_arr_get(vertex, 0)) == 4000 && yyjson_get_int(yyjson_arr_get(vertex, 1)) == 12000 &&
+            yyjson_get_int(yyjson_arr_get(vertex, 2)) == 4000)
+        {
+            exported_apex = true;
+        }
+    }
+    yyjson_doc_free(export_doc);
+    EXPECT_TRUE(exported_apex);
+
+    slayer3d_game_data_destroy(runtime);
+    runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", export_json, export_size, "/tmp/source-vertex-roundtrip-reload.json",
+        error, sizeof(error)))
+        << error;
+    SDL_free(export_json);
+
+    world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_model model{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &model, error, sizeof(error))) << error;
+    ASSERT_EQ(model.vertex_count, 9);
+    bool found_apex = false;
+    int apex_index = -1;
+    for (int i = 0; i < model.vertex_count; ++i)
+    {
+        if (model.vertices[i].coord[0] == 4000 && model.vertices[i].coord[1] == 12000 &&
+            model.vertices[i].coord[2] == 4000)
+        {
+            found_apex = true;
+            apex_index = i;
+        }
+    }
+    ASSERT_TRUE(found_apex);
+    ASSERT_GE(apex_index, 0);
+
+    editor_brush_source_vertex_operation_desc move_apex{};
+    move_apex.brush_identity = "source.box.vertex_roundtrip";
+    move_apex.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE;
+    move_apex.vertex_index = apex_index;
+    move_apex.coord[0] = 4000;
+    move_apex.coord[1] = 10000;
+    move_apex.coord[2] = 4000;
+    SDL_zero(result);
+    ASSERT_TRUE(
+        editor_brush_world_apply_source_vertex_operation(world_runtime, &move_apex, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.valid);
+    EXPECT_EQ(result.vertex_count, 9);
+    editor_brush_source_free_runtime_brush(&result.brush);
+
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &public_world));
+    EXPECT_EQ(public_world.compile_invalid_brush_count, 0);
+    EXPECT_GT(public_world.compile_rendered_face_count, 0);
+    ASSERT_NE(public_world.render_model, nullptr);
+    EXPECT_NEAR(public_world.brushes[0].bounds.max.y, 10.0f, 0.001f);
+
+    char *manifest_json = nullptr;
+    size_t manifest_size = 0u;
+    slayer3d_game_data_editor_test_run_desc test_run{};
+    test_run.data_asset_path = "asset://editor_shell_dojo.game.json";
+    test_run.player_start = "player_start.editor_shell";
+    ASSERT_TRUE(slayer3d_game_data_export_editor_test_run_manifest_json(runtime, &test_run, &manifest_json,
+                                                                        &manifest_size, error, sizeof(error)))
+        << error;
+    ASSERT_NE(manifest_json, nullptr);
+    yyjson_doc *manifest_doc = yyjson_read(manifest_json, manifest_size, YYJSON_READ_NOFLAG);
+    ASSERT_NE(manifest_doc, nullptr);
+    yyjson_val *manifest_root = yyjson_doc_get_root(manifest_doc);
+    ASSERT_NE(manifest_root, nullptr);
+    EXPECT_STREQ(yyjson_get_str(yyjson_obj_get(manifest_root, "scene")), "scene.editor_shell.test_run");
+    EXPECT_STREQ(yyjson_get_str(yyjson_obj_get(manifest_root, "player_start")), "player_start.editor_shell");
+    EXPECT_STREQ(yyjson_get_str(yyjson_obj_get(manifest_root, "target")), "entity.editor_shell.player");
+    yyjson_doc_free(manifest_doc);
+    SDL_free(manifest_json);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -100,6 +100,8 @@ extern "C"
     typedef enum editor_brush_source_vertex_operation_type
     {
         EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD,
+        EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE,
+        EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY,
         EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_DELETE,
         EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_DELETE_MANY,
         EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MERGE,
@@ -115,6 +117,7 @@ extern "C"
         int vertex_indices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
         int vertex_index_count;
         int coord[3];
+        int coords[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
         int snap_units;
     } editor_brush_source_vertex_operation_desc;
     typedef struct editor_brush_source_vertex_operation_result
@@ -19384,6 +19387,142 @@ TEST(GameDataRuntime, EditorBrushSourceVertexOperationsPreviewMergeDeleteAndAdd)
     EXPECT_GT(result.face_count, 6);
     EXPECT_NEAR(result.brush.bounds.max.y, 12.0f, 0.001f);
     editor_brush_source_free_runtime_brush(&result.brush);
+
+    editor_brush_source_vertex_operation_desc move_vertex{};
+    move_vertex.brush_identity = "source.box.topology";
+    move_vertex.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE;
+    move_vertex.vertex_index = 6;
+    move_vertex.coord[0] = 8000;
+    move_vertex.coord[1] = 12000;
+    move_vertex.coord[2] = 8000;
+    SDL_zero(result);
+    ASSERT_TRUE(
+        editor_brush_world_preview_source_vertex_operation(world_runtime, &move_vertex, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.valid);
+    EXPECT_EQ(result.vertex_count, 8);
+    EXPECT_GE(result.face_count, 6);
+    EXPECT_NEAR(result.brush.bounds.max.y, 12.0f, 0.001f);
+    editor_brush_source_free_runtime_brush(&result.brush);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorBrushSourceVertexMoveTransactionsRejectInvalidMutationsAtomically)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [{ "name": "mat.editor.wall", "albedo": [0.5, 0.5, 0.5, 1.0] }],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "boxes": [
+        {
+          "stable_id": "source.box.move_txn",
+          "name": "brush.source.move_txn",
+          "kind": "box",
+          "prefab": "box",
+          "material": "mat.editor.wall",
+          "min": [0, 0, 0],
+          "max": [8000, 8000, 8000],
+          "contents": ["solid"]
+        }
+      ]
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", import_json,
+                                                                     sizeof(import_json) - 1u,
+                                                                     "/tmp/source-move-txn.json", error, sizeof(error)))
+        << error;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    editor_brush_source_vertex_model before{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &before, error, sizeof(error))) << error;
+    ASSERT_EQ(before.vertex_count, 8);
+
+    editor_brush_source_vertex_operation_desc concave_move{};
+    concave_move.brush_identity = "source.box.move_txn";
+    concave_move.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE;
+    concave_move.vertex_index = 6;
+    concave_move.coord[0] = 4000;
+    concave_move.coord[1] = 4000;
+    concave_move.coord[2] = 4000;
+    editor_brush_source_vertex_operation_result result{};
+    EXPECT_FALSE(
+        editor_brush_world_apply_source_vertex_operation(world_runtime, &concave_move, &result, error, sizeof(error)));
+    EXPECT_FALSE(result.valid);
+    EXPECT_NE(std::string(result.diagnostic).find("discard a vertex"), std::string::npos) << result.diagnostic;
+
+    editor_brush_source_vertex_model after_concave{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &after_concave, error, sizeof(error)))
+        << error;
+    ASSERT_EQ(after_concave.vertex_count, before.vertex_count);
+    for (int i = 0; i < before.vertex_count; ++i)
+    {
+        EXPECT_EQ(after_concave.vertices[i].coord[0], before.vertices[i].coord[0]);
+        EXPECT_EQ(after_concave.vertices[i].coord[1], before.vertices[i].coord[1]);
+        EXPECT_EQ(after_concave.vertices[i].coord[2], before.vertices[i].coord[2]);
+    }
+
+    editor_brush_source_vertex_operation_desc collapse_top{};
+    collapse_top.brush_identity = "source.box.move_txn";
+    collapse_top.type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY;
+    collapse_top.vertex_index_count = 4;
+    collapse_top.vertex_indices[0] = 4;
+    collapse_top.vertex_indices[1] = 5;
+    collapse_top.vertex_indices[2] = 6;
+    collapse_top.vertex_indices[3] = 7;
+    collapse_top.coords[0][0] = 0;
+    collapse_top.coords[0][1] = 0;
+    collapse_top.coords[0][2] = 0;
+    collapse_top.coords[1][0] = 8000;
+    collapse_top.coords[1][1] = 0;
+    collapse_top.coords[1][2] = 0;
+    collapse_top.coords[2][0] = 8000;
+    collapse_top.coords[2][1] = 8000;
+    collapse_top.coords[2][2] = 0;
+    collapse_top.coords[3][0] = 0;
+    collapse_top.coords[3][1] = 8000;
+    collapse_top.coords[3][2] = 0;
+    SDL_zero(result);
+    SDL_zeroa(error);
+    EXPECT_FALSE(
+        editor_brush_world_apply_source_vertex_operation(world_runtime, &collapse_top, &result, error, sizeof(error)));
+    EXPECT_FALSE(result.valid);
+    EXPECT_NE(std::string(result.diagnostic).find("zero-volume"), std::string::npos) << result.diagnostic;
+
+    editor_brush_source_vertex_model after_collapse{};
+    ASSERT_TRUE(editor_brush_source_box_build_vertex_model(world_runtime, 0, &after_collapse, error, sizeof(error)))
+        << error;
+    ASSERT_EQ(after_collapse.vertex_count, before.vertex_count);
+    for (int i = 0; i < before.vertex_count; ++i)
+    {
+        EXPECT_EQ(after_collapse.vertices[i].coord[0], before.vertices[i].coord[0]);
+        EXPECT_EQ(after_collapse.vertices[i].coord[1], before.vertices[i].coord[1]);
+        EXPECT_EQ(after_collapse.vertices[i].coord[2], before.vertices[i].coord[2]);
+    }
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -17405,6 +17405,31 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeShiftClickFaceAddsSourceVertex)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", -1), 0);
 
     SDL_SetModState(SDL_KMOD_SHIFT);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.add.preview.active", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.add.preview.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.vertex.add.preview.message", ""),
+                 "vertex add preview");
+
+    struct AddPreviewCapture
+    {
+        int previews = 0;
+        bool saw_valid_preview = false;
+    } add_preview;
+    auto capture_add_preview = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<AddPreviewCapture *>(userdata);
+        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_ADD_PREVIEW)
+        {
+            capture->previews++;
+            if (primitive->color.g == 255 && primitive->color.r == 96)
+                capture->saw_valid_preview = true;
+        }
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_add_preview, &add_preview));
+    EXPECT_GE(add_preview.previews, 1);
+    EXPECT_TRUE(add_preview.saw_valid_preview);
+
     SDL_Event click{};
     click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
     click.button.button = SDL_BUTTON_LEFT;
@@ -17423,6 +17448,7 @@ TEST(GameDataRuntime, EditorShellDojoVertexModeShiftClickFaceAddsSourceVertex)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.add.added_count", 0), 1);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.add.vertex_count", 0), 9);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", -1), 1);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.vertex.add.preview.active", true));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "added source vertex");
 
     brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16619,6 +16619,102 @@ TEST(GameDataRuntime, EditorShellDojoVertexModePublishesSourceVertexHandles)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoVertexModeEmitsDragGuides)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    select_editor_shell_test_cube(runtime);
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int vertex_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.vertex");
+    ASSERT_GE(vertex_signal, 0);
+    slayer3d_signal_emit(bus, vertex_signal, nullptr);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    SDL_Event click{};
+    click.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    click.button.button = SDL_BUTTON_LEFT;
+    click.button.x = motion.motion.x;
+    click.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    ASSERT_GT(slayer3d_properties_get_int(scene_state, "editor.vertex.selection.count", 0), 0);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.active", false));
+
+    SDL_SetModState(SDL_KMOD_CTRL);
+    motion.motion.y = 292.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    SDL_SetModState(SDL_KMOD_NONE);
+
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.active", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.moved", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.axis_lock_y", false));
+    const slayer3d_vec3 drag_offset =
+        slayer3d_properties_get_vec3(scene_state, "editor.vertex.drag.offset", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    EXPECT_NEAR(drag_offset.x, 0.0f, 0.001f);
+    EXPECT_NEAR(drag_offset.y, 1.0f, 0.001f);
+    EXPECT_NEAR(drag_offset.z, 0.0f, 0.001f);
+
+    struct DragGuideCapture
+    {
+        int guides = 0;
+        bool saw_vertical_guide = false;
+        bool saw_axis_lock_color = false;
+    } drag_guides;
+    auto capture_guides = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<DragGuideCapture *>(userdata);
+        if (primitive == nullptr || primitive->type != SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_DRAG_GUIDE)
+            return true;
+        capture->guides++;
+        const slayer3d_vec3 delta = slayer3d_vec3_sub(primitive->end, primitive->start);
+        if (SDL_fabsf(delta.x) <= 0.001f && delta.y > 0.99f && SDL_fabsf(delta.z) <= 0.001f)
+            capture->saw_vertical_guide = true;
+        if (primitive->color.r == 255 && primitive->color.g == 96 && primitive->color.b == 72)
+            capture->saw_axis_lock_color = true;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_guides, &drag_guides));
+    EXPECT_GE(drag_guides.guides, 1);
+    EXPECT_TRUE(drag_guides.saw_vertical_guide);
+    EXPECT_TRUE(drag_guides.saw_axis_lock_color);
+
+    click.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    click.button.x = motion.motion.x;
+    click.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &click);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.vertex.drag.active", true));
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoVertexModeSelectsSharedPositionVertices)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();


### PR DESCRIPTION
## Summary
- add source vertex move and move-many operations backed by the convex source rebuild validator
- route apply through an explicit vertex transaction with rollback ownership so failed mutations leave source brushes unchanged
- add editor integration coverage for drag guides, dominant-axis locking, add previews, quick fuse, shared vertex clumps, save/reopen, compile output, collision traces, and test-run manifests
- document the internal source-vertex preview/apply boundary for future face, edge, clip, and CSG tools

## Tests
- cmake --build build/debug --target slayer3d_game_data_test -j8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoVertexModeSelectsSharedPositionVertices:GameDataRuntime.EditorBrushSourceVertexEditedSourceRoundTripsCompilesAndSupportsTestRun:GameDataRuntime.EditorBrushSourceVertexOperationApplyPersistsConvexSource' --gtest_brief=1
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.Editor*Vertex*:GameDataRuntime.EditableLevelFragmentMvpGrayboxRoundTripsSourceOnlyForTestRun' --gtest_brief=1
- ./build/debug/tests/slayer3d_game_data_test --gtest_brief=1
- ./scripts/check_clang_format.sh
- git diff --check