### PR TITLE
Build source-backed Brush Tool for grayboxing

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -530,54 +530,31 @@
       {
         "signal": "signal.editor.mode.brush",
         "actions": [
-          { "type": "editor.vertex.selection.clear" },
-          { "type": "scene_state.set", "key": "editor.mode", "value": "brush" },
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "brush" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "brush tool" }
+          { "type": "editor.tool.set_mode", "mode": "brush" }
         ]
       },
       {
         "signal": "signal.editor.mode.face",
         "actions": [
-          { "type": "editor.vertex.selection.clear" },
-          { "type": "scene_state.set", "key": "editor.mode", "value": "face" },
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "face" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "face tool" }
+          { "type": "editor.tool.set_mode", "mode": "face" }
         ]
       },
       {
         "signal": "signal.editor.mode.vertex",
         "actions": [
-          { "type": "scene_state.set", "key": "editor.mode", "value": "vertex" },
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "vertex" },
-          {
-            "type": "branch",
-            "if": { "type": "scene_state.compare", "key": "editor.selection.count", "op": ">", "value": 0, "default": 0 },
-            "then": [
-              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "vertex tool" }
-            ],
-            "else": [
-              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "select a brush before vertex tool" }
-            ]
-          }
+          { "type": "editor.tool.set_mode", "mode": "vertex" }
         ]
       },
       {
         "signal": "signal.editor.mode.select",
         "actions": [
-          { "type": "editor.vertex.selection.clear" },
-          { "type": "scene_state.set", "key": "editor.mode", "value": "select" },
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "select mode" }
+          { "type": "editor.tool.set_mode", "mode": "select" }
         ]
       },
       {
         "signal": "signal.editor.mode.texture",
         "actions": [
-          { "type": "editor.vertex.selection.clear" },
-          { "type": "scene_state.set", "key": "editor.mode", "value": "texture" },
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "paint" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "texture mode" }
+          { "type": "editor.tool.set_mode", "mode": "texture", "message": "texture mode" }
         ]
       },
       {
@@ -705,10 +682,7 @@
                     "type": "branch",
                     "if": { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "vertex", "default": "select" },
                     "then": [
-                      { "type": "scene_state.set", "key": "editor.mode", "value": "select" },
-                      { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
-                      { "type": "editor.command.clear_preview", "message": "tool closed" },
-                      { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "select mode" }
+                      { "type": "editor.tool.set_mode", "mode": "select" }
                     ],
                     "else": [
                       {
@@ -730,10 +704,7 @@
                               ]
                             },
                             "then": [
-                              { "type": "scene_state.set", "key": "editor.mode", "value": "select" },
-                              { "type": "scene_state.set", "key": "editor.tool.mode", "value": "select" },
-                              { "type": "editor.command.clear_preview", "message": "tool closed" },
-                              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "select mode" }
+                              { "type": "editor.tool.set_mode", "mode": "select" }
                             ],
                             "else": [
                               { "type": "editor.command.clear_preview", "message": "escape" }
@@ -1006,11 +977,13 @@
               "type": "all",
               "conditions": [
                 {
-                  "type": "scene_state.compare",
-                  "key": "editor.mode",
-                  "op": "==",
-                  "value": "select",
-                  "default": "select"
+                  "type": "any",
+                  "conditions": [
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "select", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "texture", "default": "select" }
+                  ]
                 },
                 {
                   "type": "scene_state.compare",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -178,7 +178,12 @@
         "snap_key": "editor.placement_preview.snap",
         "bounds_min_key": "editor.placement_preview.bounds_min",
         "bounds_max_key": "editor.placement_preview.bounds_max",
-        "overlap_count_key": "editor.placement_preview.overlaps"
+        "overlap_count_key": "editor.placement_preview.overlaps",
+        "dimensions_key": "editor.placement_preview.dimensions",
+        "dimension_x_key": "editor.placement_preview.dimension_x",
+        "dimension_y_key": "editor.placement_preview.dimension_y",
+        "dimension_z_key": "editor.placement_preview.dimension_z",
+        "warning_key": "editor.placement_preview.warning"
       },
       "previews": [
         {
@@ -541,7 +546,7 @@
         "x": 12,
         "y": 92,
         "w": 308,
-        "h": 310,
+        "h": 400,
         "layer": 120,
         "visible_if": { "type": "scene_state.compare", "key": "editor.inspector.collapsed", "op": "==", "value": false, "default": false },
         "children": [
@@ -734,6 +739,77 @@
                   { "type": "scene_state", "key": "editor.vertex.hover.y", "default": 0 },
                   { "type": "scene_state", "key": "editor.vertex.hover.z", "default": 0 },
                   { "type": "scene_state", "key": "editor.vertex.hover.shared_count", "default": 0 }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.left_inspector.row.preview",
+            "type": "panel",
+            "layout": "row",
+            "x": 12,
+            "y": 304,
+            "w": 272,
+            "h": 26,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.left_inspector.row.preview.label", "type": "label", "w": 96, "h": "fill", "text": "Preview" },
+              {
+                "id": "ui.editor_shell.left_inspector.row.preview.value",
+                "type": "label",
+                "w": "fill",
+                "h": "fill",
+                "format": "%s",
+                "bindings": [{ "type": "scene_state", "key": "editor.placement_preview.message", "default": "none" }]
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.left_inspector.row.preview_dims",
+            "type": "panel",
+            "layout": "row",
+            "x": 12,
+            "y": 334,
+            "w": 272,
+            "h": 26,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.left_inspector.row.preview_dims.label", "type": "label", "w": 96, "h": "fill", "text": "Preview Dims" },
+              {
+                "id": "ui.editor_shell.left_inspector.row.preview_dims.value",
+                "type": "label",
+                "w": "fill",
+                "h": "fill",
+                "format": "%s x %s x %s",
+                "bindings": [
+                  { "type": "scene_state", "key": "editor.placement_preview.dimension_x", "default": 0.0 },
+                  { "type": "scene_state", "key": "editor.placement_preview.dimension_y", "default": 0.0 },
+                  { "type": "scene_state", "key": "editor.placement_preview.dimension_z", "default": 0.0 }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.left_inspector.row.move_delta",
+            "type": "panel",
+            "layout": "row",
+            "x": 12,
+            "y": 364,
+            "w": 272,
+            "h": 26,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.left_inspector.row.move_delta.label", "type": "label", "w": 96, "h": "fill", "text": "Move" },
+              {
+                "id": "ui.editor_shell.left_inspector.row.move_delta.value",
+                "type": "label",
+                "w": "fill",
+                "h": "fill",
+                "format": "%s, %s, %s",
+                "bindings": [
+                  { "type": "scene_state", "key": "editor.brush.drag.delta_x", "default": 0.0 },
+                  { "type": "scene_state", "key": "editor.brush.drag.delta_y", "default": 0.0 },
+                  { "type": "scene_state", "key": "editor.brush.drag.delta_z", "default": 0.0 }
                 ]
               }
             ]

--- a/docs/data-game-runtime.md
+++ b/docs/data-game-runtime.md
@@ -187,6 +187,30 @@ saves back to `--input` unless `--output` is supplied:
 build/debug/slayer3d_editor open --project path/to/project --input path/to/level.fragment.json
 ```
 
+For the current graybox editor workflow, the saved file is a source-backed
+editable level fragment. The editor source model is the truth: brush creation,
+movement, resizing, duplication, deletion, save/reopen, and test-run handoff all
+operate on `editor_brush_sources`, then compile runtime brush geometry from that
+source. A typical blockout loop is:
+
+```sh
+build/debug/slayer3d_editor new --project demos/editor_shell_dojo --output /tmp/level.fragment.json --overwrite
+```
+
+Inside the editor, use Brush Tool and Select mode to create and edit floors,
+walls, ceilings, pits, platforms, and corridors, place a player start, then save
+with the normal save command. Reopen the same source fragment with:
+
+```sh
+build/debug/slayer3d_editor open --project demos/editor_shell_dojo --input /tmp/level.fragment.json
+```
+
+The editor test-run command validates the source model, warns about leaks,
+applies the selected player start, and switches into the playable test-run scene.
+Leak findings are warning-level during the graybox milestone, but source/compiled
+identity errors remain hard failures because stale runtime brush geometry must
+not become the shipped level.
+
 The manifest currently carries `data_root`, `editor_entry`, optional
 `media_root`, and optional `test_run_output`. The editor host translates those
 fields into a normal runner launch and injects `editor.command`,

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1468,9 +1468,10 @@ boxes; runtime brush geometry is generated only after the source candidate
 passes validation. The preview reuses the editor debug overlay's
 `command_preview` flag and color, so editor hosts do not need a second rendering
 path.
-`drag_create` optionally enables TrenchBroom-style select-mode brush creation:
-the editor dry-runs the same source-box command while the pointer is dragged in
-empty space, then commits that exact command on release. `grid_widget` can
+`drag_create` optionally enables TrenchBroom-style brush creation in select and
+Brush Tool modes: the editor dry-runs the same source-box command while the
+pointer is dragged in empty space, then commits that exact command on release.
+`grid_widget` can
 describe a small authored toolbar dropdown for selecting the active snap size.
 The widget writes both the general grid key and the brush grid key so previews,
 drag creation, selected-brush dragging, and arrow-key nudging stay in sync.

--- a/include/slayer3d/game_data_editor_runtime.h
+++ b/include/slayer3d/game_data_editor_runtime.h
@@ -292,12 +292,13 @@ extern "C"
      * The operation is atomic from the runtime caller's perspective: the brush
      * is visible only after allocations, acceleration rebuild, and render-model
      * compilation all succeed. Success marks the brush world dirty and
-     * increments its editor revision. Structural box brushes may touch existing
-     * structural brushes exactly, but positive-volume overlap is rejected.
-     * Source-backed worlds commit a canonical source box first and rebuild
-     * runtime brushes from that source. Runtime-only worlds receive stable
-     * editor metadata on the brush and generated faces. @p out_brush_name
-     * receives the final runtime brush name when non-NULL.
+     * increments its editor revision. Source-backed worlds validate and commit
+     * a canonical source box first, then rebuild runtime brushes from that
+     * source. Structural source boxes may touch or overlap; overlap is reported
+     * as source-model diagnostics and resolved by the compiler path instead of
+     * blocking authoring. Runtime-only worlds receive stable editor metadata on
+     * the brush and generated faces. @p out_brush_name receives the final
+     * runtime brush name when non-NULL.
      */
     bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
                                              const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -440,6 +440,10 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
     if (SDL_strcmp(type, "editor.vertex.selection.clear") == 0)
         return slayer3d_game_data_clear_editor_vertex_selection(runtime);
 
+    if (SDL_strcmp(type, "editor.tool.set_mode") == 0)
+        return slayer3d_game_data_set_editor_tool_mode(runtime, json_string(action, "mode", NULL),
+                                                       json_string(action, "message", NULL));
+
     if (SDL_strcmp(type, "editor.vertex.snap_selected") == 0)
         return slayer3d_game_data_snap_selected_editor_vertices(runtime, action);
 

--- a/src/game_data_brush_editor_mutation.c
+++ b/src/game_data_brush_editor_mutation.c
@@ -222,9 +222,11 @@ bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
         set_error(error_buffer, error_buffer_size, "failed to allocate source box brush");
         return false;
     }
+    editor_brush_source_prefab_result create_result;
     char rebuild_error[256] = {0};
-    if (!editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,
-                                                       &source_box, rebuild_error, sizeof(rebuild_error)))
+    if (!editor_brush_world_apply_source_box_create(world_runtime, &source_box, 0, &create_result, rebuild_error,
+                                                    sizeof(rebuild_error)) ||
+        create_result.no_op)
     {
         free_editor_brush_source_box_runtime(&source_box);
         if (rebuild_error[0] != '\0')

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -496,6 +496,100 @@ bool editor_brush_world_validate_source_box_candidate(const brush_world_runtime 
     return source_box_candidate_valid(world_runtime, box, exclude_index, error_buffer, error_buffer_size);
 }
 
+static bool source_box_create_below_minimum_extent(const editor_brush_source_box_runtime *box, int minimum_extent_units)
+{
+    if (box == NULL || minimum_extent_units <= 0)
+        return false;
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        if (box->max[axis] - box->min[axis] < minimum_extent_units)
+            return true;
+    }
+    return false;
+}
+
+static void source_box_create_populate_result(const brush_world_runtime *world_runtime,
+                                              const editor_brush_source_box_runtime *box,
+                                              editor_brush_source_prefab_result *out_result)
+{
+    if (out_result == NULL || box == NULL)
+        return;
+    out_result->valid = true;
+    SDL_strlcpy(out_result->brush_name,
+                box->name != NULL && box->name[0] != '\0' ? box->name : (box->stable_id != NULL ? box->stable_id : ""),
+                sizeof(out_result->brush_name));
+    out_result->bounds = editor_brush_source_box_bounds_meters(world_runtime, box);
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        out_result->source_min[axis] = box->min[axis];
+        out_result->source_max[axis] = box->max[axis];
+    }
+}
+
+bool editor_brush_world_preview_source_box_create(const brush_world_runtime *world_runtime,
+                                                  const editor_brush_source_box_runtime *box, int minimum_extent_units,
+                                                  editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                  int error_buffer_size)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model || box == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source box creation requires a source-backed brush world");
+        return false;
+    }
+    if (!source_box_extents_valid(box))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush edit would create invalid geometry");
+        return false;
+    }
+    if (source_box_create_below_minimum_extent(box, minimum_extent_units))
+    {
+        if (out_result != NULL)
+        {
+            out_result->valid = true;
+            out_result->no_op = true;
+            source_box_create_populate_result(world_runtime, box, out_result);
+            SDL_strlcpy(out_result->warning, "source box create ignored tiny drag", sizeof(out_result->warning));
+        }
+        return true;
+    }
+    if (!source_box_candidate_valid(world_runtime, box, -1, error_buffer, error_buffer_size))
+        return false;
+    source_box_create_populate_result(world_runtime, box, out_result);
+    source_box_candidate_collect_warnings(world_runtime, box, -1, out_result);
+    return true;
+}
+
+bool editor_brush_world_apply_source_box_create(brush_world_runtime *world_runtime,
+                                                const editor_brush_source_box_runtime *box, int minimum_extent_units,
+                                                editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                int error_buffer_size)
+{
+    editor_brush_source_prefab_result preview;
+    if (!editor_brush_world_preview_source_box_create(world_runtime, box, minimum_extent_units, &preview, error_buffer,
+                                                      error_buffer_size))
+    {
+        if (out_result != NULL)
+            *out_result = preview;
+        return false;
+    }
+    if (preview.no_op)
+    {
+        if (out_result != NULL)
+            *out_result = preview;
+        return true;
+    }
+    if (!editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count, box,
+                                                       error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    if (out_result != NULL)
+        *out_result = preview;
+    return true;
+}
+
 static bool source_box_overlaps_on_other_axes(const editor_brush_source_box_runtime *a,
                                               const editor_brush_source_box_runtime *b, int axis)
 {
@@ -2567,8 +2661,9 @@ bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_run
         return false;
     }
 
-    bool ok = editor_brush_world_validate_source_box_candidate(world_runtime, &source_box, -1, error_buffer,
-                                                               error_buffer_size);
+    editor_brush_source_prefab_result preview_result;
+    bool ok = editor_brush_world_preview_source_box_create(world_runtime, &source_box, 0, &preview_result, error_buffer,
+                                                           error_buffer_size);
     if (ok && out_result != NULL)
     {
         const int existing_index = find_matching_source_prefab_cell(world_runtime, &source_box);
@@ -2592,23 +2687,17 @@ bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_run
             free_editor_brush_source_box(&source_box);
             return true;
         }
-        source_box_candidate_collect_warnings(world_runtime, &source_box, -1, out_result);
+        *out_result = preview_result;
     }
     if (ok && apply)
     {
-        ok = editor_brush_world_insert_source_box_at_index(world_runtime, world_runtime->editor_source_box_count,
-                                                           &source_box, error_buffer, error_buffer_size);
+        ok = editor_brush_world_apply_source_box_create(world_runtime, &source_box, 0, &preview_result, error_buffer,
+                                                        error_buffer_size);
     }
     if (ok && out_result != NULL)
     {
-        out_result->valid = true;
+        *out_result = preview_result;
         SDL_strlcpy(out_result->brush_name, name, sizeof(out_result->brush_name));
-        out_result->bounds = editor_brush_source_box_bounds_meters(world_runtime, &source_box);
-        for (int axis = 0; axis < 3; ++axis)
-        {
-            out_result->source_min[axis] = source_box.min[axis];
-            out_result->source_max[axis] = source_box.max[axis];
-        }
     }
     free_editor_brush_source_box(&source_box);
     return ok;

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -41,6 +41,10 @@ typedef struct source_convex_plane
     int source_face_index;
 } source_convex_plane;
 
+static bool source_box_to_runtime_brush(const brush_world_runtime *world_runtime,
+                                        const editor_brush_source_box_runtime *box, slayer3d_game_data_brush *out_brush,
+                                        char *error_buffer, int error_buffer_size);
+
 static bool source_vec3i(yyjson_val *object, const char *key, int out_values[3])
 {
     yyjson_val *value = obj_get(object, key);
@@ -199,6 +203,23 @@ static int source_convex_rebuilt_face_index_for_identity(const editor_brush_sour
     return -1;
 }
 
+static int runtime_brush_face_index_for_identity(const slayer3d_game_data_brush *brush, const char *face_identity,
+                                                 int fallback_face_index)
+{
+    if (brush == NULL)
+        return -1;
+    if (face_identity != NULL && face_identity[0] != '\0')
+    {
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            const char *stable_id = brush->faces[face_index].editor.stable_id;
+            if (stable_id != NULL && SDL_strcmp(stable_id, face_identity) == 0)
+                return face_index;
+        }
+    }
+    return fallback_face_index >= 0 && fallback_face_index < brush->face_count ? fallback_face_index : -1;
+}
+
 int editor_brush_world_source_box_face_index_for_identity(const brush_world_runtime *world_runtime,
                                                           const char *brush_identity, int fallback_face_index,
                                                           const char *face_identity)
@@ -251,8 +272,28 @@ bool editor_brush_world_source_box_face_normal_for_identity(const brush_world_ru
     if (out_face_index != NULL)
         *out_face_index = face_index;
     if (out_normal != NULL)
-        *out_normal = source_box_face_normal_for_index(face_index);
-    return face_index >= 0;
+        *out_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (face_index < 0)
+        return false;
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_identity);
+    if (source_index < 0)
+        return false;
+
+    slayer3d_game_data_brush brush;
+    if (!source_box_to_runtime_brush(world_runtime, &world_runtime->editor_source_boxes[source_index], &brush, NULL, 0))
+    {
+        if (out_normal != NULL)
+            *out_normal = source_box_face_normal_for_index(face_index);
+        return face_index >= 0 && face_index < (int)SDL_arraysize(editor_brush_source_box_face_keys);
+    }
+
+    const int runtime_face_index = runtime_brush_face_index_for_identity(&brush, face_identity, face_index);
+    const bool ok = runtime_face_index >= 0 && runtime_face_index < brush.face_count;
+    if (ok && out_normal != NULL)
+        *out_normal = slayer3d_vec3_normalize(brush.faces[runtime_face_index].normal);
+    editor_brush_source_free_runtime_brush(&brush);
+    return ok;
 }
 
 bool editor_brush_world_copy_source_box_by_identity(const brush_world_runtime *world_runtime,
@@ -3070,6 +3111,189 @@ bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtim
         return false;
     }
     return true;
+}
+
+static bool source_face_resize_desc(const brush_world_runtime *world_runtime, const char *brush_name,
+                                    int fallback_face_index, const char *face_identity, float distance,
+                                    editor_brush_source_vertex_operation_desc *out_desc,
+                                    slayer3d_game_data_brush *out_brush, int *out_original_vertex_count,
+                                    char *error_buffer, int error_buffer_size)
+{
+    if (out_desc != NULL)
+        SDL_zero(*out_desc);
+    if (out_brush != NULL)
+        SDL_zero(*out_brush);
+    if (out_original_vertex_count != NULL)
+        *out_original_vertex_count = 0;
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model || brush_name == NULL ||
+        brush_name[0] == '\0' || out_desc == NULL || out_brush == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed face resize requires a source brush");
+        return false;
+    }
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_name);
+    if (source_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        return false;
+    }
+
+    const editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    editor_brush_source_vertex_model model;
+    if (!editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model, error_buffer,
+                                                    error_buffer_size) ||
+        !source_box_to_runtime_brush(world_runtime, box, out_brush, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+
+    const int source_face_index = editor_brush_world_source_box_face_index_for_identity(
+        world_runtime, brush_name, fallback_face_index, face_identity);
+    const int runtime_face_index = runtime_brush_face_index_for_identity(out_brush, face_identity, source_face_index);
+    if (source_face_index < 0 || runtime_face_index < 0 || runtime_face_index >= out_brush->face_count)
+    {
+        editor_brush_source_free_runtime_brush(out_brush);
+        set_error(error_buffer, error_buffer_size, "source brush face not found");
+        return false;
+    }
+    int model_face_index = source_face_index;
+    if (box->vertex_count > 0)
+    {
+        model_face_index = -1;
+        const slayer3d_game_data_brush_face *runtime_face = &out_brush->faces[runtime_face_index];
+        for (int face_index = 0; face_index < model.face_count; ++face_index)
+        {
+            const editor_brush_source_face_ref *face = &model.faces[face_index];
+            bool matches = face->vertex_count > 0;
+            for (int vertex = 0; matches && vertex < face->vertex_count; ++vertex)
+            {
+                const int vertex_index = face->vertex_indices[vertex];
+                if (vertex_index < 0 || vertex_index >= model.vertex_count)
+                {
+                    matches = false;
+                    break;
+                }
+                const slayer3d_vec3 point =
+                    source_convex_vertex_meters(world_runtime, &model.vertices[vertex_index].coord[0]);
+                matches = SDL_fabsf(slayer3d_vec3_dot(runtime_face->normal, point) - runtime_face->distance) <= 0.001f;
+            }
+            if (matches)
+            {
+                model_face_index = face_index;
+                break;
+            }
+        }
+    }
+    if (model_face_index < 0 || model_face_index >= model.face_count)
+    {
+        editor_brush_source_free_runtime_brush(out_brush);
+        set_error(error_buffer, error_buffer_size, "source brush face vertices not found");
+        return false;
+    }
+    if (out_original_vertex_count != NULL)
+        *out_original_vertex_count = model.vertex_count;
+
+    const int distance_units = editor_brush_source_units_from_meters(world_runtime, distance);
+    const slayer3d_vec3 normal = slayer3d_vec3_normalize(out_brush->faces[runtime_face_index].normal);
+    int delta[3] = {
+        (int)SDL_lroundf(normal.x * (float)distance_units),
+        (int)SDL_lroundf(normal.y * (float)distance_units),
+        (int)SDL_lroundf(normal.z * (float)distance_units),
+    };
+    if (delta[0] == 0 && delta[1] == 0 && delta[2] == 0)
+    {
+        editor_brush_source_free_runtime_brush(out_brush);
+        set_error(error_buffer, error_buffer_size, "source brush face resize distance did not reach the source grid");
+        return false;
+    }
+
+    out_desc->brush_identity = brush_name;
+    out_desc->type = EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_MOVE_MANY;
+    const editor_brush_source_face_ref *face = &model.faces[model_face_index];
+    for (int i = 0; i < face->vertex_count; ++i)
+    {
+        const int vertex_index = face->vertex_indices[i];
+        if (vertex_index < 0 || vertex_index >= model.vertex_count ||
+            out_desc->vertex_index_count >= SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY)
+        {
+            editor_brush_source_free_runtime_brush(out_brush);
+            set_error(error_buffer, error_buffer_size, "source brush face resize vertex index out of range");
+            return false;
+        }
+        out_desc->vertex_indices[out_desc->vertex_index_count] = vertex_index;
+        for (int axis = 0; axis < 3; ++axis)
+            out_desc->coords[out_desc->vertex_index_count][axis] =
+                model.vertices[vertex_index].coord[axis] + delta[axis];
+        out_desc->vertex_index_count++;
+    }
+    return true;
+}
+
+bool editor_brush_world_preview_resize_source_face(const brush_world_runtime *world_runtime, const char *brush_name,
+                                                   int fallback_face_index, const char *face_identity, float distance,
+                                                   editor_brush_source_vertex_operation_result *out_result,
+                                                   char *error_buffer, int error_buffer_size)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    editor_brush_source_vertex_operation_desc desc;
+    slayer3d_game_data_brush brush;
+    int original_vertex_count = 0;
+    if (!source_face_resize_desc(world_runtime, brush_name, fallback_face_index, face_identity, distance, &desc, &brush,
+                                 &original_vertex_count, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&brush);
+    if (!editor_brush_world_preview_source_vertex_operation(world_runtime, &desc, out_result, error_buffer,
+                                                            error_buffer_size))
+    {
+        return false;
+    }
+    if (out_result != NULL && out_result->valid && out_result->vertex_count != original_vertex_count)
+    {
+        editor_brush_source_free_runtime_brush(&out_result->brush);
+        source_vertex_operation_set_failure(out_result, "source brush face resize would collapse vertices");
+        set_error(error_buffer, error_buffer_size, "source brush face resize would collapse vertices");
+        return false;
+    }
+    return true;
+}
+
+bool editor_brush_world_resize_source_face(brush_world_runtime *world_runtime, const char *brush_name,
+                                           int fallback_face_index, const char *face_identity, float distance,
+                                           editor_brush_source_vertex_operation_result *out_result, char *error_buffer,
+                                           int error_buffer_size)
+{
+    if (out_result != NULL)
+        SDL_zero(*out_result);
+    editor_brush_source_vertex_operation_desc desc;
+    slayer3d_game_data_brush brush;
+    int original_vertex_count = 0;
+    if (!source_face_resize_desc(world_runtime, brush_name, fallback_face_index, face_identity, distance, &desc, &brush,
+                                 &original_vertex_count, error_buffer, error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&brush);
+    editor_brush_source_vertex_operation_result result;
+    if (!editor_brush_world_preview_source_vertex_operation(world_runtime, &desc, &result, error_buffer,
+                                                            error_buffer_size))
+    {
+        return false;
+    }
+    if (result.valid && result.vertex_count != original_vertex_count)
+    {
+        editor_brush_source_free_runtime_brush(&result.brush);
+        if (out_result != NULL)
+            source_vertex_operation_set_failure(out_result, "source brush face resize would collapse vertices");
+        set_error(error_buffer, error_buffer_size, "source brush face resize would collapse vertices");
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&result.brush);
+    return editor_brush_world_apply_source_vertex_operation(world_runtime, &desc, out_result, error_buffer,
+                                                            error_buffer_size);
 }
 
 bool editor_brush_world_update_source_box_bounds_batch(brush_world_runtime *world_runtime,

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -383,6 +383,22 @@ static void source_box_update_bounds_from_vertices(editor_brush_source_box_runti
     }
 }
 
+static void translate_source_box_coordinates(editor_brush_source_box_runtime *box, const int delta[3])
+{
+    if (box == NULL || delta == NULL)
+        return;
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        box->min[axis] += delta[axis];
+        box->max[axis] += delta[axis];
+    }
+    for (int vertex = 0; vertex < box->vertex_count; ++vertex)
+    {
+        for (int axis = 0; axis < 3; ++axis)
+            box->vertices[vertex][axis] += delta[axis];
+    }
+}
+
 static bool source_intervals_overlap_positive(int a_min, int a_max, int b_min, int b_max)
 {
     return SDL_max(a_min, b_min) < SDL_min(a_max, b_max);
@@ -2942,20 +2958,20 @@ bool editor_brush_world_translate_source_box(brush_world_runtime *world_runtime,
     int old_min[3];
     int old_max[3];
     copy_source_box_coordinates(box, old_min, old_max);
-    for (int axis = 0; axis < 3; ++axis)
-    {
-        box->min[axis] += delta[axis];
-        box->max[axis] += delta[axis];
-    }
+    translate_source_box_coordinates(box, delta);
 
     if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size))
     {
+        const int rollback_delta[3] = {-delta[0], -delta[1], -delta[2]};
+        translate_source_box_coordinates(box, rollback_delta);
         restore_source_box_coordinates(box, old_min, old_max);
         return false;
     }
 
     if (!editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
     {
+        const int rollback_delta[3] = {-delta[0], -delta[1], -delta[2]};
+        translate_source_box_coordinates(box, rollback_delta);
         restore_source_box_coordinates(box, old_min, old_max);
         (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
         return false;

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -79,6 +79,14 @@ slayer3d_bounding_box editor_brush_source_box_bounds_meters(const brush_world_ru
 bool editor_brush_world_validate_source_box_candidate(const brush_world_runtime *world_runtime,
                                                       const editor_brush_source_box_runtime *box, int exclude_index,
                                                       char *error_buffer, int error_buffer_size);
+bool editor_brush_world_preview_source_box_create(const brush_world_runtime *world_runtime,
+                                                  const editor_brush_source_box_runtime *box, int minimum_extent_units,
+                                                  editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                  int error_buffer_size);
+bool editor_brush_world_apply_source_box_create(brush_world_runtime *world_runtime,
+                                                const editor_brush_source_box_runtime *box, int minimum_extent_units,
+                                                editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                int error_buffer_size);
 bool editor_brush_world_run_source_prefab_command(brush_world_runtime *world_runtime,
                                                   const editor_brush_source_prefab_desc *desc, const char *brush_name,
                                                   const int *source_min, const int *source_max, bool apply,

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -114,6 +114,14 @@ bool editor_brush_world_source_box_face_normal_for_identity(const brush_world_ru
 bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                int error_buffer_size);
+bool editor_brush_world_preview_resize_source_face(const brush_world_runtime *world_runtime, const char *brush_name,
+                                                   int fallback_face_index, const char *face_identity, float distance,
+                                                   editor_brush_source_vertex_operation_result *out_result,
+                                                   char *error_buffer, int error_buffer_size);
+bool editor_brush_world_resize_source_face(brush_world_runtime *world_runtime, const char *brush_name,
+                                           int fallback_face_index, const char *face_identity, float distance,
+                                           editor_brush_source_vertex_operation_result *out_result, char *error_buffer,
+                                           int error_buffer_size);
 bool editor_brush_world_update_source_box_bounds_batch(brush_world_runtime *world_runtime,
                                                        const editor_source_box_bounds_update *updates, int update_count,
                                                        char *error_buffer, int error_buffer_size);

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -7,6 +7,8 @@
 
 bool slayer3d_game_data_clear_active_editor_selection(slayer3d_game_data_runtime *runtime);
 bool slayer3d_game_data_clear_editor_vertex_selection(slayer3d_game_data_runtime *runtime);
+bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime, const char *mode,
+                                             const char *message_override);
 slayer3d_game_data_editor_selection resolved_editor_selection(const slayer3d_game_data_runtime *runtime,
                                                               const slayer3d_game_data_editor_selection *selection);
 slayer3d_properties *slayer3d_game_data_create_editor_selection_payload(

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -182,7 +182,8 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
 {
     if (out_consumed != NULL)
         *out_consumed = false;
-    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_select(runtime))
+    const bool movement_mode = editor_mode_is_select(runtime) || editor_mode_is_brush(runtime);
+    if (runtime == NULL || runtime->scene_state == NULL || !movement_mode)
     {
         clear_editor_drag_move(runtime);
         return true;
@@ -201,12 +202,21 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
     const bool can_start_from_hover = editor_selection_is_selectable_brush(hover_selection);
     const bool can_start_y_axis_drag =
         y_axis_lock && editor_selected_brushes_active_for_scene(runtime) && runtime->editor_selected_brush_count > 0;
-    bool just_started_without_consuming_click = false;
     if (!drag->active && left_pressed && (can_start_from_hover || can_start_y_axis_drag))
     {
         const bool hover_was_selected =
             can_start_from_hover && editor_hover_is_selected_brush(runtime, hover_selection);
-        const bool consume_start_click = hover_was_selected || can_start_y_axis_drag;
+        const bool additive = (modifiers & (SDL_KMOD_SHIFT | SDL_KMOD_CTRL | SDL_KMOD_GUI)) != 0;
+        if (can_start_from_hover && !hover_was_selected)
+        {
+            const slayer3d_game_data_editor_selection resolved_hover =
+                resolved_editor_selection(runtime, hover_selection);
+            if (!additive)
+                clear_editor_selected_brushes(runtime);
+            if (!add_editor_selected_brush(runtime, &resolved_hover))
+                return false;
+            update_active_editor_selection_from_selected_brushes(runtime);
+        }
         SDL_zero(*drag);
         drag->active = true;
         drag->axis_lock_y = y_axis_lock;
@@ -217,13 +227,10 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
         drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
         (void)slayer3d_input_get_mouse_position(input, &drag->start_mouse_x, &drag->start_mouse_y);
         if (out_consumed != NULL)
-            *out_consumed = consume_start_click;
-        just_started_without_consuming_click = !consume_start_click;
+            *out_consumed = true;
     }
 
     if (!drag->active)
-        return true;
-    if (just_started_without_consuming_click)
         return true;
     if (out_consumed != NULL)
         *out_consumed = true;
@@ -280,7 +287,8 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime, bool *
     if (runtime == NULL || runtime->scene_state == NULL)
         return true;
     const bool vertex_mode = editor_mode_is_vertex(runtime);
-    if (!editor_mode_is_select(runtime) && !vertex_mode)
+    const bool brush_transform_mode = editor_mode_is_select(runtime) || editor_mode_is_brush(runtime);
+    if (!brush_transform_mode && !vertex_mode)
         return true;
 
     slayer3d_input_manager *input = runtime_input(runtime);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -204,7 +204,7 @@ static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
     float mouse_y = drag->start_mouse_y;
     (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
     const float units_per_pixel = SDL_max(drag->grid_size, 0.001f) / 48.0f;
-    const float distance = editor_snap_delta((mouse_y - drag->start_mouse_y) * units_per_pixel, drag->grid_size);
+    const float distance = editor_snap_delta((drag->start_mouse_y - mouse_y) * units_per_pixel, drag->grid_size);
     if (SDL_fabsf(distance) > 0.000001f)
     {
         drag->moved = editor_set_face_resize_preview(runtime, &drag->face_selection, distance);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -71,11 +71,28 @@ static void editor_set_face_drag_state(slayer3d_game_data_runtime *runtime, bool
                                  (SDL_GetModState() & SDL_KMOD_SHIFT) != 0);
 }
 
-static void editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
+static bool editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
                                            const slayer3d_game_data_editor_selection *selection, float distance)
 {
     if (runtime == NULL || selection == NULL || !selection->hit || selection->face_index < 0)
-        return;
+        return false;
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, selection->world_name);
+    const char *brush_identity = editor_metadata_stable_id(selection->element_editor);
+    if (brush_identity == NULL || brush_identity[0] == '\0')
+        brush_identity = selection->element_name;
+    const char *face_identity = editor_metadata_stable_id(selection->face_editor);
+    editor_brush_source_vertex_operation_result result;
+    char error[256];
+    SDL_zeroa(error);
+    if (!editor_brush_world_preview_resize_source_face(world_runtime, brush_identity, selection->face_index,
+                                                       face_identity, distance, &result, error, sizeof(error)))
+    {
+        clear_editor_command_preview(runtime);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
+                                       error[0] != '\0' ? error : "brush face resize invalid");
+        return false;
+    }
 
     editor_command_preview_state *preview = &runtime->editor_command_preview;
     SDL_zero(*preview);
@@ -93,10 +110,11 @@ static void editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
     preview->material_index = -1;
     preview->previous_material_index = -1;
     preview->offset = slayer3d_vec3_scale(slayer3d_vec3_normalize(selection->normal), distance);
-    preview->has_bounds = selection->has_bounds;
-    preview->bounds = selection->has_bounds
-                          ? editor_resized_preview_bounds(selection->bounds, selection->normal, distance)
-                          : (slayer3d_bounding_box){selection->point, selection->point};
+    preview->has_bounds = result.brush.has_bounds;
+    preview->bounds =
+        result.brush.has_bounds ? result.brush.bounds : (slayer3d_bounding_box){selection->point, selection->point};
+    editor_brush_source_free_runtime_brush(&result.brush);
+    return true;
 }
 
 static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
@@ -104,13 +122,16 @@ static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
 {
     if (out_consumed != NULL)
         *out_consumed = false;
-    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_face(runtime))
+    if (runtime == NULL || runtime->scene_state == NULL ||
+        !(editor_mode_is_face(runtime) || editor_mode_is_brush(runtime)))
     {
         editor_set_face_drag_state(runtime, false, false);
         return true;
     }
 
-    const bool can_resize_face = editor_selection_is_selectable_brush(hover_selection) &&
+    const bool brush_face_resize_modifier =
+        editor_mode_is_face(runtime) || (editor_mode_is_brush(runtime) && (SDL_GetModState() & SDL_KMOD_SHIFT) != 0);
+    const bool can_resize_face = brush_face_resize_modifier && editor_selection_is_selectable_brush(hover_selection) &&
                                  hover_selection->face_index >= 0 && hover_selection->has_bounds;
     slayer3d_input_manager *input = runtime_input(runtime);
     if (input == NULL)
@@ -155,8 +176,7 @@ static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
     const float distance = editor_snap_delta((mouse_y - drag->start_mouse_y) * units_per_pixel, drag->grid_size);
     if (SDL_fabsf(distance) > 0.000001f)
     {
-        editor_set_face_resize_preview(runtime, &drag->face_selection, distance);
-        drag->moved = true;
+        drag->moved = editor_set_face_resize_preview(runtime, &drag->face_selection, distance);
     }
     editor_set_face_drag_state(runtime, true, true);
 

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -219,6 +219,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
     const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
     const SDL_Keymod modifiers = SDL_GetModState();
     const bool y_axis_lock = (modifiers & SDL_KMOD_ALT) != 0;
+    const bool duplicate_modifier = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_GUI)) != 0;
     const bool can_start_from_hover = editor_selection_is_selectable_brush(hover_selection);
     const bool can_start_y_axis_drag =
         y_axis_lock && editor_selected_brushes_active_for_scene(runtime) && runtime->editor_selected_brush_count > 0;
@@ -231,18 +232,24 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
         {
             const slayer3d_game_data_editor_selection resolved_hover =
                 resolved_editor_selection(runtime, hover_selection);
-            if (!additive)
+            if (!additive || duplicate_modifier)
                 clear_editor_selected_brushes(runtime);
             if (!add_editor_selected_brush(runtime, &resolved_hover))
                 return false;
             update_active_editor_selection_from_selected_brushes(runtime);
         }
+        if (duplicate_modifier && runtime->editor_selected_brush_count > 0)
+            (void)slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                                       false);
         SDL_zero(*drag);
         drag->active = true;
         drag->axis_lock_y = y_axis_lock;
+        drag->duplicate_drag = duplicate_modifier;
         drag->scene = slayer3d_game_data_active_scene(runtime);
-        const slayer3d_game_data_editor_selection resolved = resolved_editor_selection(
-            runtime, can_start_from_hover ? hover_selection : &runtime->editor_active_selection);
+        const slayer3d_game_data_editor_selection *drag_selection =
+            duplicate_modifier ? &runtime->editor_active_selection
+                               : (can_start_from_hover ? hover_selection : &runtime->editor_active_selection);
+        const slayer3d_game_data_editor_selection resolved = resolved_editor_selection(runtime, drag_selection);
         drag->start_point = resolved.hit ? resolved.point : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
         drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
         (void)slayer3d_input_get_mouse_position(input, &drag->start_mouse_x, &drag->start_mouse_y);
@@ -318,6 +325,14 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime, bool *
 
     const SDL_Keymod modifiers = SDL_GetModState();
     const bool transform_modifier = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_ALT)) != 0;
+    const bool duplicate_modifier = (modifiers & (SDL_KMOD_CTRL | SDL_KMOD_GUI)) != 0;
+    if (!vertex_mode && duplicate_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_D))
+    {
+        (void)slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), true);
+        if (out_changed != NULL)
+            *out_changed = true;
+        return true;
+    }
     if (!vertex_mode && (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_HOME) ||
                          (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT))))
     {

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -148,6 +148,41 @@ static bool editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
+static float editor_face_drag_distance(const slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag,
+                                       float mouse_x, float mouse_y)
+{
+    if (drag == NULL)
+        return 0.0f;
+
+    const float units_per_pixel = SDL_max(drag->grid_size, 0.001f) / 48.0f;
+    const slayer3d_vec3 normal = slayer3d_vec3_normalize(drag->face_selection.normal);
+    slayer3d_camera3d camera;
+    if (runtime != NULL && slayer3d_game_data_get_camera(runtime, slayer3d_game_data_active_camera(runtime), &camera))
+    {
+        const slayer3d_vec3 forward = slayer3d_vec3_normalize(slayer3d_vec3_sub(camera.target, camera.position));
+        const slayer3d_vec3 right = slayer3d_vec3_normalize(slayer3d_vec3_cross(forward, camera.up));
+        const slayer3d_vec3 up = slayer3d_vec3_normalize(slayer3d_vec3_cross(right, forward));
+        if (slayer3d_vec3_length_squared(normal) > 0.000001f && slayer3d_vec3_length_squared(right) > 0.000001f &&
+            slayer3d_vec3_length_squared(up) > 0.000001f)
+        {
+            const float projected_x = slayer3d_vec3_dot(normal, right);
+            const float projected_y = -slayer3d_vec3_dot(normal, up);
+            const float projected_length_squared = projected_x * projected_x + projected_y * projected_y;
+            if (projected_length_squared > 0.000001f)
+            {
+                const float inverse_projected_length = 1.0f / SDL_sqrtf(projected_length_squared);
+                const float mouse_dx = mouse_x - drag->start_mouse_x;
+                const float mouse_dy = mouse_y - drag->start_mouse_y;
+                const float pixel_distance =
+                    (mouse_dx * projected_x + mouse_dy * projected_y) * inverse_projected_length;
+                return editor_snap_delta(pixel_distance * units_per_pixel, drag->grid_size);
+            }
+        }
+    }
+
+    return editor_snap_delta((drag->start_mouse_y - mouse_y) * units_per_pixel, drag->grid_size);
+}
+
 static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
                                     const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
 {
@@ -203,8 +238,7 @@ static bool editor_handle_face_drag(slayer3d_game_data_runtime *runtime,
     float mouse_x = drag->start_mouse_x;
     float mouse_y = drag->start_mouse_y;
     (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
-    const float units_per_pixel = SDL_max(drag->grid_size, 0.001f) / 48.0f;
-    const float distance = editor_snap_delta((drag->start_mouse_y - mouse_y) * units_per_pixel, drag->grid_size);
+    const float distance = editor_face_drag_distance(runtime, drag, mouse_x, mouse_y);
     if (SDL_fabsf(distance) > 0.000001f)
     {
         drag->moved = editor_set_face_resize_preview(runtime, &drag->face_selection, distance);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -71,6 +71,36 @@ static void editor_set_face_drag_state(slayer3d_game_data_runtime *runtime, bool
                                  (SDL_GetModState() & SDL_KMOD_SHIFT) != 0);
 }
 
+static slayer3d_vec3 editor_bounds_dimensions(slayer3d_bounding_box bounds)
+{
+    return slayer3d_vec3_make(SDL_max(0.0f, bounds.max.x - bounds.min.x), SDL_max(0.0f, bounds.max.y - bounds.min.y),
+                              SDL_max(0.0f, bounds.max.z - bounds.min.z));
+}
+
+static void publish_editor_face_resize_feedback(slayer3d_game_data_runtime *runtime, float distance,
+                                                slayer3d_bounding_box bounds, bool has_bounds)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    const slayer3d_vec3 dimensions =
+        has_bounds ? editor_bounds_dimensions(bounds) : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.resize.distance", distance);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.resize.dimension_x", dimensions.x);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.resize.dimension_y", dimensions.y);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.resize.dimension_z", dimensions.z);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.brush.resize.dimensions", dimensions);
+}
+
+static void publish_editor_drag_move_feedback(slayer3d_game_data_runtime *runtime, slayer3d_vec3 delta)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.drag.delta_x", delta.x);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.drag.delta_y", delta.y);
+    slayer3d_properties_set_float(runtime->scene_state, "editor.brush.drag.delta_z", delta.z);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.brush.drag.delta", delta);
+}
+
 static bool editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
                                            const slayer3d_game_data_editor_selection *selection, float distance)
 {
@@ -113,6 +143,7 @@ static bool editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
     preview->has_bounds = result.brush.has_bounds;
     preview->bounds =
         result.brush.has_bounds ? result.brush.bounds : (slayer3d_bounding_box){selection->point, selection->point};
+    publish_editor_face_resize_feedback(runtime, distance, preview->bounds, preview->has_bounds);
     editor_brush_source_free_runtime_brush(&result.brush);
     return true;
 }
@@ -278,6 +309,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
                 drag->applied_offset = desired;
                 drag->moved = true;
                 update_active_editor_selection_from_selected_brushes(runtime);
+                publish_editor_drag_move_feedback(runtime, drag->applied_offset);
             }
         }
     }
@@ -294,6 +326,7 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
                 drag->applied_offset = desired;
                 drag->moved = true;
                 update_active_editor_selection_from_selected_brushes(runtime);
+                publish_editor_drag_move_feedback(runtime, drag->applied_offset);
             }
         }
     }
@@ -301,7 +334,10 @@ static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
     if (left_released || !left_down)
     {
         if (runtime->scene_state != NULL && drag->moved)
+        {
             slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "drag moved brush");
+            editor_publish_console_message(runtime, "drag moved brush");
+        }
         clear_editor_drag_move(runtime);
     }
     return true;

--- a/src/game_data_editor_command_preview.c
+++ b/src/game_data_editor_command_preview.c
@@ -273,6 +273,32 @@ bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runti
             ? (face_resize ? editor_resized_preview_bounds(selection.bounds, selection.normal, face_distance)
                            : translated_bounds(selection.bounds, offset))
             : (slayer3d_bounding_box){selection.point, selection.point};
+    editor_brush_source_vertex_operation_result source_face_preview;
+    SDL_zero(source_face_preview);
+    if (face_resize && selection.world_name != NULL)
+    {
+        const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, selection.world_name);
+        const char *brush_identity = editor_metadata_stable_id(selection.element_editor);
+        if (brush_identity == NULL || brush_identity[0] == '\0')
+            brush_identity = selection.element_name;
+        const char *face_identity = editor_metadata_stable_id(selection.face_editor);
+        char error[256];
+        SDL_zeroa(error);
+        if (editor_brush_world_preview_resize_source_face(world_runtime, brush_identity, selection.face_index,
+                                                          face_identity, face_distance, &source_face_preview, error,
+                                                          sizeof(error)))
+        {
+            if (source_face_preview.brush.has_bounds)
+                bounds = source_face_preview.brush.bounds;
+        }
+        else
+        {
+            clear_editor_command_preview(runtime);
+            publish_editor_command_preview(runtime, outputs, false, command, target,
+                                           error[0] != '\0' ? error : "invalid source face resize", NULL, NULL);
+            return true;
+        }
+    }
 
     editor_command_preview_state *preview = &runtime->editor_command_preview;
     SDL_zero(*preview);
@@ -298,6 +324,7 @@ bool slayer3d_game_data_preview_editor_command(slayer3d_game_data_runtime *runti
     preview->offset = offset;
     preview->has_bounds = true;
     preview->bounds = bounds;
+    editor_brush_source_free_runtime_brush(&source_face_preview.brush);
 
     slayer3d_properties *payload = slayer3d_game_data_create_editor_selection_payload(&selection);
     char message[256];

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -884,6 +884,150 @@ static void refresh_editor_brush_selection_for_identity(const brush_world_runtim
     }
 }
 
+static void publish_editor_transaction_selection_state(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
+    publish_editor_selection(runtime, obj_get(selection_json, "outputs"), &runtime->editor_active_selection);
+    publish_editor_selected_brush_count(runtime);
+}
+
+static void remove_editor_selected_brushes_for_transaction(slayer3d_game_data_runtime *runtime,
+                                                           const editor_command_transaction_entry *entry)
+{
+    if (runtime == NULL || entry == NULL)
+        return;
+
+    bool removed_any = false;
+    if (editor_selected_brushes_active_for_scene(runtime))
+    {
+        for (int i = runtime->editor_selected_brush_count - 1; i >= 0; --i)
+        {
+            if (editor_selection_matches_transaction_element(&runtime->editor_selected_brushes[i], entry))
+            {
+                remove_editor_selected_brush_at(runtime, i);
+                removed_any = true;
+            }
+        }
+    }
+
+    if (runtime->editor_active_selection.hit &&
+        editor_selection_matches_transaction_element(&runtime->editor_active_selection, entry))
+    {
+        init_editor_selection(&runtime->editor_active_selection);
+        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+        removed_any = true;
+    }
+
+    if (removed_any)
+    {
+        clear_editor_selected_vertices(runtime);
+        update_active_editor_selection_from_selected_brushes(runtime);
+        publish_editor_transaction_selection_state(runtime);
+    }
+}
+
+static void refresh_editor_selected_brushes_for_transaction(slayer3d_game_data_runtime *runtime,
+                                                            const editor_command_transaction_entry *entry)
+{
+    if (runtime == NULL || entry == NULL)
+        return;
+
+    const brush_world_runtime *world_runtime =
+        entry->world_name != NULL ? find_brush_world_runtime(runtime, entry->world_name) : NULL;
+    if (world_runtime == NULL)
+        return;
+
+    bool changed = false;
+    if (editor_selected_brushes_active_for_scene(runtime))
+    {
+        for (int i = runtime->editor_selected_brush_count - 1; i >= 0; --i)
+        {
+            slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+            if (!editor_selection_matches_transaction_element(selection, entry))
+                continue;
+            const int face_index = selection->face_index;
+            refresh_editor_brush_selection_for_identity(world_runtime, selection, entry->element_name,
+                                                        entry->element_stable_id, face_index, entry->face_stable_id);
+            if (!selection->hit)
+                remove_editor_selected_brush_at(runtime, i);
+            changed = true;
+        }
+    }
+
+    if (runtime->editor_active_selection.hit &&
+        editor_selection_matches_transaction_element(&runtime->editor_active_selection, entry))
+    {
+        const int face_index = runtime->editor_active_selection.face_index;
+        refresh_editor_brush_selection_for_identity(world_runtime, &runtime->editor_active_selection,
+                                                    entry->element_name, entry->element_stable_id, face_index,
+                                                    entry->face_stable_id);
+        changed = true;
+    }
+    else if (changed)
+    {
+        update_active_editor_selection_from_selected_brushes(runtime);
+    }
+
+    if (changed)
+        publish_editor_transaction_selection_state(runtime);
+}
+
+static void select_editor_brush_for_transaction(slayer3d_game_data_runtime *runtime,
+                                                const editor_command_transaction_entry *entry)
+{
+    if (runtime == NULL || entry == NULL || entry->world_name == NULL)
+        return;
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, entry->world_name);
+    slayer3d_game_data_editor_selection selection;
+    init_editor_selection(&selection);
+    refresh_editor_brush_selection_for_identity(world_runtime, &selection, entry->element_name,
+                                                entry->element_stable_id, -1, NULL);
+    if (!selection.hit)
+        return;
+
+    clear_editor_selected_brushes(runtime);
+    (void)add_editor_selected_brush(runtime, &selection);
+    update_active_editor_selection_from_selected_brushes(runtime);
+    publish_editor_transaction_selection_state(runtime);
+}
+
+static void sync_editor_selection_after_transaction(slayer3d_game_data_runtime *runtime,
+                                                    const editor_command_transaction_entry *entry, bool forward)
+{
+    if (runtime == NULL || entry == NULL || entry->command == NULL)
+        return;
+
+    if (SDL_strcmp(entry->command, "delete") == 0)
+    {
+        if (forward)
+            remove_editor_selected_brushes_for_transaction(runtime, entry);
+        else
+            select_editor_brush_for_transaction(runtime, entry);
+        return;
+    }
+
+    if (SDL_strcmp(entry->command, "duplicate") == 0)
+    {
+        if (forward)
+            select_editor_brush_for_transaction(runtime, entry);
+        else
+            remove_editor_selected_brushes_for_transaction(runtime, entry);
+        return;
+    }
+
+    if (SDL_strcmp(entry->command, "create") == 0)
+    {
+        if (!forward)
+            remove_editor_selected_brushes_for_transaction(runtime, entry);
+        return;
+    }
+
+    refresh_editor_selected_brushes_for_transaction(runtime, entry);
+}
+
 static bool delete_editor_floor_fill_brushes(brush_world_runtime *world_runtime, const char *brush_name, float low_y,
                                              float high_y)
 {
@@ -1125,16 +1269,38 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         editor_selection_matches_transaction_face(&runtime->editor_active_selection, entry);
 
     if (SDL_strcmp(entry->command, "delete") == 0)
-        return apply_editor_brush_delete(runtime, entry, forward);
+    {
+        if (forward)
+            sync_editor_selection_after_transaction(runtime, entry, forward);
+        if (!apply_editor_brush_delete(runtime, entry, forward))
+            return false;
+        if (!forward)
+            sync_editor_selection_after_transaction(runtime, entry, forward);
+        return true;
+    }
     if (SDL_strcmp(entry->command, "create") == 0 || SDL_strcmp(entry->command, "duplicate") == 0)
-        return apply_editor_brush_create(runtime, entry, forward);
+    {
+        if (!forward)
+            sync_editor_selection_after_transaction(runtime, entry, forward);
+        if (!apply_editor_brush_create(runtime, entry, forward))
+            return false;
+        if (forward)
+            sync_editor_selection_after_transaction(runtime, entry, forward);
+        return true;
+    }
     if (SDL_strcmp(entry->command, "sector_floor") == 0)
-        return apply_editor_brush_sector_floor(runtime, entry, forward);
+    {
+        if (!apply_editor_brush_sector_floor(runtime, entry, forward))
+            return false;
+        sync_editor_selection_after_transaction(runtime, entry, forward);
+        return true;
+    }
     if (SDL_strcmp(entry->command, "paint") == 0)
     {
         if (!apply_editor_brush_paint(runtime, entry, forward))
             return false;
         update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_face_matches);
+        sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
     if (SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0)
@@ -1142,6 +1308,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         if (!apply_editor_brush_face_resize(runtime, entry, forward))
             return false;
         resize_active_editor_selection_for_transaction(runtime, entry, forward, active_face_matches);
+        sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
     if (SDL_strcmp(entry->command, "rotate_y") == 0)
@@ -1150,6 +1317,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         if (!apply_editor_brush_rotate_y(runtime, entry, quarter_turns))
             return false;
         update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_element_matches);
+        sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
 
@@ -1157,6 +1325,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
     if (!apply_editor_brush_translate(runtime, entry, offset))
         return false;
     translate_active_editor_selection_for_transaction(runtime, entry, offset, active_element_matches);
+    sync_editor_selection_after_transaction(runtime, entry, forward);
     return true;
 }
 

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -662,8 +662,8 @@ static bool apply_editor_brush_paint(slayer3d_game_data_runtime *runtime, const 
     return false;
 }
 
-static bool apply_editor_brush_face_resize(slayer3d_game_data_runtime *runtime,
-                                           const editor_command_transaction_entry *entry, bool forward)
+static bool apply_editor_brush_face_resize(slayer3d_game_data_runtime *runtime, editor_command_transaction_entry *entry,
+                                           bool forward)
 {
     if (runtime == NULL || entry == NULL || entry->world_name == NULL || entry->element_name == NULL ||
         entry->face_index < 0)
@@ -675,20 +675,49 @@ static bool apply_editor_brush_face_resize(slayer3d_game_data_runtime *runtime,
     const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
                                      ? entry->element_stable_id
                                      : entry->element_name;
-    slayer3d_vec3 face_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-    int face_index = -1;
     if (world_runtime == NULL || !world_runtime->editor_has_source_model)
         return false;
 
+    if (!forward)
+    {
+        if (!entry->has_source_box_snapshot)
+            return false;
+        const int current_index = editor_brush_world_find_source_box_index(world_runtime, brush_identity);
+        if (current_index >= 0 && !editor_brush_world_remove_source_box_at_index(world_runtime, current_index, NULL, 0))
+            return false;
+        const int restored_index = SDL_clamp(entry->brush_index, 0, world_runtime->editor_source_box_count);
+        if (!editor_brush_world_insert_source_box_at_index(world_runtime, restored_index, &entry->source_box_snapshot,
+                                                           NULL, 0))
+        {
+            return false;
+        }
+        editor_brush_world_mark_dirty(world_runtime);
+        return true;
+    }
+
+    if (!entry->has_source_box_snapshot)
+    {
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity, &entry->source_box_snapshot,
+                                                            &entry->brush_index, NULL, 0))
+        {
+            return false;
+        }
+        entry->has_source_box_snapshot = true;
+    }
+
+    slayer3d_vec3 face_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    int face_index = -1;
     if (!editor_brush_world_source_box_face_normal_for_identity(world_runtime, brush_identity, entry->face_index,
                                                                 entry->face_stable_id, &face_index, &face_normal))
     {
         return false;
     }
-    const float distance =
-        slayer3d_vec3_dot(face_normal, forward ? entry->offset : slayer3d_vec3_scale(entry->offset, -1.0f));
-    if (!editor_brush_world_resize_source_box_face(world_runtime, brush_identity, face_normal, distance, NULL, 0))
+    const float distance = slayer3d_vec3_dot(face_normal, entry->offset);
+    if (!editor_brush_world_resize_source_face(world_runtime, brush_identity, entry->face_index, entry->face_stable_id,
+                                               distance, NULL, NULL, 0))
+    {
         return false;
+    }
     editor_brush_world_mark_dirty(world_runtime);
     return true;
 }

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -846,6 +846,7 @@ static void refresh_editor_brush_selection_for_identity(const brush_world_runtim
 
     const slayer3d_game_data_brush_world *world = &world_runtime->desc;
     selection->hit = false;
+    selection->type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
     selection->world_name = world->name;
     selection->world_editor = &world->editor;
     selection->element_name = NULL;
@@ -1102,7 +1103,8 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
     return (SDL_strcmp(entry->command, "translate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
-           (SDL_strcmp(entry->command, "create") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           ((SDL_strcmp(entry->command, "create") == 0 || SDL_strcmp(entry->command, "duplicate") == 0) &&
+            SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "delete") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "paint") == 0 && SDL_strcmp(entry->target, "face") == 0) ||
            ((SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0) &&
@@ -1124,7 +1126,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
 
     if (SDL_strcmp(entry->command, "delete") == 0)
         return apply_editor_brush_delete(runtime, entry, forward);
-    if (SDL_strcmp(entry->command, "create") == 0)
+    if (SDL_strcmp(entry->command, "create") == 0 || SDL_strcmp(entry->command, "duplicate") == 0)
         return apply_editor_brush_create(runtime, entry, forward);
     if (SDL_strcmp(entry->command, "sector_floor") == 0)
         return apply_editor_brush_sector_floor(runtime, entry, forward);
@@ -1740,6 +1742,187 @@ bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtim
     if (runtime->scene_state != NULL)
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", entry->message);
     return true;
+}
+
+static int editor_transaction_source_units_from_meters(const brush_world_runtime *world_runtime, float value)
+{
+    const float meters_per_unit = world_runtime != NULL && world_runtime->editor_source_meters_per_unit > 0.0f
+                                      ? world_runtime->editor_source_meters_per_unit
+                                      : 0.001f;
+    return (int)SDL_lroundf(value / meters_per_unit);
+}
+
+static void translate_editor_source_box_snapshot(editor_brush_source_box_runtime *box, const int delta[3])
+{
+    if (box == NULL || delta == NULL)
+        return;
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        box->min[axis] += delta[axis];
+        box->max[axis] += delta[axis];
+    }
+    for (int vertex = 0; vertex < box->vertex_count; ++vertex)
+    {
+        for (int axis = 0; axis < 3; ++axis)
+            box->vertices[vertex][axis] += delta[axis];
+    }
+}
+
+static bool assign_editor_source_box_snapshot_identity(editor_brush_source_box_runtime *box, const char *identity)
+{
+    if (box == NULL || identity == NULL || identity[0] == '\0')
+        return false;
+    char *stable_id = SDL_strdup(identity);
+    char *name = SDL_strdup(identity);
+    if (stable_id == NULL || name == NULL)
+    {
+        SDL_free(stable_id);
+        SDL_free(name);
+        return false;
+    }
+    SDL_free(box->stable_id);
+    SDL_free(box->name);
+    box->stable_id = stable_id;
+    box->name = name;
+    return true;
+}
+
+static bool append_editor_brush_duplicate_transaction(slayer3d_game_data_runtime *runtime, const char *active_scene,
+                                                      const slayer3d_game_data_editor_selection *selection,
+                                                      const int source_delta[3],
+                                                      editor_command_transaction_entry **out_entry)
+{
+    if (out_entry != NULL)
+        *out_entry = NULL;
+    if (runtime == NULL || selection == NULL || source_delta == NULL ||
+        !transaction_editor_selection_is_selectable_brush(selection))
+    {
+        return false;
+    }
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection->world_name);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+        return false;
+
+    const char *source_identity = editor_metadata_stable_id(selection->element_editor);
+    if (source_identity == NULL || source_identity[0] == '\0')
+        source_identity = selection->element_name;
+
+    editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+    if (entry == NULL)
+        return false;
+
+    char brush_name[256];
+    if (!editor_brush_world_generate_brush_name(world_runtime, brush_name, sizeof(brush_name)) ||
+        !editor_prepare_transaction_common(entry, active_scene, "duplicate", "element", selection->world_name,
+                                           brush_name) ||
+        !copy_editor_transaction_string(brush_name, &entry->element_stable_id) ||
+        !editor_brush_world_copy_source_box_by_identity(world_runtime, source_identity, &entry->source_box_snapshot,
+                                                        NULL, NULL, 0) ||
+        !assign_editor_source_box_snapshot_identity(&entry->source_box_snapshot, brush_name))
+    {
+        return false;
+    }
+
+    entry->has_source_box_snapshot = true;
+    translate_editor_source_box_snapshot(&entry->source_box_snapshot, source_delta);
+    if (!editor_brush_world_validate_source_box_candidate(world_runtime, &entry->source_box_snapshot, -1, NULL, 0))
+        return false;
+
+    entry->brush_index = world_runtime->editor_source_box_count;
+    entry->has_bounds = true;
+    entry->bounds = editor_brush_source_box_bounds_meters(world_runtime, &entry->source_box_snapshot);
+    const float meters_per_unit =
+        world_runtime->editor_source_meters_per_unit > 0.0f ? world_runtime->editor_source_meters_per_unit : 0.001f;
+    entry->offset =
+        slayer3d_vec3_make((float)source_delta[0] * meters_per_unit, (float)source_delta[1] * meters_per_unit,
+                           (float)source_delta[2] * meters_per_unit);
+    SDL_snprintf(entry->message, sizeof(entry->message), "duplicated %s", selection->element_name);
+    if (out_entry != NULL)
+        *out_entry = entry;
+    return true;
+}
+
+bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
+                                                          bool use_last_offset)
+{
+    if (runtime == NULL || runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+        return false;
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+        return false;
+
+    slayer3d_vec3 duplicate_offset = offset;
+    if (use_last_offset && runtime->editor_has_last_duplicate_offset &&
+        slayer3d_vec3_length_squared(offset) <= 0.0000001f)
+    {
+        duplicate_offset = runtime->editor_last_duplicate_offset;
+    }
+
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int source_delta[3] = {0, 0, 0};
+    int applied_count = 0;
+    slayer3d_game_data_editor_selection duplicated[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+    SDL_zeroa(duplicated);
+
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection selection = runtime->editor_selected_brushes[i];
+        const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, selection.world_name);
+        if (world_runtime == NULL)
+            goto fail;
+
+        source_delta[0] = editor_transaction_source_units_from_meters(world_runtime, duplicate_offset.x);
+        source_delta[1] = editor_transaction_source_units_from_meters(world_runtime, duplicate_offset.y);
+        source_delta[2] = editor_transaction_source_units_from_meters(world_runtime, duplicate_offset.z);
+
+        editor_command_transaction_entry *entry = NULL;
+        if (!append_editor_brush_duplicate_transaction(runtime, active_scene, &selection, source_delta, &entry) ||
+            !apply_editor_transaction_mutation(runtime, entry, true))
+        {
+            goto fail;
+        }
+
+        brush_world_runtime *mutable_world = find_brush_world_runtime_mutable(runtime, entry->world_name);
+        init_editor_selection(&duplicated[applied_count]);
+        refresh_editor_brush_selection_for_identity(mutable_world, &duplicated[applied_count], entry->element_name,
+                                                    entry->element_stable_id, -1, NULL);
+        applied_count++;
+    }
+
+    clear_editor_selected_brushes(runtime);
+    runtime->editor_selected_brush_scene = active_scene;
+    for (int i = 0; i < applied_count; ++i)
+    {
+        if (duplicated[i].hit)
+            (void)add_editor_selected_brush(runtime, &duplicated[i]);
+    }
+    update_active_editor_selection_from_selected_brushes(runtime);
+
+    if (slayer3d_vec3_length_squared(duplicate_offset) > 0.0000001f)
+    {
+        runtime->editor_last_duplicate_offset = duplicate_offset;
+        runtime->editor_has_last_duplicate_offset = true;
+    }
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "duplicated 1 selected brush" : "duplicated %d selected brushes",
+                     applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
 }
 
 bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset)

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -400,6 +400,170 @@ static int editor_face_index_for_identity(const slayer3d_game_data_brush *brush,
     return face_index >= 0 && face_index < brush->face_count ? face_index : -1;
 }
 
+static void refresh_editor_brush_selection_for_identity(const brush_world_runtime *world_runtime,
+                                                        slayer3d_game_data_editor_selection *selection,
+                                                        const char *brush_name, const char *brush_stable_id,
+                                                        int face_index, const char *face_stable_id);
+static void publish_editor_transaction_selection_state(slayer3d_game_data_runtime *runtime);
+
+typedef struct editor_selection_identity_snapshot
+{
+    bool valid;
+    char *world_name;
+    char *element_name;
+    char *element_stable_id;
+    char *face_stable_id;
+    int face_index;
+} editor_selection_identity_snapshot;
+
+static void free_editor_selection_identity_snapshot(editor_selection_identity_snapshot *snapshot)
+{
+    if (snapshot == NULL)
+        return;
+    SDL_free(snapshot->world_name);
+    SDL_free(snapshot->element_name);
+    SDL_free(snapshot->element_stable_id);
+    SDL_free(snapshot->face_stable_id);
+    SDL_zero(*snapshot);
+    snapshot->face_index = -1;
+}
+
+static bool copy_optional_editor_snapshot_string(const char *value, char **out_value)
+{
+    if (out_value == NULL)
+        return false;
+    *out_value = NULL;
+    if (value == NULL)
+        return true;
+    *out_value = SDL_strdup(value);
+    return *out_value != NULL;
+}
+
+static bool capture_editor_selection_identity(const slayer3d_game_data_editor_selection *selection,
+                                              editor_selection_identity_snapshot *snapshot)
+{
+    if (snapshot == NULL)
+        return false;
+    SDL_zero(*snapshot);
+    snapshot->face_index = -1;
+    if (!editor_selection_is_selectable_brush(selection))
+        return true;
+
+    const char *element_stable_id = editor_metadata_stable_id(selection->element_editor);
+    const char *face_stable_id = editor_metadata_stable_id(selection->face_editor);
+    if (!copy_optional_editor_snapshot_string(selection->world_name, &snapshot->world_name) ||
+        !copy_optional_editor_snapshot_string(selection->element_name, &snapshot->element_name) ||
+        !copy_optional_editor_snapshot_string(element_stable_id, &snapshot->element_stable_id) ||
+        !copy_optional_editor_snapshot_string(face_stable_id, &snapshot->face_stable_id))
+    {
+        free_editor_selection_identity_snapshot(snapshot);
+        return false;
+    }
+
+    snapshot->valid = true;
+    snapshot->face_index = selection->face_index;
+    return true;
+}
+
+static void refresh_editor_brush_selection_for_snapshot(const slayer3d_game_data_runtime *runtime,
+                                                        slayer3d_game_data_editor_selection *selection,
+                                                        const editor_selection_identity_snapshot *snapshot)
+{
+    if (selection == NULL)
+        return;
+    init_editor_selection(selection);
+    if (runtime == NULL || snapshot == NULL || !snapshot->valid || snapshot->world_name == NULL)
+        return;
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, snapshot->world_name);
+    refresh_editor_brush_selection_for_identity(world_runtime, selection, snapshot->element_name,
+                                                snapshot->element_stable_id, snapshot->face_index,
+                                                snapshot->face_stable_id);
+}
+
+static bool capture_current_editor_selection_snapshots(
+    const slayer3d_game_data_runtime *runtime,
+    editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY],
+    int *out_selected_count, editor_selection_identity_snapshot *active_snapshot)
+{
+    if (out_selected_count != NULL)
+        *out_selected_count = 0;
+    if (runtime == NULL || selected_snapshots == NULL || out_selected_count == NULL || active_snapshot == NULL)
+        return false;
+
+    SDL_memset(selected_snapshots, 0, sizeof(selected_snapshots[0]) * SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY);
+    SDL_zero(*active_snapshot);
+    active_snapshot->face_index = -1;
+
+    const int selected_count =
+        editor_selected_brushes_active_for_scene(runtime) ? runtime->editor_selected_brush_count : 0;
+    for (int i = 0; i < selected_count; ++i)
+    {
+        if (!capture_editor_selection_identity(&runtime->editor_selected_brushes[i], &selected_snapshots[i]))
+        {
+            for (int cleanup = 0; cleanup < i; ++cleanup)
+                free_editor_selection_identity_snapshot(&selected_snapshots[cleanup]);
+            return false;
+        }
+    }
+    *out_selected_count = selected_count;
+
+    if (!capture_editor_selection_identity(&runtime->editor_active_selection, active_snapshot))
+    {
+        for (int cleanup = 0; cleanup < selected_count; ++cleanup)
+            free_editor_selection_identity_snapshot(&selected_snapshots[cleanup]);
+        return false;
+    }
+    return true;
+}
+
+static void free_current_editor_selection_snapshots(
+    editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY], int selected_count,
+    editor_selection_identity_snapshot *active_snapshot)
+{
+    if (selected_snapshots != NULL)
+    {
+        for (int i = 0; i < selected_count; ++i)
+            free_editor_selection_identity_snapshot(&selected_snapshots[i]);
+    }
+    free_editor_selection_identity_snapshot(active_snapshot);
+}
+
+static void refresh_editor_selections_from_snapshots(
+    slayer3d_game_data_runtime *runtime,
+    const editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY],
+    int selected_count, const editor_selection_identity_snapshot *active_snapshot)
+{
+    if (runtime == NULL)
+        return;
+
+    bool selected_changed = false;
+    for (int i = selected_count - 1; i >= 0 && i < runtime->editor_selected_brush_count; --i)
+    {
+        refresh_editor_brush_selection_for_snapshot(runtime, &runtime->editor_selected_brushes[i],
+                                                    &selected_snapshots[i]);
+        if (!runtime->editor_selected_brushes[i].hit)
+        {
+            remove_editor_selected_brush_at(runtime, i);
+            selected_changed = true;
+        }
+    }
+
+    if (active_snapshot != NULL && active_snapshot->valid)
+    {
+        refresh_editor_brush_selection_for_snapshot(runtime, &runtime->editor_active_selection, active_snapshot);
+        runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
+        selected_changed = true;
+    }
+    else if (selected_changed)
+    {
+        update_active_editor_selection_from_selected_brushes(runtime);
+    }
+
+    if (selected_changed)
+        publish_editor_transaction_selection_state(runtime);
+}
+
 static bool editor_selection_matches_transaction_element(const slayer3d_game_data_editor_selection *selection,
                                                          const editor_command_transaction_entry *entry)
 {
@@ -1272,8 +1436,22 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
     {
         if (forward)
             sync_editor_selection_after_transaction(runtime, entry, forward);
-        if (!apply_editor_brush_delete(runtime, entry, forward))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_delete(runtime, entry, forward))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         if (!forward)
             sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
@@ -1282,31 +1460,87 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
     {
         if (!forward)
             sync_editor_selection_after_transaction(runtime, entry, forward);
-        if (!apply_editor_brush_create(runtime, entry, forward))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_create(runtime, entry, forward))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         if (forward)
             sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
     if (SDL_strcmp(entry->command, "sector_floor") == 0)
     {
-        if (!apply_editor_brush_sector_floor(runtime, entry, forward))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_sector_floor(runtime, entry, forward))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
     if (SDL_strcmp(entry->command, "paint") == 0)
     {
-        if (!apply_editor_brush_paint(runtime, entry, forward))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_paint(runtime, entry, forward))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_face_matches);
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
     if (SDL_strcmp(entry->command, "resize") == 0 || SDL_strcmp(entry->command, "extrude") == 0)
     {
-        if (!apply_editor_brush_face_resize(runtime, entry, forward))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_face_resize(runtime, entry, forward))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         resize_active_editor_selection_for_transaction(runtime, entry, forward, active_face_matches);
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
@@ -1314,16 +1548,43 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
     if (SDL_strcmp(entry->command, "rotate_y") == 0)
     {
         const int quarter_turns = forward ? entry->rotation_quarter_turns : -entry->rotation_quarter_turns;
-        if (!apply_editor_brush_rotate_y(runtime, entry, quarter_turns))
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
             return false;
+        }
+        if (!apply_editor_brush_rotate_y(runtime, entry, quarter_turns))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
         update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_element_matches);
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
 
     const slayer3d_vec3 offset = forward ? entry->offset : slayer3d_vec3_scale(entry->offset, -1.0f);
-    if (!apply_editor_brush_translate(runtime, entry, offset))
+    editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+    editor_selection_identity_snapshot active_snapshot;
+    int selected_snapshot_count = 0;
+    if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                    &active_snapshot))
+    {
         return false;
+    }
+    if (!apply_editor_brush_translate(runtime, entry, offset))
+    {
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+        return false;
+    }
+    refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count, &active_snapshot);
+    free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
     translate_active_editor_selection_for_transaction(runtime, entry, offset, active_element_matches);
     sync_editor_selection_after_transaction(runtime, entry, forward);
     return true;

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -107,6 +107,8 @@ bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtim
                                                        editor_brush_source_prefab_result *out_result);
 bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
 bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);
+bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
+                                                          bool use_last_offset);
 void editor_set_string_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, const char *value);
 void editor_set_bool_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, bool value);
 void editor_set_int_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, int value);

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -114,5 +114,6 @@ void editor_set_bool_output(slayer3d_properties *props, yyjson_val *outputs, con
 void editor_set_int_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, int value);
 void editor_set_float_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, float value);
 void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, slayer3d_vec3 value);
+void editor_publish_console_message(slayer3d_game_data_runtime *runtime, const char *message);
 
 #endif

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -1,5 +1,7 @@
 #include "game_data_internal.h"
 
+#include <SDL3/SDL_log.h>
+
 void editor_set_string_output(slayer3d_properties *props, yyjson_val *outputs, const char *key_name, const char *value)
 {
     const char *key = json_string(outputs, key_name, NULL);
@@ -33,6 +35,21 @@ void editor_set_vec3_output(slayer3d_properties *props, yyjson_val *outputs, con
     const char *key = json_string(outputs, key_name, NULL);
     if (props != NULL && key != NULL)
         slayer3d_properties_set_vec3(props, key, value);
+}
+
+void editor_publish_console_message(slayer3d_game_data_runtime *runtime, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || message == NULL || message[0] == '\0')
+        return;
+
+    const char *old_line0 = slayer3d_properties_get_string(runtime->scene_state, "editor.console.line0", "");
+    const char *old_line1 = slayer3d_properties_get_string(runtime->scene_state, "editor.console.line1", "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.console.line2", old_line1);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.console.line1", old_line0);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.console.line0", message);
+    slayer3d_properties_set_int(runtime->scene_state, "editor.console.count",
+                                slayer3d_properties_get_int(runtime->scene_state, "editor.console.count", 0) + 1);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%s", message);
 }
 
 static int editor_revision_to_int(Uint64 revision)

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -41,6 +41,15 @@ static yyjson_val *editor_drag_create_json(yyjson_val *placement)
     return yyjson_is_obj(drag) ? drag : NULL;
 }
 
+static slayer3d_vec3 editor_preview_dimensions(const editor_placement_preview_state *preview)
+{
+    if (preview == NULL || !preview->has_bounds)
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    return slayer3d_vec3_make(SDL_max(0.0f, preview->bounds.max.x - preview->bounds.min.x),
+                              SDL_max(0.0f, preview->bounds.max.y - preview->bounds.min.y),
+                              SDL_max(0.0f, preview->bounds.max.z - preview->bounds.min.z));
+}
+
 static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,
                                              yyjson_val *preview_json, const editor_placement_preview_state *preview,
                                              const char *message)
@@ -68,6 +77,13 @@ static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime
                                                                            : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
     editor_set_int_output(scene_state, outputs, "overlap_count_key",
                           valid && preview != NULL ? preview->source_positive_overlap_count : 0);
+    const slayer3d_vec3 dimensions = valid ? editor_preview_dimensions(preview) : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    editor_set_vec3_output(scene_state, outputs, "dimensions_key", dimensions);
+    editor_set_float_output(scene_state, outputs, "dimension_x_key", dimensions.x);
+    editor_set_float_output(scene_state, outputs, "dimension_y_key", dimensions.y);
+    editor_set_float_output(scene_state, outputs, "dimension_z_key", dimensions.z);
+    editor_set_string_output(scene_state, outputs, "warning_key",
+                             valid && preview != NULL ? preview->source_warning : "");
     const char *last_action_key = json_string(preview_json, "last_action_key", NULL);
     if (last_action_key != NULL && last_action_key[0] != '\0')
         slayer3d_properties_set_string(scene_state, last_action_key, message != NULL ? message : "");
@@ -488,7 +504,12 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
                 runtime->scene_state != NULL)
             {
                 slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "drag brush created");
+                editor_publish_console_message(runtime, "drag brush created");
             }
+        }
+        else if (drag->moved && message[0] != '\0')
+        {
+            editor_publish_console_message(runtime, message);
         }
         clear_editor_drag_create(runtime);
         clear_editor_placement_preview(runtime);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -412,7 +412,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         return false;
 
     const char *mode = scene_state_string(runtime, "editor.mode", "select");
-    if (SDL_strcmp(mode, "select") != 0)
+    if (SDL_strcmp(mode, "select") != 0 && SDL_strcmp(mode, "brush") != 0)
     {
         clear_editor_drag_create(runtime);
         return true;

--- a/src/game_data_editor_selection_helpers.c
+++ b/src/game_data_editor_selection_helpers.c
@@ -8,6 +8,11 @@
 #include <SDL3/SDL_keyboard.h>
 #include <SDL3/SDL_stdinc.h>
 
+static bool editor_selection_additive_modifier_active(void)
+{
+    return (SDL_GetModState() & (SDL_KMOD_SHIFT | SDL_KMOD_CTRL | SDL_KMOD_GUI)) != 0;
+}
+
 bool editor_selection_is_selectable_brush(const slayer3d_game_data_editor_selection *selection)
 {
     return selection != NULL && selection->hit && selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD &&
@@ -111,7 +116,7 @@ void update_active_editor_selection_from_selected_brushes(slayer3d_game_data_run
 bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime,
                                       const slayer3d_game_data_editor_selection *hover_selection)
 {
-    const bool shift = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
+    const bool additive = editor_selection_additive_modifier_active();
     if (!editor_selection_is_selectable_brush(hover_selection))
     {
         if (hover_selection != NULL && hover_selection->hit &&
@@ -122,7 +127,7 @@ bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime,
             runtime->editor_selection_scene = slayer3d_game_data_active_scene(runtime);
             return true;
         }
-        if (!shift)
+        if (!additive)
             clear_editor_active_selection(runtime);
         return true;
     }
@@ -135,7 +140,7 @@ bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime,
         return true;
     }
 
-    if (!shift)
+    if (!additive)
         clear_editor_selected_brushes(runtime);
     if (!add_editor_selected_brush(runtime, hover_selection))
         return false;

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -86,51 +86,80 @@ bool editor_handle_prefabs_widget(slayer3d_game_data_runtime *runtime, yyjson_va
     return true;
 }
 
-static bool editor_apply_tool_action(slayer3d_game_data_runtime *runtime, const char *action)
+static const char *editor_mode_for_tool_action(const char *action)
 {
-    const char *mode = NULL;
-    const char *tool_mode = NULL;
-    const char *message = NULL;
     if (SDL_strcmp(action, "editor.tool.select") == 0)
+        return "select";
+    if (SDL_strcmp(action, "editor.tool.brush") == 0)
+        return "brush";
+    if (SDL_strcmp(action, "editor.tool.face") == 0)
+        return "face";
+    if (SDL_strcmp(action, "editor.tool.vertex") == 0)
+        return "vertex";
+    if (SDL_strcmp(action, "editor.tool.texture") == 0)
+        return "texture";
+    return NULL;
+}
+
+bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime, const char *mode,
+                                             const char *message_override)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || mode == NULL || mode[0] == '\0')
+        return false;
+
+    const char *tool_mode = mode;
+    const char *message = message_override;
+    if (SDL_strcmp(mode, "select") == 0)
     {
-        mode = "select";
         tool_mode = "select";
-        message = "select mode";
+        if (message == NULL || message[0] == '\0')
+            message = "select mode";
     }
-    else if (SDL_strcmp(action, "editor.tool.brush") == 0)
+    else if (SDL_strcmp(mode, "brush") == 0)
     {
-        mode = "brush";
         tool_mode = "brush";
-        message = "brush tool";
+        if (message == NULL || message[0] == '\0')
+            message = "brush tool";
     }
-    else if (SDL_strcmp(action, "editor.tool.face") == 0)
+    else if (SDL_strcmp(mode, "face") == 0)
     {
-        mode = "face";
         tool_mode = "face";
-        message = "face tool";
+        if (message == NULL || message[0] == '\0')
+            message = "face tool";
     }
-    else if (SDL_strcmp(action, "editor.tool.vertex") == 0)
+    else if (SDL_strcmp(mode, "vertex") == 0)
     {
-        mode = "vertex";
         tool_mode = "vertex";
-        message = "vertex tool";
+        if (message == NULL || message[0] == '\0')
+        {
+            const int selected_count = slayer3d_properties_get_int(runtime->scene_state, "editor.selection.count", 0);
+            message = selected_count > 0 ? "vertex tool" : "select a brush before vertex tool";
+        }
     }
-    else if (SDL_strcmp(action, "editor.tool.texture") == 0)
+    else if (SDL_strcmp(mode, "texture") == 0)
     {
-        mode = "texture";
         tool_mode = "paint";
-        message = "texture tool";
+        if (message == NULL || message[0] == '\0')
+            message = "texture tool";
     }
     else
     {
         return false;
     }
 
+    if (SDL_strcmp(mode, "vertex") != 0)
+        (void)slayer3d_game_data_clear_editor_vertex_selection(runtime);
     slayer3d_properties_set_string(runtime->scene_state, "editor.mode", mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.mode", tool_mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     clear_editor_command_preview(runtime);
     return true;
+}
+
+static bool editor_apply_tool_action(slayer3d_game_data_runtime *runtime, const char *action)
+{
+    const char *mode = editor_mode_for_tool_action(action);
+    return mode != NULL && slayer3d_game_data_set_editor_tool_mode(runtime, mode, NULL);
 }
 
 bool editor_handle_tool_mode_buttons(slayer3d_game_data_runtime *runtime, yyjson_val *editor, bool *out_consumed)
@@ -173,14 +202,9 @@ bool editor_handle_tool_mode_buttons(slayer3d_game_data_runtime *runtime, yyjson
             return true;
 
         const char *mode = json_string(button, "mode", NULL);
-        const char *tool_mode = json_string(button, "tool_mode", mode);
-        if (mode == NULL || mode[0] == '\0' || tool_mode == NULL || tool_mode[0] == '\0')
+        if (mode == NULL || mode[0] == '\0')
             return true;
-        slayer3d_properties_set_string(runtime->scene_state, "editor.mode", mode);
-        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.mode", tool_mode);
-        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
-                                       json_string(button, "message", "tool mode"));
-        clear_editor_command_preview(runtime);
+        (void)slayer3d_game_data_set_editor_tool_mode(runtime, mode, json_string(button, "message", NULL));
         return true;
     }
     return true;

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -78,6 +78,7 @@ typedef struct editor_drag_move_state
     bool axis_lock_y;
     bool axis_lock_dominant;
     bool face_resize;
+    bool duplicate_drag;
     bool vertex_drag;
     bool vertex_add_drag;
     bool vertex_lasso;

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -161,6 +161,8 @@ typedef struct slayer3d_game_data_runtime
     editor_drag_create_state editor_drag_create;
     editor_drag_move_state editor_drag_move;
     editor_camera_orbit_state editor_camera_orbit;
+    bool editor_has_last_duplicate_offset;
+    slayer3d_vec3 editor_last_duplicate_offset;
     editor_command_history_state editor_command_history;
     scene_activity_state activity;
     float current_dt;

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -969,6 +969,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("console.write", validate_console_write_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.clear", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.selection.clear", validate_noop_action),
+        ACTION_RULE_EXACT_HANDLER("editor.tool.set_mode", validate_editor_tool_set_mode_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.delete_selected", validate_editor_vertex_delete_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.merge_selected_to_hover",
                                   validate_editor_vertex_merge_selected_to_hover_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -148,6 +148,28 @@ bool validate_editor_vertex_snap_selected_action(validation_context *ctx, yyjson
     return validate_optional_output_keys(ctx, action, json_path, type, output_fields, SDL_arraysize(output_fields));
 }
 
+static bool editor_tool_mode_valid(const char *mode)
+{
+    return mode != NULL &&
+           (SDL_strcmp(mode, "select") == 0 || SDL_strcmp(mode, "brush") == 0 || SDL_strcmp(mode, "face") == 0 ||
+            SDL_strcmp(mode, "vertex") == 0 || SDL_strcmp(mode, "texture") == 0);
+}
+
+bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                          validation_names *names, const char *type)
+{
+    (void)names;
+    (void)type;
+    const char *mode = json_string(action, "mode");
+    if (!editor_tool_mode_valid(mode))
+        return validation_error(ctx, json_path,
+                                "editor.tool.set_mode mode must be one of select, brush, face, vertex, texture");
+    yyjson_val *message = obj_get(action, "message");
+    if (message != NULL && (!yyjson_is_str(message) || yyjson_get_str(message)[0] == '\0'))
+        return validation_error(ctx, json_path, "editor.tool.set_mode message must be non-empty");
+    return true;
+}
+
 static bool validate_optional_action_branches(validation_context *ctx, yyjson_val *action, const char *json_path,
                                               validation_names *names, bool require_actions)
 {

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -19,6 +19,8 @@ bool validate_editor_vertex_validate_source_action(validation_context *ctx, yyjs
                                                    validation_names *names, const char *type);
 bool validate_editor_vertex_snap_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                  validation_names *names, const char *type);
+bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                          validation_names *names, const char *type);
 bool validate_editor_selection_select_brush_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                    validation_names *names, const char *type);
 bool validate_editor_selection_delete_selected_action(validation_context *ctx, yyjson_val *action,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -18525,6 +18525,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int grid_increase_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.grid.increase");
     const int wall_axis_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.wall_axis.toggle");
     const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
+    const int delete_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.delete_selected");
     const int escape_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.escape");
     const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
     const int mode_face_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.face");
@@ -18550,6 +18551,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GE(grid_increase_signal, 0);
     ASSERT_GE(wall_axis_signal, 0);
     ASSERT_GE(clear_selection_signal, 0);
+    ASSERT_GE(delete_signal, 0);
     ASSERT_GE(escape_signal, 0);
     ASSERT_GE(mode_brush_signal, 0);
     ASSERT_GE(mode_face_signal, 0);
@@ -18573,8 +18575,10 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
     const int export_action_id = slayer3d_game_data_find_action(runtime, "action.editor.export");
+    const int brush_mode_action_id = slayer3d_game_data_find_action(runtime, "action.editor.mode.brush");
     const int select_mode_action_id = slayer3d_game_data_find_action(runtime, "action.editor.mode.select");
     ASSERT_GE(export_action_id, 0);
+    ASSERT_GE(brush_mode_action_id, 0);
     ASSERT_GE(select_mode_action_id, 0);
     auto press_save_chord = [&](SDL_Keymod modifiers, Uint64 frame) {
         SDL_SetModState(modifiers);
@@ -18598,6 +18602,19 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         slayer3d_input_process_event(input, &key);
         slayer3d_input_update(input, frame);
         const bool pressed = slayer3d_input_is_pressed(input, select_mode_action_id);
+        EXPECT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+        key.type = SDL_EVENT_KEY_UP;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, frame + 1U);
+        return pressed;
+    };
+    auto press_key_for_action = [&](SDL_Scancode scancode, int action_id, Uint64 frame) {
+        SDL_Event key{};
+        key.type = SDL_EVENT_KEY_DOWN;
+        key.key.scancode = scancode;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, frame);
+        const bool pressed = slayer3d_input_is_pressed(input, action_id);
         EXPECT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
         key.type = SDL_EVENT_KEY_UP;
         slayer3d_input_process_event(input, &key);
@@ -18770,6 +18787,12 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.elevation", 1.0f), 0.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.thickness", 0.0f), 0.2f, 0.001f);
 
+    EXPECT_TRUE(press_key_for_action(SDL_SCANCODE_B, brush_mode_action_id, 105));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "brush");
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+
     slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "brush");
@@ -18824,6 +18847,21 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "select mode");
+
+    seed_editor_shell_test_cube(runtime);
+    select_editor_shell_test_cube(runtime);
+    EXPECT_EQ(world().brush_count, 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
+    slayer3d_signal_emit(bus, delete_signal, nullptr);
+    EXPECT_EQ(world().brush_count, 0);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.transaction.command", ""), "delete");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.undo_count", -1), 1);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "deleted 1 selected brush");
+    slayer3d_signal_emit(bus, escape_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
 
     slayer3d_signal_emit(bus, palette_brush_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "brush");

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -230,6 +230,12 @@ extern "C"
                                                            const char *material_name, unsigned int contents,
                                                            const int source_min[3], const int source_max[3],
                                                            editor_brush_source_prefab_result *out_result);
+    bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
+                                                              bool use_last_offset);
+    bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                const slayer3d_properties *payload);
+    bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                const slayer3d_properties *payload);
     bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_snap_selected_editor_vertices(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_data_runtime *runtime,
@@ -20046,6 +20052,161 @@ TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
     EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
 
     SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    editor_brush_source_prefab_result source_result{};
+    const int source_min[3] = {0, 0, 0};
+    const int source_max[3] = {1000, 1000, 1000};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, source_min,
+        source_max, &source_result));
+    ASSERT_TRUE(source_result.valid);
+    ASSERT_STRNE(source_result.brush_name, "");
+
+    auto brush_world = [&]() {
+        slayer3d_game_data_brush_world world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+        return world;
+    };
+    auto brush_index = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return i;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return -1;
+    };
+    auto brush_exists = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return true;
+        }
+        return false;
+    };
+    auto brush_bounds = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return slayer3d_bounding_box{};
+    };
+    auto first_face_material = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+            {
+                EXPECT_GT(brush.face_count, 0);
+                EXPECT_NE(brush.faces, nullptr);
+                return brush.faces != nullptr && brush.face_count > 0 ? brush.faces[0].material_name : nullptr;
+            }
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return (const char *)NULL;
+    };
+
+    slayer3d_game_data_editor_selection source_selection{};
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(source_result.brush_name), -1, &source_selection));
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &source_selection));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+
+    const slayer3d_bounding_box source_bounds = brush_bounds(source_result.brush_name);
+    const int initial_brush_count = brush_world().brush_count;
+    ASSERT_TRUE(
+        slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(2.0f, 0.0f, 0.0f), false));
+    ASSERT_EQ(brush_world().brush_count, initial_brush_count + 1);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "duplicated 1 selected brush");
+
+    slayer3d_game_data_editor_selection duplicate_selection{};
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &duplicate_selection));
+    ASSERT_STRNE(duplicate_selection.element_name, source_result.brush_name);
+    ASSERT_NE(duplicate_selection.element_editor, nullptr);
+    EXPECT_STREQ(duplicate_selection.element_name, duplicate_selection.element_editor->stable_id);
+    const std::string first_duplicate_name = duplicate_selection.element_name;
+
+    const slayer3d_bounding_box first_duplicate_bounds = brush_bounds(first_duplicate_name.c_str());
+    EXPECT_NEAR(first_duplicate_bounds.min.x, source_bounds.min.x + 2.0f, 0.001f);
+    EXPECT_NEAR(first_duplicate_bounds.max.x, source_bounds.max.x + 2.0f, 0.001f);
+    EXPECT_NEAR(first_duplicate_bounds.min.y, source_bounds.min.y, 0.001f);
+    EXPECT_NEAR(first_duplicate_bounds.max.y, source_bounds.max.y, 0.001f);
+    EXPECT_STREQ(first_face_material(first_duplicate_name.c_str()), "mat.editor.wall");
+
+    ASSERT_TRUE(
+        slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), true));
+    ASSERT_EQ(brush_world().brush_count, initial_brush_count + 2);
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &duplicate_selection));
+    const std::string second_duplicate_name = duplicate_selection.element_name;
+    ASSERT_STRNE(second_duplicate_name.c_str(), first_duplicate_name.c_str());
+    const slayer3d_bounding_box second_duplicate_bounds = brush_bounds(second_duplicate_name.c_str());
+    EXPECT_NEAR(second_duplicate_bounds.min.x, first_duplicate_bounds.min.x + 2.0f, 0.001f);
+    EXPECT_NEAR(second_duplicate_bounds.max.x, first_duplicate_bounds.max.x + 2.0f, 0.001f);
+    EXPECT_STREQ(first_face_material(second_duplicate_name.c_str()), "mat.editor.wall");
+
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count + 1);
+    EXPECT_FALSE(brush_exists(second_duplicate_name.c_str()));
+
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count + 2);
+    EXPECT_TRUE(brush_exists(second_duplicate_name.c_str()));
+    EXPECT_STREQ(first_face_material(second_duplicate_name.c_str()), "mat.editor.wall");
+
+    slayer3d_game_data_editor_selection redo_selection{};
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(second_duplicate_name.c_str()), -1, &redo_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &redo_selection));
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_D;
+    key.key.mod = SDL_KMOD_CTRL;
+    SDL_SetModState(SDL_KMOD_CTRL);
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    key.type = SDL_EVENT_KEY_UP;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count + 3);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "duplicated 1 selected brush");
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16788,7 +16788,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoFaceDragMapsUpwardMouseMotionToPositiveResize)
+TEST(GameDataRuntime, EditorShellDojoFaceDragUsesProjectedFaceNormalDirection)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -16822,6 +16822,21 @@ TEST(GameDataRuntime, EditorShellDojoFaceDragMapsUpwardMouseMotionToPositiveResi
     slayer3d_input_update(input, 1);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
+    const slayer3d_value *selection_normal = slayer3d_properties_get_value(scene_state, "editor.selection.normal");
+    ASSERT_NE(selection_normal, nullptr);
+    ASSERT_EQ(selection_normal->type, SLAYER3D_VALUE_VEC3);
+    slayer3d_camera3d camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, slayer3d_game_data_active_camera(runtime), &camera));
+    const slayer3d_vec3 forward = slayer3d_vec3_normalize(slayer3d_vec3_sub(camera.target, camera.position));
+    const slayer3d_vec3 right = slayer3d_vec3_normalize(slayer3d_vec3_cross(forward, camera.up));
+    const slayer3d_vec3 up_direction = slayer3d_vec3_normalize(slayer3d_vec3_cross(right, forward));
+    const float projected_x = slayer3d_vec3_dot(selection_normal->as_vec3, right);
+    const float projected_y = -slayer3d_vec3_dot(selection_normal->as_vec3, up_direction);
+    const float projected_length = SDL_sqrtf(projected_x * projected_x + projected_y * projected_y);
+    ASSERT_GT(projected_length, 0.000001f);
+    ASSERT_GT(SDL_fabsf(projected_x), SDL_fabsf(projected_y)) << "fixture should exercise horizontal face swipes";
+    const float drag_x = projected_x / projected_length * 48.0f;
+    const float drag_y = projected_y / projected_length * 48.0f;
 
     SDL_Event down{};
     down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
@@ -16832,13 +16847,15 @@ TEST(GameDataRuntime, EditorShellDojoFaceDragMapsUpwardMouseMotionToPositiveResi
     slayer3d_input_update(input, 2);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
 
-    motion.motion.y = 292.0f;
+    motion.motion.x = 640.0f + drag_x;
+    motion.motion.y = 340.0f + drag_y;
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 3);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.resize.distance", 0.0f), 1.0f, 0.001f);
 
-    motion.motion.y = 388.0f;
+    motion.motion.x = 640.0f - drag_x;
+    motion.motion.y = 340.0f - drag_y;
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 4);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19703,10 +19703,14 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
     ASSERT_NE(bus, nullptr);
     const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
     ASSERT_GE(clear_selection_signal, 0);
+    ASSERT_GE(mode_brush_signal, 0);
     slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
 
     const slayer3d_bounding_box before_drag_move = find_brush_bounds(created_name);
     mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -22368,18 +22368,21 @@ TEST(GameDataRuntime, EditableLevelFragmentMvpGrayboxRoundTripsSourceOnlyForTest
         runtime, "brush.editor_shell.target", &export_json, &export_size, error, sizeof(error)))
         << error;
     ASSERT_NE(export_json, nullptr);
-    EXPECT_NE(std::string(export_json, export_size).find("\"editor_brush_sources\""), std::string::npos);
-    EXPECT_NE(std::string(export_json, export_size).find("\"room.sky.ceiling\""), std::string::npos);
+    const std::string exported_graybox(export_json, export_size);
+    SDL_free(export_json);
+    export_json = nullptr;
+    export_size = exported_graybox.size();
+    EXPECT_NE(exported_graybox.find("\"editor_brush_sources\""), std::string::npos);
+    EXPECT_NE(exported_graybox.find("\"room.sky.ceiling\""), std::string::npos);
 
     slayer3d_game_data_destroy(runtime);
     runtime = nullptr;
     ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
         << error;
-    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", export_json,
-                                                                     export_size, "/tmp/mvp-graybox-roundtrip.json",
-                                                                     error, sizeof(error)))
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", exported_graybox.c_str(), exported_graybox.size(),
+        "/tmp/mvp-graybox-roundtrip.json", error, sizeof(error)))
         << error;
-    SDL_free(export_json);
 
     SDL_zero(diagnostics);
     ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
@@ -22418,7 +22421,96 @@ TEST(GameDataRuntime, EditableLevelFragmentMvpGrayboxRoundTripsSourceOnlyForTest
     SDL_free(manifest_json);
 
     slayer3d_game_data_destroy(runtime);
+    runtime = nullptr;
     slayer3d_game_session_destroy(session);
+    session = nullptr;
+
+    const std::filesystem::path save_dir = unique_test_dir("mvp_graybox_acceptance");
+    const std::filesystem::path save_path = save_dir / "level.fragment.json";
+    const std::string root = dojo_path.parent_path().string();
+    const std::string asset_path = std::string("asset://") + dojo_path.filename().string();
+
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", exported_graybox.c_str(), exported_graybox.size(),
+        "/tmp/mvp-graybox-save-source.json", error, sizeof(error)))
+        << error;
+    size_t saved_size = 0u;
+    ASSERT_TRUE(slayer3d_game_data_save_editable_level_fragment_file(
+        runtime, "brush.editor_shell.target", save_path.string().c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    EXPECT_GT(saved_size, 0u);
+    EXPECT_TRUE(std::filesystem::exists(save_path));
+    slayer3d_game_data_destroy(runtime);
+    runtime = nullptr;
+    slayer3d_game_session_destroy(session);
+    session = nullptr;
+
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_properties *initial_state = slayer3d_properties_create();
+    ASSERT_NE(initial_state, nullptr);
+    slayer3d_properties_set_string(initial_state, "editor.command", "open");
+    slayer3d_properties_set_string(initial_state, "editor.input.path", save_path.string().c_str());
+    slayer3d_properties_set_string(initial_state, "editor.save.path", save_path.string().c_str());
+
+    slayer3d_data_game_runtime_desc desc{};
+    slayer3d_data_game_runtime_desc_init(&desc);
+    desc.session = session;
+    desc.media_dir = SLAYER3D_MEDIA_DIR;
+    desc.data_asset_path = asset_path.c_str();
+    desc.mount_assets = mount_test_directory_assets;
+    desc.mount_userdata = const_cast<char *>(root.c_str());
+    desc.initial_scene_state = initial_state;
+    desc.initial_scene_payload = initial_state;
+
+    slayer3d_data_game_runtime *host_runtime = nullptr;
+    ASSERT_TRUE(slayer3d_data_game_runtime_create(&desc, &host_runtime, error, sizeof(error))) << error;
+    slayer3d_properties_destroy(initial_state);
+    runtime = slayer3d_data_game_runtime_data(host_runtime);
+    ASSERT_NE(runtime, nullptr);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.load.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.load.message", ""), "editable level loaded");
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    EXPECT_EQ(world.brush_count, 15);
+    expect_compiled_brush_world_has_no_positive_coplanar_overlap(world);
+    slayer3d_game_data_brush_world_editor_state brush_state{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world_editor_state(runtime, "brush.editor_shell.target", &brush_state));
+    EXPECT_STREQ(brush_state.source_path, save_path.string().c_str());
+    EXPECT_FALSE(brush_state.dirty);
+
+    SDL_zero(diagnostics);
+    ASSERT_TRUE(slayer3d_game_data_validate_editor_brush_source_model(runtime, "brush.editor_shell.target", 1,
+                                                                      &diagnostics, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(diagnostics.structurally_valid) << diagnostics.first_issue;
+    EXPECT_EQ(diagnostics.runtime_source_mismatch_count, 0);
+    EXPECT_EQ(diagnostics.compiled_face_missing_source_count, 0);
+    EXPECT_EQ(diagnostics.compiled_face_unknown_source_count, 0);
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int test_run_enter_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.test_run.enter");
+    ASSERT_GE(test_run_enter_signal, 0);
+    ASSERT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.dojo");
+    slayer3d_signal_emit(bus, test_run_enter_signal, nullptr);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.test_run.enter.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.test_run.enter.message", ""),
+                 "test run player start applied");
+    EXPECT_STREQ(slayer3d_game_data_active_scene(runtime), "scene.editor_shell.test_run");
+    slayer3d_registered_actor *player = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.player");
+    ASSERT_NE(player, nullptr);
+    EXPECT_NEAR(player->position.x, start.position.x, 0.001f);
+    EXPECT_NEAR(player->position.y, start.position.y, 0.001f);
+    EXPECT_NEAR(player->position.z, start.position.z, 0.001f);
+
+    slayer3d_data_game_runtime_destroy(host_runtime);
+    slayer3d_game_session_destroy(session);
+    remove_test_dir(save_dir);
 }
 
 TEST(GameDataRuntime, EditableLevelFragmentRejectsRuntimeOnlyBrushLayout)

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16805,7 +16805,9 @@ TEST(GameDataRuntime, EditorShellDojoFaceDragUsesProjectedFaceNormalDirection)
     slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
     ASSERT_NE(bus, nullptr);
     const int mode_face_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.face");
+    const int mode_select_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.select");
     ASSERT_GE(mode_face_signal, 0);
+    ASSERT_GE(mode_select_signal, 0);
     slayer3d_signal_emit(bus, mode_face_signal, nullptr);
 
     const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
@@ -16869,6 +16871,52 @@ TEST(GameDataRuntime, EditorShellDojoFaceDragUsesProjectedFaceNormalDirection)
     slayer3d_input_process_event(input, &up);
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_game_data_brush_world brush_world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+    ASSERT_EQ(brush_world.brush_count, 1);
+    ASSERT_NE(brush_world.brushes[0].name, nullptr);
+    const std::string brush_name = brush_world.brushes[0].name;
+    const slayer3d_bounding_box before_select_drag = brush_world.brushes[0].bounds;
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    down.button.x = motion.motion.x;
+    down.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &down);
+    slayer3d_input_update(input, 7);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 760.0f;
+    motion.motion.y = 430.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 8);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    up.button.x = motion.motion.x;
+    up.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &up);
+    slayer3d_input_update(input, 9);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+    const slayer3d_game_data_brush *after_drag_brush = nullptr;
+    for (int i = 0; i < brush_world.brush_count; ++i)
+    {
+        if (brush_world.brushes[i].name != nullptr && brush_name == brush_world.brushes[i].name)
+        {
+            after_drag_brush = &brush_world.brushes[i];
+            break;
+        }
+    }
+    ASSERT_NE(after_drag_brush, nullptr);
+    const float drag_dx = after_drag_brush->bounds.min.x - before_select_drag.min.x;
+    const float drag_dz = after_drag_brush->bounds.min.z - before_select_drag.min.z;
+    EXPECT_GT(SDL_fabsf(drag_dx) + SDL_fabsf(drag_dz), 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -212,6 +212,10 @@ extern "C"
                                                     int minimum_extent_units,
                                                     editor_brush_source_prefab_result *out_result, char *error_buffer,
                                                     int error_buffer_size);
+    bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                                           const char *material_name, unsigned int contents,
+                                                           const int source_min[3], const int source_max[3],
+                                                           editor_brush_source_prefab_result *out_result);
     bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_snap_selected_editor_vertices(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_data_runtime *runtime,
@@ -224,6 +228,11 @@ extern "C"
     bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
                                    const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed);
     bool editor_translate_selected_vertices(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
+    bool editor_selection_from_brush_index(const slayer3d_game_data_runtime *runtime, const char *world_name,
+                                           int brush_index, int face_index,
+                                           slayer3d_game_data_editor_selection *out_selection);
+    bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime,
+                                          const slayer3d_game_data_editor_selection *hover_selection);
 }
 
 namespace
@@ -19913,6 +19922,112 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
     EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
 
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    editor_brush_source_prefab_result first_result{};
+    const int first_min[3] = {0, 0, 0};
+    const int first_max[3] = {1000, 1000, 1000};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, first_min,
+        first_max, &first_result));
+    ASSERT_TRUE(first_result.valid);
+    ASSERT_STRNE(first_result.brush_name, "");
+
+    editor_brush_source_prefab_result second_result{};
+    const int second_min[3] = {2000, 0, 0};
+    const int second_max[3] = {3000, 1000, 1000};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, second_min,
+        second_max, &second_result));
+    ASSERT_TRUE(second_result.valid);
+    ASSERT_STRNE(second_result.brush_name, "");
+
+    auto brush_index = [&](const char *brush_name) {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        for (int i = 0; i < brush_world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = brush_world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return i;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return -1;
+    };
+
+    slayer3d_game_data_editor_selection first_selection{};
+    slayer3d_game_data_editor_selection second_selection{};
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(first_result.brush_name), -1, &first_selection));
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(second_result.brush_name), -1, &second_selection));
+
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &first_selection));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.multiple", true));
+    slayer3d_game_data_editor_selection active_selection{};
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, first_result.brush_name);
+    ASSERT_NE(active_selection.element_editor, nullptr);
+    EXPECT_STREQ(active_selection.element_editor->stable_id, first_result.brush_name);
+    EXPECT_NEAR(active_selection.bounds.max.x - active_selection.bounds.min.x, 1.0f, 0.001f);
+    EXPECT_NEAR(active_selection.bounds.max.y - active_selection.bounds.min.y, 1.0f, 0.001f);
+    EXPECT_NEAR(active_selection.bounds.max.z - active_selection.bounds.min.z, 1.0f, 0.001f);
+
+    SDL_SetModState(SDL_KMOD_CTRL);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &second_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.multiple", false));
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, second_result.brush_name);
+
+    SDL_SetModState(SDL_KMOD_GUI);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &first_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.selection.multiple", true));
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, second_result.brush_name);
+
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &first_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, first_result.brush_name);
+
+    slayer3d_game_data_editor_selection empty_selection{};
+    SDL_SetModState(SDL_KMOD_CTRL);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &empty_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+    EXPECT_STREQ(active_selection.element_name, first_result.brush_name);
+
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &empty_selection));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
+    EXPECT_FALSE(slayer3d_game_data_get_active_editor_selection(runtime, &active_selection));
+
+    SDL_SetModState(SDL_KMOD_NONE);
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16788,6 +16788,75 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoFaceDragMapsUpwardMouseMotionToPositiveResize)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_face_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.face");
+    ASSERT_GE(mode_face_signal, 0);
+    slayer3d_signal_emit(bus, mode_face_signal, nullptr);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "face");
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.hit", false));
+
+    SDL_Event down{};
+    down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    down.button.button = SDL_BUTTON_LEFT;
+    down.button.x = motion.motion.x;
+    down.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &down);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.y = 292.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.resize.distance", 0.0f), 1.0f, 0.001f);
+
+    motion.motion.y = 388.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.resize.distance", 0.0f), -1.0f, 0.001f);
+
+    SDL_Event up{};
+    up.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    up.button.button = SDL_BUTTON_LEFT;
+    up.button.x = motion.motion.x;
+    up.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &up);
+    slayer3d_input_update(input, 5);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoVertexModePublishesSourceVertexHandles)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -232,6 +232,10 @@ extern "C"
                                                            editor_brush_source_prefab_result *out_result);
     bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
                                                               bool use_last_offset);
+    bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime,
+                                                              slayer3d_vec3 offset);
+    bool slayer3d_game_data_delete_selected_editor_brushes(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                           const slayer3d_properties *payload);
     bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                                 const slayer3d_properties *payload);
     bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
@@ -20183,10 +20187,8 @@ TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection
     EXPECT_STREQ(first_face_material(second_duplicate_name.c_str()), "mat.editor.wall");
 
     slayer3d_game_data_editor_selection redo_selection{};
-    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
-                                                  brush_index(second_duplicate_name.c_str()), -1, &redo_selection));
-    SDL_SetModState(SDL_KMOD_NONE);
-    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &redo_selection));
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &redo_selection));
+    ASSERT_STREQ(redo_selection.element_name, second_duplicate_name.c_str());
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
     SDL_Event key{};
@@ -20206,6 +20208,120 @@ TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection
     EXPECT_EQ(brush_world().brush_count, initial_brush_count + 3);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
                  "duplicated 1 selected brush");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    auto brush_world = [&]() {
+        slayer3d_game_data_brush_world world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+        return world;
+    };
+    auto brush_index = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return i;
+        }
+        return -1;
+    };
+    auto brush_exists = [&](const char *brush_name) { return brush_index(brush_name) >= 0; };
+    auto brush_bounds = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return slayer3d_bounding_box{};
+    };
+    auto select_brush = [&](const char *brush_name) {
+        slayer3d_game_data_editor_selection selection{};
+        ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target", brush_index(brush_name), -1,
+                                                      &selection));
+        ASSERT_TRUE(editor_select_mode_primary_click(runtime, &selection));
+        EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    };
+    auto active_selection = [&]() {
+        slayer3d_game_data_editor_selection selection{};
+        EXPECT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &selection));
+        return selection;
+    };
+
+    const int initial_brush_count = brush_world().brush_count;
+    const int source_min[3] = {0, 0, 0};
+    const int source_max[3] = {1000, 1000, 1000};
+    editor_brush_source_prefab_result source_result{};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, source_min,
+        source_max, &source_result));
+    ASSERT_TRUE(source_result.valid);
+    const std::string brush_name = source_result.brush_name;
+    ASSERT_TRUE(brush_exists(brush_name.c_str()));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count + 1);
+
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_FALSE(brush_exists(brush_name.c_str()));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    ASSERT_TRUE(brush_exists(brush_name.c_str()));
+    EXPECT_EQ(brush_world().brush_count, initial_brush_count + 1);
+
+    select_brush(brush_name.c_str());
+    ASSERT_TRUE(slayer3d_game_data_translate_selected_editor_brushes(runtime, slayer3d_vec3_make(2.0f, 0.0f, 0.0f)));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 2.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.min.x, 2.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.min.x, 0.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 2.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.min.x, 2.0f, 0.001f);
+
+    ASSERT_TRUE(
+        slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(1.0f, 0.0f, 0.0f), false));
+    ASSERT_EQ(brush_world().brush_count, initial_brush_count + 2);
+    const std::string duplicate_name = active_selection().element_name;
+    ASSERT_NE(duplicate_name, brush_name);
+    EXPECT_TRUE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_FALSE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 0);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_TRUE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_STREQ(active_selection().element_name, duplicate_name.c_str());
+
+    ASSERT_TRUE(slayer3d_game_data_delete_selected_editor_brushes(runtime, nullptr, nullptr));
+    EXPECT_FALSE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 0);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_TRUE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_STREQ(active_selection().element_name, duplicate_name.c_str());
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_FALSE(brush_exists(duplicate_name.c_str()));
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 0);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19753,6 +19753,9 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 7);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const float live_drag_dx = slayer3d_properties_get_float(scene_state, "editor.brush.drag.delta_x", 0.0f);
+    const float live_drag_dz = slayer3d_properties_get_float(scene_state, "editor.brush.drag.delta_z", 0.0f);
+    EXPECT_GT(SDL_fabsf(live_drag_dx) + SDL_fabsf(live_drag_dz), 0.001f);
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;
     mouse.button.y = motion.motion.y;
@@ -19766,6 +19769,7 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     EXPECT_NEAR(drag_dx, SDL_roundf(drag_dx), 0.001f);
     EXPECT_NEAR(drag_dz, SDL_roundf(drag_dz), 0.001f);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag moved brush");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.console.line0", ""), "drag moved brush");
 
     const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
     SDL_Event key{};
@@ -19929,6 +19933,28 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
     ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
     const slayer3d_vec3 expected_min = preview_min->as_vec3;
     const slayer3d_vec3 expected_max = preview_max->as_vec3;
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_x", 0.0f),
+                expected_max.x - expected_min.x, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f),
+                expected_max.y - expected_min.y, 0.001f);
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_z", 0.0f),
+                expected_max.z - expected_min.z, 0.001f);
+    struct DragPreviewDebug
+    {
+        int edges = 0;
+    } drag_preview_debug;
+    auto count_drag_preview = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) {
+        auto *debug = static_cast<DragPreviewDebug *>(userdata);
+        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE &&
+            primitive->element_name != nullptr && SDL_strcmp(primitive->element_name, "drag_box") == 0)
+        {
+            debug->edges++;
+        }
+        return true;
+    };
+    ASSERT_TRUE(
+        slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_drag_preview, &drag_preview_debug));
+    EXPECT_EQ(drag_preview_debug.edges, 24);
 
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;
@@ -19949,6 +19975,7 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
     ASSERT_NE(created_brush.faces, nullptr);
     EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.console.line0", ""), "drag brush created");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19820,6 +19820,103 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "brush");
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 660.0f;
+    motion.motion.y = 360.0f;
+    slayer3d_input_process_event(input, &motion);
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
+    const slayer3d_value *preview_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *preview_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(preview_min, nullptr);
+    ASSERT_NE(preview_max, nullptr);
+    ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+    const slayer3d_vec3 expected_min = preview_min->as_vec3;
+    const slayer3d_vec3 expected_max = preview_max->as_vec3;
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    const slayer3d_game_data_brush_world brush_world = world();
+    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
+    const slayer3d_game_data_brush &created_brush = brush_world.brushes[brush_world.brush_count - 1];
+    EXPECT_NEAR(created_brush.bounds.min.x, expected_min.x, 0.001f);
+    EXPECT_NEAR(created_brush.bounds.min.y, expected_min.y, 0.001f);
+    EXPECT_NEAR(created_brush.bounds.min.z, expected_min.z, 0.001f);
+    EXPECT_NEAR(created_brush.bounds.max.x, expected_max.x, 0.001f);
+    EXPECT_NEAR(created_brush.bounds.max.y, expected_max.y, 0.001f);
+    EXPECT_NEAR(created_brush.bounds.max.z, expected_max.z, 0.001f);
+    ASSERT_NE(created_brush.faces, nullptr);
+    EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditableLevelFragmentLoadsIntoEditorRuntime)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -165,6 +165,11 @@ extern "C"
                                                                 const char *brush_identity, int fallback_face_index,
                                                                 const char *face_identity, int *out_face_index,
                                                                 slayer3d_vec3 *out_normal);
+    void free_editor_brush_source_box_runtime(editor_brush_source_box_runtime *box);
+    bool editor_brush_world_copy_source_box_by_identity(const brush_world_runtime *world_runtime,
+                                                        const char *brush_identity,
+                                                        editor_brush_source_box_runtime *out_box, int *out_index,
+                                                        char *error_buffer, int error_buffer_size);
     bool editor_brush_world_translate_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                                  slayer3d_vec3 offset, char *error_buffer, int error_buffer_size);
     bool editor_brush_world_rotate_source_box_y_quarter_turns(brush_world_runtime *world_runtime,
@@ -173,6 +178,15 @@ extern "C"
     bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                    slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                    int error_buffer_size);
+    bool editor_brush_world_preview_resize_source_face(const brush_world_runtime *world_runtime, const char *brush_name,
+                                                       int fallback_face_index, const char *face_identity,
+                                                       float distance,
+                                                       editor_brush_source_vertex_operation_result *out_result,
+                                                       char *error_buffer, int error_buffer_size);
+    bool editor_brush_world_resize_source_face(brush_world_runtime *world_runtime, const char *brush_name,
+                                               int fallback_face_index, const char *face_identity, float distance,
+                                               editor_brush_source_vertex_operation_result *out_result,
+                                               char *error_buffer, int error_buffer_size);
     bool editor_brush_world_build_source_convex_brush_from_vertices(const brush_world_runtime *world_runtime,
                                                                     const char *brush_identity, const int *vertices,
                                                                     int vertex_count,
@@ -24326,6 +24340,43 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordi
     ASSERT_TRUE(world.brushes[0].has_bounds);
     EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.1f, 0.001f);
     EXPECT_NEAR(world.brushes[0].bounds.max.x, 8.2f, 0.001f);
+
+    SDL_zeroa(error);
+    editor_brush_source_vertex_operation_result face_preview{};
+    ASSERT_TRUE(editor_brush_world_preview_resize_source_face(
+        world_runtime, "source.box.001", 0, "source.box.001.face.px", 0.1f, &face_preview, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(face_preview.valid);
+    ASSERT_TRUE(face_preview.brush.has_bounds);
+    EXPECT_NEAR(face_preview.brush.bounds.max.x, 8.3f, 0.001f);
+    editor_brush_source_free_runtime_brush(&face_preview.brush);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 8.2f, 0.001f) << "face resize preview must not mutate";
+
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_resize_source_face(world_runtime, "source.box.001", 0, "source.box.001.face.px",
+                                                      0.1f, &face_preview, error, sizeof(error)))
+        << error;
+    editor_brush_source_free_runtime_brush(&face_preview.brush);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.1f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 8.3f, 0.001f);
+
+    editor_brush_source_box_runtime resized_source{};
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(world_runtime, "source.box.001", &resized_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(resized_source.vertex_count, 8) << "face push/pull should persist through source vertices";
+    free_editor_brush_source_box_runtime(&resized_source);
+
+    SDL_zeroa(error);
+    EXPECT_FALSE(editor_brush_world_preview_resize_source_face(
+        world_runtime, "source.box.001", 0, "source.box.001.face.px", -8.2f, &face_preview, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("zero-volume"), std::string::npos) << error;
+    editor_brush_source_free_runtime_brush(&face_preview.brush);
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 8.3f, 0.001f) << "invalid face resize must be atomic";
 
     const char rotate_json[] = R"json({
   "schema": "slayer3d.fragment.v0",

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -97,6 +97,30 @@ extern "C"
         char first_issue[256];
         char first_issue_stable_id[SLAYER3D_EDITOR_SOURCE_STABLE_ID_MAX];
     } editor_brush_source_vertex_diagnostics;
+    typedef struct editor_brush_source_box_runtime
+    {
+        char *stable_id;
+        char *name;
+        char *prefab;
+        char *material;
+        char *face_materials[6];
+        int min[3];
+        int max[3];
+        int vertex_count;
+        int vertices[16][3];
+        unsigned int contents;
+    } editor_brush_source_box_runtime;
+    typedef struct editor_brush_source_prefab_result
+    {
+        bool valid;
+        bool no_op;
+        char brush_name[256];
+        slayer3d_bounding_box bounds;
+        int source_min[3];
+        int source_max[3];
+        int positive_overlap_count;
+        char warning[256];
+    } editor_brush_source_prefab_result;
     typedef enum editor_brush_source_vertex_operation_type
     {
         EDITOR_BRUSH_SOURCE_VERTEX_OPERATION_ADD,
@@ -178,6 +202,16 @@ extern "C"
                                                         editor_brush_source_shared_vertex *out_vertices,
                                                         int out_capacity, int *out_count, char *error_buffer,
                                                         int error_buffer_size);
+    bool editor_brush_world_preview_source_box_create(const brush_world_runtime *world_runtime,
+                                                      const editor_brush_source_box_runtime *box,
+                                                      int minimum_extent_units,
+                                                      editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                      int error_buffer_size);
+    bool editor_brush_world_apply_source_box_create(brush_world_runtime *world_runtime,
+                                                    const editor_brush_source_box_runtime *box,
+                                                    int minimum_extent_units,
+                                                    editor_brush_source_prefab_result *out_result, char *error_buffer,
+                                                    int error_buffer_size);
     bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_snap_selected_editor_vertices(slayer3d_game_data_runtime *runtime, yyjson_val *action);
     bool slayer3d_game_data_merge_selected_editor_vertices_to_hover(slayer3d_game_data_runtime *runtime,
@@ -23868,6 +23902,117 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateRejectsOffSnapCoordina
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_EQ(world.brush_count, 1);
     EXPECT_STREQ(world.brushes[0].name, "brush.source.on_snap");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateCommandPreviewsAndAppliesAtomically)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+    char error[512]{};
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const char import_json[] = R"json({
+  "schema": "slayer3d.fragment.v0",
+  "brush_worlds": [
+    {
+      "name": "brush.editor_shell.target",
+      "materials": [{ "name": "mat.editor.floor", "albedo": [0.25, 0.5, 0.75, 1.0] }],
+      "brushes": []
+    }
+  ],
+  "editor_brush_sources": [
+    {
+      "world": "brush.editor_shell.target",
+      "coordinate_system": "fixed_millimeters",
+      "meters_per_unit": 0.001,
+      "snap_units": 100,
+      "boxes": []
+    }
+  ],
+  "editor_player_starts": []
+})json";
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(
+        runtime, "brush.editor_shell.target", import_json, sizeof(import_json) - 1u, "/tmp/source-create-command.json",
+        error, sizeof(error)))
+        << error;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    auto make_box = [](const char *name, int min_x, int min_y, int min_z, int max_x, int max_y, int max_z) {
+        editor_brush_source_box_runtime box{};
+        box.stable_id = const_cast<char *>(name);
+        box.name = const_cast<char *>(name);
+        box.prefab = const_cast<char *>("editor.box");
+        box.material = const_cast<char *>("mat.editor.floor");
+        box.min[0] = min_x;
+        box.min[1] = min_y;
+        box.min[2] = min_z;
+        box.max[0] = max_x;
+        box.max[1] = max_y;
+        box.max[2] = max_z;
+        box.contents = SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID;
+        return box;
+    };
+
+    editor_brush_source_prefab_result result{};
+    editor_brush_source_box_runtime valid = make_box("source.box.valid", 0, -200, 0, 8000, 0, 8000);
+    ASSERT_TRUE(editor_brush_world_preview_source_box_create(world_runtime, &valid, 100, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.valid);
+    EXPECT_FALSE(result.no_op);
+    EXPECT_STREQ(result.brush_name, "source.box.valid");
+    EXPECT_EQ(world().brush_count, 0) << "preview must not mutate runtime geometry";
+
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_apply_source_box_create(world_runtime, &valid, 100, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.valid);
+    EXPECT_FALSE(result.no_op);
+    ASSERT_EQ(world().brush_count, 1);
+    EXPECT_STREQ(world().brushes[0].name, "source.box.valid");
+
+    SDL_zeroa(error);
+    editor_brush_source_box_runtime tiny = make_box("source.box.tiny", 8000, -200, 0, 8050, 0, 8000);
+    ASSERT_TRUE(editor_brush_world_apply_source_box_create(world_runtime, &tiny, 100, &result, error, sizeof(error)))
+        << error;
+    EXPECT_TRUE(result.no_op);
+    EXPECT_NE(std::string(result.warning).find("ignored tiny drag"), std::string::npos) << result.warning;
+    EXPECT_EQ(world().brush_count, 1);
+
+    SDL_zeroa(error);
+    editor_brush_source_box_runtime invalid = make_box("source.box.invalid", 0, -200, 0, 0, 0, 8000);
+    EXPECT_FALSE(
+        editor_brush_world_apply_source_box_create(world_runtime, &invalid, 100, &result, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("invalid geometry"), std::string::npos) << error;
+    EXPECT_EQ(world().brush_count, 1);
+
+    SDL_zeroa(error);
+    editor_brush_source_box_runtime off_snap = make_box("source.box.off_snap", 50, -200, 0, 8050, 0, 8000);
+    EXPECT_FALSE(
+        editor_brush_world_apply_source_box_create(world_runtime, &off_snap, 100, &result, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("not aligned to 100-unit source snap"), std::string::npos) << error;
+    EXPECT_EQ(world().brush_count, 1);
+
+    SDL_zeroa(error);
+    editor_brush_source_box_runtime duplicate = make_box("source.box.valid", 8000, -200, 0, 16000, 0, 8000);
+    EXPECT_FALSE(
+        editor_brush_world_apply_source_box_create(world_runtime, &duplicate, 100, &result, error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("duplicate editor brush source stable id"), std::string::npos) << error;
+    EXPECT_EQ(world().brush_count, 1);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- Add centralized `editor.tool.set_mode` routing for Select, Brush, Face, Vertex, and Texture modes.
- Route editor shell hotkeys, Escape handling, and retained toolbar clicks through the shared mode transition path.
- Allow selected brush deletion through the command system while Brush Tool is active.
- Add source box preview/apply creation helpers so dry-run and commit share validation.
- Suppress tiny source box creation drags as no-op, reject invalid/off-snap/duplicate candidates atomically, and preserve source overlap diagnostics.
- Enable Brush Tool drag-create gestures against the editor work plane, with preview bounds matching the committed source brush.
- Extend brush selection to support Shift/Ctrl/Cmd additive toggles while preserving empty-click clear behavior and source-stable selection identity.
- Enable Brush Tool movement gestures: click-dragging an unselected brush selects and moves it in one gesture, selected brushes can still be dragged, grid nudging works in Brush Tool mode, and modifier-assisted vertical movement remains snapped.
- Add source-backed Brush/Face Tool face push-pull resizing so preview, commit, undo, and redo use the same source-vertex validation path.
- Add source-backed brush duplication for Ctrl/Cmd+D and Ctrl/Cmd-drag, preserving materials/source identity, selecting the duplicates, supporting repeat-offset duplication, and integrating undo/redo.
- Harden undo/redo selection synchronization so create, translate, duplicate, delete, resize, paint, and rotate history replay keeps active and multi-brush selection tied to restored source/runtime brush identity.
- Polish Brush Tool feedback: placement previews publish dimensions and warnings, brush movement publishes live deltas, face resize publishes live dimensions, and create/move diagnostics route through the editor console and SDL log.
- Add graybox acceptance coverage: a source-backed blockout with floors, walls, sky sealing, a lowered pit, corridors/platform-style spans, and a player start now saves to disk, reopens through the editor host, validates source/compiled identity, enters the playable test-run scene, and preserves player start placement.
- Document the current source-backed graybox editor workflow and the source-model guarantees for save/reopen/test-run.
- Add regression coverage for source face resize preview/apply atomicity, invalid zero-volume rejection, additive selection, brush duplication, create/translate/duplicate/delete history replay, preview debug edges, dimension readouts, drag deltas, console diagnostics, and source-backed graybox save/reopen/test-run acceptance.

## Verification
- `./scripts/check_clang_format.sh`
- `git diff --check`
- `cmake --build build/debug --target slayer3d_game_data_test`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordinates:GameDataRuntime.EditorExtrudeCommandResizesSelectedBrushFace:GameDataRuntime.EditorShellDojoDragCreatesAndNudgesSourceBrush"`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditorShellDojoBrush*"`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelection:GameDataRuntime.EditorShellDojoBrushDuplicationPreservesSourceAndSelection:GameDataRuntime.EditorExtrudeCommandResizesSelectedBrushFace"`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditorShellDojoBrushTool*:GameDataRuntime.EditorShellDojoBrushHistory*:GameDataRuntime.EditorShellDojoDragCreatesAndNudgesSourceBrush:GameDataRuntime.EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel:GameDataRuntime.EditorShellDojoPrefabPreviewReportsSourceOverlapWarning"`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditableLevelFragmentMvpGrayboxRoundTripsSourceOnlyForTestRun"`
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter="GameDataRuntime.EditorShellDojo*:GameDataRuntime.EditableLevelFragmentMvpGrayboxRoundTripsSourceOnlyForTestRun:GameDataRuntime.EditableLevelFragmentReportsSourceEnclosureDiagnostics:GameDataRuntime.EditableLevelFragmentValidatesLoweredPitEnclosure"`
- `./build/debug/tests/slayer3d_game_data_test`
