### PR TITLE
Avoid duplicate GoogleTest linkage and parallelize Makefile builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 
 BUILD_DIR    ?= build
 CMAKE_FLAGS  ?=
+BUILD_FLAGS  ?= --parallel
 
 .PHONY: all debug release sanitize test demos clean install format format-fix help
 
@@ -25,7 +26,7 @@ debug:
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DSLAYER3D_BUILD_TESTS=ON \
 		$(CMAKE_FLAGS)
-	@cmake --build $(BUILD_DIR)/debug
+	@cmake --build $(BUILD_DIR)/debug $(BUILD_FLAGS)
 
 release:
 	@cmake -B $(BUILD_DIR)/release \
@@ -33,7 +34,7 @@ release:
 		-DSLAYER3D_BUILD_TESTS=ON \
 		-DSLAYER3D_BUILD_DEMOS=ON \
 		$(CMAKE_FLAGS)
-	@cmake --build $(BUILD_DIR)/release --parallel
+	@cmake --build $(BUILD_DIR)/release $(BUILD_FLAGS)
 
 sanitize:
 	@CC=clang cmake -B $(BUILD_DIR)/sanitize \
@@ -41,7 +42,7 @@ sanitize:
 		-DSLAYER3D_BUILD_TESTS=ON \
 		-DSLAYER3D_ENABLE_SANITIZERS=ON \
 		$(CMAKE_FLAGS)
-	@cmake --build $(BUILD_DIR)/sanitize
+	@cmake --build $(BUILD_DIR)/sanitize $(BUILD_FLAGS)
 
 test: debug
 	@cd $(BUILD_DIR)/debug && ctest --output-on-failure
@@ -55,7 +56,7 @@ demos:
 		-DSLAYER3D_BUILD_TESTS=ON \
 		-DSLAYER3D_BUILD_DEMOS=ON \
 		$(CMAKE_FLAGS)
-	@cmake --build $(BUILD_DIR)/debug
+	@cmake --build $(BUILD_DIR)/debug $(BUILD_FLAGS)
 
 install: release
 	@cmake --install $(BUILD_DIR)/release

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,6 @@ function(slayer3d_add_test target_name source_file test_label)
         ${target_name}
         PRIVATE
             Slayer3D::slayer3d
-            GTest::gtest
             GTest::gtest_main
     )
 


### PR DESCRIPTION
## Summary
- Stop linking desktop test executables against both `GTest::gtest` and `GTest::gtest_main`.
- Rely on `GTest::gtest_main` to carry the GoogleTest library dependency, which avoids duplicate `libgtest.a` entries on Homebrew/macOS.
- Preserve custom-main mobile test runner linkage, which still links `GTest::gtest` directly.
- Add shared `BUILD_FLAGS ?= --parallel` Makefile build flags so `make` / `make debug`, `make release`, `make sanitize`, and `make demos` build through CMake in parallel by default.

## Verification
- `cmake --build build/debug --target slayer3d_ui_test slayer3d_asset_test slayer3d_gl_renderer_test`
- `cmake --build build/debug`
- `ctest --test-dir build/debug -R 'SLAYER3DMath\.DegreesRadiansRoundTrip|SLAYER3DUI\.' --output-on-failure`
- `make -n debug`
- `make`
