### PR TITLE
Add pending brush footprint state

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -945,181 +945,211 @@
               "conditions": [
                 {
                   "type": "scene_state.compare",
-                  "key": "editor.mode",
+                  "key": "editor.placement_preview.active",
                   "op": "==",
-                  "value": "vertex",
-                  "default": "select"
+                  "value": true,
+                  "default": false
                 },
                 {
                   "type": "scene_state.compare",
-                  "key": "editor.vertex.selection.count",
-                  "op": ">",
-                  "value": 0,
-                  "default": 0
+                  "key": "editor.placement_preview.mode",
+                  "op": "==",
+                  "value": "drag_box",
+                  "default": ""
                 }
               ]
             },
             "then": [
               {
-                "type": "editor.vertex.delete_selected",
-                "outputs": {
-                  "valid_key": "editor.vertex.delete.valid",
-                  "message_key": "editor.vertex.delete.message",
-                  "source_count_key": "editor.vertex.delete.source_count",
-                  "deleted_count_key": "editor.vertex.delete.deleted_count"
-                }
-              }
-            ],
-            "else": [
-              {
-                "type": "branch",
-            "if": {
-              "type": "all",
-              "conditions": [
-                {
-                  "type": "any",
-                  "conditions": [
-                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "select", "default": "select" },
-                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
-                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
-                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "texture", "default": "select" }
-                  ]
-                },
-                {
-                  "type": "scene_state.compare",
-                  "key": "editor.selection.count",
-                  "op": ">",
-                  "value": 0,
-                  "default": 0
-                }
-              ]
-            },
-            "then": [
-              {
-                "type": "editor.selection.delete_selected",
-                "message": "deleted selected brushes",
-                "invalid_message": "nothing selected to delete",
-                "outputs": {
-                  "valid_key": "editor.transaction.valid",
-                  "event_key": "editor.transaction.event",
-                  "message_key": "editor.transaction.message",
-                  "transaction_id_key": "editor.transaction.id",
-                  "undo_count_key": "editor.transaction.undo_count",
-                  "redo_count_key": "editor.transaction.redo_count",
-                  "command_key": "editor.transaction.command",
-                  "target_key": "editor.transaction.target",
-                  "world_key": "editor.transaction.world",
-                  "element_key": "editor.transaction.element",
-                  "element_stable_id_key": "editor.transaction.element_stable_id",
-                  "face_stable_id_key": "editor.transaction.face_stable_id",
-                  "face_index_key": "editor.transaction.face_index",
-                  "dirty_key": "editor.brush_world.dirty",
-                  "revision_key": "editor.brush_world.revision",
-                  "saved_revision_key": "editor.brush_world.saved_revision",
-                  "source_path_key": "editor.brush_world.source_path"
-                },
-                "actions": [
-                  {
-                    "type": "scene_state.set",
-                    "key": "editor.tool.last_action",
-                    "value": "{editor_transaction_message}"
-                  }
-                ],
-                "else": [
-                  {
-                    "type": "scene_state.set",
-                    "key": "editor.tool.last_action",
-                    "value": "nothing selected to delete"
-                  }
-                ]
+                "type": "editor.placement_preview.cancel",
+                "message": "brush preview cancelled"
               }
             ],
             "else": [
               {
                 "type": "branch",
                 "if": {
-                  "type": "scene_state.compare",
-                  "key": "editor.selection.type",
-                  "op": "==",
-                  "value": "editor_player_start"
+                  "type": "all",
+                  "conditions": [
+                    {
+                      "type": "scene_state.compare",
+                      "key": "editor.mode",
+                      "op": "==",
+                      "value": "vertex",
+                      "default": "select"
+                    },
+                    {
+                      "type": "scene_state.compare",
+                      "key": "editor.vertex.selection.count",
+                      "op": ">",
+                      "value": 0,
+                      "default": 0
+                    }
+                  ]
                 },
                 "then": [
                   {
-                    "type": "editor.player_start.delete",
-                    "name_from_selection": true,
-                    "message": "player start deleted",
+                    "type": "editor.vertex.delete_selected",
                     "outputs": {
-                      "valid_key": "editor.player_start.valid",
-                      "message_key": "editor.player_start.message",
-                      "player_start_key": "editor.player_start.name",
-                      "dirty_key": "editor.player_start.dirty",
-                      "revision_key": "editor.player_start.revision",
-                      "saved_revision_key": "editor.player_start.saved_revision"
+                      "valid_key": "editor.vertex.delete.valid",
+                      "message_key": "editor.vertex.delete.message",
+                      "source_count_key": "editor.vertex.delete.source_count",
+                      "deleted_count_key": "editor.vertex.delete.deleted_count"
                     }
-                  },
-                  { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start deleted" }
+                  }
                 ],
                 "else": [
                   {
-                    "type": "editor.command.preview",
-                    "command": "delete",
-                    "target": "element",
-                    "message": "delete {selection_element}",
-                    "outputs": {
-                      "active_key": "editor.command_preview.active",
-                      "valid_key": "editor.command_preview.valid",
-                      "command_key": "editor.command_preview.command",
-                      "target_key": "editor.command_preview.target",
-                      "message_key": "editor.command_preview.message",
-                      "world_key": "editor.command_preview.world",
-                      "element_key": "editor.command_preview.element",
-                      "face_index_key": "editor.command_preview.face_index",
-                      "bounds_min_key": "editor.command_preview.bounds_min",
-                      "bounds_max_key": "editor.command_preview.bounds_max"
-                    }
-                  },
-                  {
-                    "type": "editor.command.commit",
-                    "message": "deleted {editor_transaction_element}",
-                    "invalid_message": "nothing selected to delete",
-                    "outputs": {
-                      "valid_key": "editor.transaction.valid",
-                      "event_key": "editor.transaction.event",
-                      "message_key": "editor.transaction.message",
-                      "transaction_id_key": "editor.transaction.id",
-                      "undo_count_key": "editor.transaction.undo_count",
-                      "redo_count_key": "editor.transaction.redo_count",
-                      "command_key": "editor.transaction.command",
-                      "target_key": "editor.transaction.target",
-                      "world_key": "editor.transaction.world",
-                      "element_key": "editor.transaction.element",
-                      "element_stable_id_key": "editor.transaction.element_stable_id",
-                      "face_stable_id_key": "editor.transaction.face_stable_id",
-                      "face_index_key": "editor.transaction.face_index",
-                      "dirty_key": "editor.brush_world.dirty",
-                      "revision_key": "editor.brush_world.revision",
-                      "saved_revision_key": "editor.brush_world.saved_revision",
-                      "source_path_key": "editor.brush_world.source_path"
+                    "type": "branch",
+                    "if": {
+                      "type": "all",
+                      "conditions": [
+                        {
+                          "type": "any",
+                          "conditions": [
+                            { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "select", "default": "select" },
+                            { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
+                            { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
+                            { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "texture", "default": "select" }
+                          ]
+                        },
+                        {
+                          "type": "scene_state.compare",
+                          "key": "editor.selection.count",
+                          "op": ">",
+                          "value": 0,
+                          "default": 0
+                        }
+                      ]
                     },
-                    "actions": [
+                    "then": [
                       {
-                        "type": "scene_state.set",
-                        "key": "editor.tool.last_action",
-                        "value": "deleted {editor_transaction_element}"
+                        "type": "editor.selection.delete_selected",
+                        "message": "deleted selected brushes",
+                        "invalid_message": "nothing selected to delete",
+                        "outputs": {
+                          "valid_key": "editor.transaction.valid",
+                          "event_key": "editor.transaction.event",
+                          "message_key": "editor.transaction.message",
+                          "transaction_id_key": "editor.transaction.id",
+                          "undo_count_key": "editor.transaction.undo_count",
+                          "redo_count_key": "editor.transaction.redo_count",
+                          "command_key": "editor.transaction.command",
+                          "target_key": "editor.transaction.target",
+                          "world_key": "editor.transaction.world",
+                          "element_key": "editor.transaction.element",
+                          "element_stable_id_key": "editor.transaction.element_stable_id",
+                          "face_stable_id_key": "editor.transaction.face_stable_id",
+                          "face_index_key": "editor.transaction.face_index",
+                          "dirty_key": "editor.brush_world.dirty",
+                          "revision_key": "editor.brush_world.revision",
+                          "saved_revision_key": "editor.brush_world.saved_revision",
+                          "source_path_key": "editor.brush_world.source_path"
+                        },
+                        "actions": [
+                          {
+                            "type": "scene_state.set",
+                            "key": "editor.tool.last_action",
+                            "value": "{editor_transaction_message}"
+                          }
+                        ],
+                        "else": [
+                          {
+                            "type": "scene_state.set",
+                            "key": "editor.tool.last_action",
+                            "value": "nothing selected to delete"
+                          }
+                        ]
                       }
                     ],
                     "else": [
                       {
-                        "type": "scene_state.set",
-                        "key": "editor.tool.last_action",
-                        "value": "nothing selected to delete"
+                        "type": "branch",
+                        "if": {
+                          "type": "scene_state.compare",
+                          "key": "editor.selection.type",
+                          "op": "==",
+                          "value": "editor_player_start"
+                        },
+                        "then": [
+                          {
+                            "type": "editor.player_start.delete",
+                            "name_from_selection": true,
+                            "message": "player start deleted",
+                            "outputs": {
+                              "valid_key": "editor.player_start.valid",
+                              "message_key": "editor.player_start.message",
+                              "player_start_key": "editor.player_start.name",
+                              "dirty_key": "editor.player_start.dirty",
+                              "revision_key": "editor.player_start.revision",
+                              "saved_revision_key": "editor.player_start.saved_revision"
+                            }
+                          },
+                          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start deleted" }
+                        ],
+                        "else": [
+                          {
+                            "type": "editor.command.preview",
+                            "command": "delete",
+                            "target": "element",
+                            "message": "delete {selection_element}",
+                            "outputs": {
+                              "active_key": "editor.command_preview.active",
+                              "valid_key": "editor.command_preview.valid",
+                              "command_key": "editor.command_preview.command",
+                              "target_key": "editor.command_preview.target",
+                              "message_key": "editor.command_preview.message",
+                              "world_key": "editor.command_preview.world",
+                              "element_key": "editor.command_preview.element",
+                              "face_index_key": "editor.command_preview.face_index",
+                              "bounds_min_key": "editor.command_preview.bounds_min",
+                              "bounds_max_key": "editor.command_preview.bounds_max"
+                            }
+                          },
+                          {
+                            "type": "editor.command.commit",
+                            "message": "deleted {editor_transaction_element}",
+                            "invalid_message": "nothing selected to delete",
+                            "outputs": {
+                              "valid_key": "editor.transaction.valid",
+                              "event_key": "editor.transaction.event",
+                              "message_key": "editor.transaction.message",
+                              "transaction_id_key": "editor.transaction.id",
+                              "undo_count_key": "editor.transaction.undo_count",
+                              "redo_count_key": "editor.transaction.redo_count",
+                              "command_key": "editor.transaction.command",
+                              "target_key": "editor.transaction.target",
+                              "world_key": "editor.transaction.world",
+                              "element_key": "editor.transaction.element",
+                              "element_stable_id_key": "editor.transaction.element_stable_id",
+                              "face_stable_id_key": "editor.transaction.face_stable_id",
+                              "face_index_key": "editor.transaction.face_index",
+                              "dirty_key": "editor.brush_world.dirty",
+                              "revision_key": "editor.brush_world.revision",
+                              "saved_revision_key": "editor.brush_world.saved_revision",
+                              "source_path_key": "editor.brush_world.source_path"
+                            },
+                            "actions": [
+                              {
+                                "type": "scene_state.set",
+                                "key": "editor.tool.last_action",
+                                "value": "deleted {editor_transaction_element}"
+                              }
+                            ],
+                            "else": [
+                              {
+                                "type": "scene_state.set",
+                                "key": "editor.tool.last_action",
+                                "value": "nothing selected to delete"
+                              }
+                            ]
+                          }
+                        ]
                       }
                     ]
                   }
                 ]
               }
-            ]
-          }
             ]
           }
         ]

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -81,6 +81,7 @@
             "work_plane": {
               "enabled": true,
               "normal": [0.0, 1.0, 0.0],
+              "normal_key": "editor.work_plane.normal",
               "distance": 0.0,
               "distance_key": "editor.work_plane.distance"
             }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -183,7 +183,8 @@
         "dimension_x_key": "editor.placement_preview.dimension_x",
         "dimension_y_key": "editor.placement_preview.dimension_y",
         "dimension_z_key": "editor.placement_preview.dimension_z",
-        "warning_key": "editor.placement_preview.warning"
+        "warning_key": "editor.placement_preview.warning",
+        "state_key": "editor.placement_preview.state"
       },
       "previews": [
         {

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -547,7 +547,7 @@
         "x": 12,
         "y": 92,
         "w": 308,
-        "h": 400,
+        "h": 460,
         "layer": 120,
         "visible_if": { "type": "scene_state.compare", "key": "editor.inspector.collapsed", "op": "==", "value": false, "default": false },
         "children": [
@@ -795,7 +795,7 @@
             "type": "panel",
             "layout": "row",
             "x": 12,
-            "y": 364,
+            "y": 424,
             "w": 272,
             "h": 26,
             "layer": 121,
@@ -811,6 +811,51 @@
                   { "type": "scene_state", "key": "editor.brush.drag.delta_x", "default": 0.0 },
                   { "type": "scene_state", "key": "editor.brush.drag.delta_y", "default": 0.0 },
                   { "type": "scene_state", "key": "editor.brush.drag.delta_z", "default": 0.0 }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.left_inspector.row.preview_state",
+            "type": "panel",
+            "layout": "row",
+            "x": 12,
+            "y": 364,
+            "w": 272,
+            "h": 26,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.left_inspector.row.preview_state.label", "type": "label", "w": 96, "h": "fill", "text": "Preview State" },
+              {
+                "id": "ui.editor_shell.left_inspector.row.preview_state.value",
+                "type": "label",
+                "w": "fill",
+                "h": "fill",
+                "format": "%s",
+                "bindings": [{ "type": "scene_state", "key": "editor.placement_preview.state", "default": "idle" }]
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.left_inspector.row.preview_grid_axis",
+            "type": "panel",
+            "layout": "row",
+            "x": 12,
+            "y": 394,
+            "w": 272,
+            "h": 26,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.left_inspector.row.preview_grid_axis.label", "type": "label", "w": 96, "h": "fill", "text": "Grid / Axis" },
+              {
+                "id": "ui.editor_shell.left_inspector.row.preview_grid_axis.value",
+                "type": "label",
+                "w": "fill",
+                "h": "fill",
+                "format": "%s / %s",
+                "bindings": [
+                  { "type": "scene_state", "key": "editor.placement_preview.snap", "default": 0.0 },
+                  { "type": "scene_state", "key": "editor.placement_preview.axis", "default": "none" }
                 ]
               }
             ]

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1471,6 +1471,13 @@ path.
 `drag_create` optionally enables TrenchBroom-style brush creation in select and
 Brush Tool modes: the editor dry-runs the same source-box command while the
 pointer is dragged in empty space, then commits that exact command on release.
+The dragged footprint is projected onto the active editor work plane. The
+dominant work-plane normal becomes the extrusion axis, so a horizontal Y-up
+work plane draws an X/Z footprint and extrudes along Y, while front/side
+orthographic work planes can draw X/Y or Y/Z footprints and extrude along Z or
+X. `extrusion_axis` may be authored as `x`, `y`, or `z` to force an axis, or
+`extrusion_axis_key` may read the axis from scene state when a tool wants to
+override the active work plane.
 `grid_widget` can
 describe a small authored toolbar dropdown for selecting the active snap size.
 The widget writes both the general grid key and the brush grid key so previews,

--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -95,6 +95,10 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_HOVER_HANDLE = 15,
         /** @brief Hovered source brush vertex coordinate label. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_VERTEX_HOVER_LABEL = 16,
+        /** @brief Pending brush placement footprint edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_FOOTPRINT_EDGE = 17,
+        /** @brief Pending brush placement extrusion-axis guide. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_AXIS = 18,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -444,6 +444,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         return slayer3d_game_data_set_editor_tool_mode(runtime, json_string(action, "mode", NULL),
                                                        json_string(action, "message", NULL));
 
+    if (SDL_strcmp(type, "editor.placement_preview.cancel") == 0)
+        return editor_cancel_pending_brush_preview(runtime, json_string(action, "message", NULL));
+
     if (SDL_strcmp(type, "editor.vertex.snap_selected") == 0)
         return slayer3d_game_data_snap_selected_editor_vertices(runtime, action);
 

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -819,19 +819,32 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
         return true;
     }
     bool drag_move_consumed = false;
-    if (!editor_handle_drag_move(runtime, &hover_selection, &drag_move_consumed))
-        return false;
-    if (drag_move_consumed)
+    if (runtime->editor_drag_move.active)
     {
-        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
-        publish_editor_selected_brush_count(runtime);
-        return true;
+        if (!editor_handle_drag_move(runtime, &hover_selection, &drag_move_consumed))
+            return false;
+        if (drag_move_consumed)
+        {
+            publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+            publish_editor_selected_brush_count(runtime);
+            return true;
+        }
     }
     bool drag_consumed = false;
     if (!update_editor_drag_create(runtime, editor, &hover_selection, &drag_consumed))
         return false;
     if (!drag_consumed)
+    {
+        if (!editor_handle_drag_move(runtime, &hover_selection, &drag_move_consumed))
+            return false;
+        if (drag_move_consumed)
+        {
+            publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+            publish_editor_selected_brush_count(runtime);
+            return true;
+        }
         update_editor_placement_preview(runtime, editor, &hover_selection);
+    }
     bool grid_nudge_changed = false;
     if (!editor_handle_grid_nudge(runtime, &grid_nudge_changed))
         return false;

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -540,6 +540,112 @@ static bool emit_editor_debug_bounds(editor_debug_iteration_context *context, sl
     return true;
 }
 
+static int editor_preview_axis_index(const editor_placement_preview_state *preview)
+{
+    if (preview == NULL || preview->axis == NULL)
+        return 1;
+    if (SDL_strcmp(preview->axis, "x") == 0)
+        return 0;
+    if (SDL_strcmp(preview->axis, "z") == 0)
+        return 2;
+    return 1;
+}
+
+static float editor_vec3_component(slayer3d_vec3 value, int axis)
+{
+    if (axis == 0)
+        return value.x;
+    if (axis == 2)
+        return value.z;
+    return value.y;
+}
+
+static void editor_set_vec3_component(slayer3d_vec3 *value, int axis, float component)
+{
+    if (value == NULL)
+        return;
+    if (axis == 0)
+        value->x = component;
+    else if (axis == 2)
+        value->z = component;
+    else
+        value->y = component;
+}
+
+static float editor_preview_base_plane_coordinate(const slayer3d_game_data_runtime *runtime,
+                                                  const editor_placement_preview_state *preview, int axis)
+{
+    if (runtime != NULL && runtime->editor_drag_create.active && axis == runtime->editor_drag_create.extrusion_axis)
+    {
+        const editor_drag_create_state *drag = &runtime->editor_drag_create;
+        const float base = (float)drag->start_cell[axis] * SDL_max(drag->grid_size, 0.001f);
+        if (base >= editor_vec3_component(preview->bounds.min, axis) - 0.001f &&
+            base <= editor_vec3_component(preview->bounds.max, axis) + 0.001f)
+        {
+            return base;
+        }
+    }
+    return editor_vec3_component(preview->bounds.min, axis);
+}
+
+static bool emit_editor_debug_placement_footprint(editor_debug_iteration_context *context,
+                                                  const slayer3d_game_data_runtime *runtime,
+                                                  const editor_placement_preview_state *preview)
+{
+    if (context == NULL || preview == NULL || !preview->has_bounds)
+        return false;
+
+    const int axis = editor_preview_axis_index(preview);
+    const int u_axis = axis == 0 ? 1 : 0;
+    const int v_axis = axis == 2 ? 1 : 2;
+    const float base = editor_preview_base_plane_coordinate(runtime, preview, axis);
+    slayer3d_vec3 corners[4] = {preview->bounds.min, preview->bounds.min, preview->bounds.min, preview->bounds.min};
+    for (int corner = 0; corner < 4; ++corner)
+        editor_set_vec3_component(&corners[corner], axis, base);
+    editor_set_vec3_component(&corners[1], u_axis, editor_vec3_component(preview->bounds.max, u_axis));
+    editor_set_vec3_component(&corners[2], u_axis, editor_vec3_component(preview->bounds.max, u_axis));
+    editor_set_vec3_component(&corners[2], v_axis, editor_vec3_component(preview->bounds.max, v_axis));
+    editor_set_vec3_component(&corners[3], v_axis, editor_vec3_component(preview->bounds.max, v_axis));
+
+    for (int i = 0; i < 4; ++i)
+    {
+        if (!emit_editor_debug_line(context, corners[i], corners[(i + 1) % 4]))
+            return false;
+    }
+    return true;
+}
+
+static bool emit_editor_debug_placement_axis(editor_debug_iteration_context *context,
+                                             const slayer3d_game_data_runtime *runtime,
+                                             const editor_placement_preview_state *preview)
+{
+    if (context == NULL || preview == NULL || !preview->has_bounds)
+        return false;
+
+    const int axis = editor_preview_axis_index(preview);
+    const int u_axis = axis == 0 ? 1 : 0;
+    const int v_axis = axis == 2 ? 1 : 2;
+    const float base = editor_preview_base_plane_coordinate(runtime, preview, axis);
+    const float min_axis = editor_vec3_component(preview->bounds.min, axis);
+    const float max_axis = editor_vec3_component(preview->bounds.max, axis);
+    const float end = SDL_fabsf(base - min_axis) <= SDL_fabsf(base - max_axis) ? max_axis : min_axis;
+
+    slayer3d_vec3 start = preview->bounds.min;
+    slayer3d_vec3 stop = preview->bounds.min;
+    editor_set_vec3_component(
+        &start, u_axis,
+        (editor_vec3_component(preview->bounds.min, u_axis) + editor_vec3_component(preview->bounds.max, u_axis)) *
+            0.5f);
+    editor_set_vec3_component(
+        &start, v_axis,
+        (editor_vec3_component(preview->bounds.min, v_axis) + editor_vec3_component(preview->bounds.max, v_axis)) *
+            0.5f);
+    editor_set_vec3_component(&start, axis, base);
+    stop = start;
+    editor_set_vec3_component(&stop, axis, end);
+    return emit_editor_debug_line(context, start, stop);
+}
+
 static bool emit_editor_debug_source_brush_edges(editor_debug_iteration_context *context,
                                                  const brush_world_runtime *world,
                                                  const slayer3d_game_data_editor_selection *selection)
@@ -1212,7 +1318,16 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
         context.face_index = -1;
         if (!emit_editor_debug_bounds(&context, preview->bounds))
             return true;
+        context.color = (slayer3d_color){255, 220, 80, 230};
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_FOOTPRINT_EDGE;
+        if (!emit_editor_debug_placement_footprint(&context, runtime, preview))
+            return true;
+        context.color = (slayer3d_color){255, 145, 40, 245};
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_AXIS;
+        if (!emit_editor_debug_placement_axis(&context, runtime, preview))
+            return true;
         context.color = color;
+        context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE;
         if (!emit_editor_debug_bounds(&context, preview->bounds))
             return true;
     }

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -91,6 +91,7 @@ bool editor_handle_prefabs_widget(slayer3d_game_data_runtime *runtime, yyjson_va
 bool editor_handle_tool_mode_buttons(slayer3d_game_data_runtime *runtime, yyjson_val *editor, bool *out_consumed);
 void clear_editor_command_preview(slayer3d_game_data_runtime *runtime);
 void clear_editor_placement_preview(slayer3d_game_data_runtime *runtime);
+bool editor_cancel_pending_brush_preview(slayer3d_game_data_runtime *runtime, const char *message);
 void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
                                      const slayer3d_game_data_editor_selection *hover_selection);
 bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *editor,

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -248,6 +248,35 @@ static bool editor_drag_selection_can_start(const slayer3d_game_data_editor_sele
             selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
 }
 
+static bool editor_drag_mode_supports_creation(const char *mode)
+{
+    return SDL_strcmp(mode, "select") == 0 || SDL_strcmp(mode, "brush") == 0;
+}
+
+static bool editor_drag_selection_can_start_for_mode(const char *mode,
+                                                     const slayer3d_game_data_editor_selection *selection)
+{
+    if (selection == NULL || !selection->hit)
+        return false;
+
+    if (SDL_strcmp(mode, "select") == 0)
+    {
+        /* Select mode mirrors TrenchBroom's default draw-shape behavior: empty/work-plane drags
+           can create a cuboid, but brush-face drags remain available for selection/move tools. */
+        return selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID;
+    }
+
+    if (SDL_strcmp(mode, "brush") == 0)
+    {
+        /* Brush Tool mirrors TrenchBroom's assemble-brush behavior: an existing brush face is a
+           valid reference surface for drawing a secondary brush footprint. Empty work-plane drags
+           remain valid for the current simple blockout workflow. */
+        return editor_drag_selection_can_start(selection);
+    }
+
+    return false;
+}
+
 static int editor_drag_extrusion_axis_from_selection(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
                                                      yyjson_val *drag_json,
                                                      const slayer3d_game_data_editor_selection *selection)
@@ -726,7 +755,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         return false;
 
     const char *mode = scene_state_string(runtime, "editor.mode", "select");
-    if (SDL_strcmp(mode, "brush") != 0)
+    if (!editor_drag_mode_supports_creation(mode))
     {
         (void)editor_cancel_pending_brush_preview(runtime, "brush preview cancelled");
         return true;
@@ -760,7 +789,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         editor_drag_cancel_pending(runtime, placement, drag_json, "brush preview replaced");
     }
 
-    if (!drag->active && left_pressed && editor_drag_selection_can_start(hover_selection))
+    if (!drag->active && left_pressed && editor_drag_selection_can_start_for_mode(mode, hover_selection))
     {
         const float grid_size = editor_placement_grid_size(runtime, placement, drag_json,
                                                            json_float(placement, "default_grid_size", 16.0f));

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -14,6 +14,26 @@ static void clear_editor_drag_create(slayer3d_game_data_runtime *runtime)
     SDL_zero(runtime->editor_drag_create);
 }
 
+static const char *editor_drag_create_phase_name(editor_drag_create_phase phase)
+{
+    switch (phase)
+    {
+    case EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT:
+        return "drawing_footprint";
+    case EDITOR_DRAG_CREATE_PENDING_FOOTPRINT:
+        return "pending_footprint";
+    case EDITOR_DRAG_CREATE_ADJUSTING_DEPTH:
+        return "adjusting_depth";
+    case EDITOR_DRAG_CREATE_COMMITTED:
+        return "committed";
+    case EDITOR_DRAG_CREATE_CANCELED:
+        return "canceled";
+    case EDITOR_DRAG_CREATE_IDLE:
+    default:
+        return "idle";
+    }
+}
+
 bool editor_placement_preview_active_for_scene(const slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL || !runtime->editor_placement_preview.active)
@@ -84,6 +104,9 @@ static void publish_editor_placement_preview(slayer3d_game_data_runtime *runtime
     editor_set_float_output(scene_state, outputs, "dimension_z_key", dimensions.z);
     editor_set_string_output(scene_state, outputs, "warning_key",
                              valid && preview != NULL ? preview->source_warning : "");
+    editor_set_string_output(scene_state, outputs, "state_key",
+                             runtime != NULL ? editor_drag_create_phase_name(runtime->editor_drag_create.phase)
+                                             : "idle");
     const char *last_action_key = json_string(preview_json, "last_action_key", NULL);
     if (last_action_key != NULL && last_action_key[0] != '\0')
         slayer3d_properties_set_string(scene_state, last_action_key, message != NULL ? message : "");
@@ -216,6 +239,17 @@ static void editor_drag_publish_preview(slayer3d_game_data_runtime *runtime, yyj
         SDL_strlcpy(preview->source_warning, result->warning, sizeof(preview->source_warning));
     }
     publish_editor_placement_preview(runtime, outputs, valid, drag_json, valid ? preview : NULL, message);
+}
+
+static void editor_drag_cancel_pending(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                       yyjson_val *drag_json, const char *message)
+{
+    if (runtime == NULL)
+        return;
+    runtime->editor_drag_create.phase = EDITOR_DRAG_CREATE_CANCELED;
+    clear_editor_placement_preview(runtime);
+    publish_editor_placement_preview(runtime, obj_get(placement, "outputs"), false, drag_json, NULL, message);
+    clear_editor_drag_create(runtime);
 }
 
 static float editor_placement_elevation(slayer3d_game_data_runtime *runtime, yyjson_val *placement)
@@ -443,7 +477,21 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
     const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
     const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
+    const bool cancel_pressed = slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_ESCAPE);
     editor_drag_create_state *drag = &runtime->editor_drag_create;
+
+    if (drag->active && cancel_pressed)
+    {
+        editor_drag_cancel_pending(runtime, placement, drag_json, "brush preview cancelled");
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    if (drag->active && drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT && left_pressed)
+    {
+        editor_drag_cancel_pending(runtime, placement, drag_json, "brush preview replaced");
+    }
 
     if (!drag->active && left_pressed && hover_selection != NULL && hover_selection->hit &&
         hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID)
@@ -455,6 +503,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         (void)slayer3d_game_data_clear_active_editor_selection(runtime);
         SDL_zero(*drag);
         drag->active = true;
+        drag->phase = EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT;
         drag->scene = slayer3d_game_data_active_scene(runtime);
         drag->world_name = json_string(drag_json, "world", "brush.editor_shell.target");
         drag->material_name =
@@ -478,11 +527,14 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     if (out_consumed != NULL)
         *out_consumed = true;
 
-    editor_drag_update_current_cell(drag, hover_selection);
+    if (drag->phase == EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT)
+        editor_drag_update_current_cell(drag, hover_selection);
 
     editor_brush_source_prefab_result result;
     const bool valid = editor_drag_preview_source_box(runtime, drag_json, drag, &result);
-    const char *base_message = json_string(drag_json, "message", "drag brush preview");
+    const char *base_message = drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT
+                                   ? "Hold Shift and move mouse to set brush depth"
+                                   : json_string(drag_json, "message", "drag brush preview");
     char message[256];
     if (valid && result.warning[0] != '\0')
         SDL_snprintf(message, sizeof(message), "%s; %s", base_message, result.warning);
@@ -492,29 +544,20 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         SDL_strlcpy(message, base_message, sizeof(message));
     editor_drag_publish_preview(runtime, placement, drag_json, drag, &result, message, valid);
 
-    if (left_released || !left_down)
+    if (drag->phase == EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT && (left_released || !left_down))
     {
-        const bool should_commit = valid && drag->moved;
-        if (should_commit)
+        if (valid && drag->moved)
         {
-            editor_brush_source_prefab_result commit_result;
-            if (slayer3d_game_data_create_editor_source_box_brush(runtime, drag->world_name, drag->material_name,
-                                                                  drag->contents, drag->source_min, drag->source_max,
-                                                                  &commit_result) &&
-                runtime->scene_state != NULL)
-            {
-                slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "drag brush created");
-                editor_publish_console_message(runtime, "drag brush created");
-            }
+            drag->phase = EDITOR_DRAG_CREATE_PENDING_FOOTPRINT;
+            editor_drag_publish_preview(runtime, placement, drag_json, drag, &result,
+                                        "Hold Shift and move mouse to set brush depth", valid);
         }
-        else if (drag->moved && message[0] != '\0')
+        else
         {
-            editor_publish_console_message(runtime, message);
+            if (drag->moved && message[0] != '\0')
+                editor_publish_console_message(runtime, message);
+            editor_drag_cancel_pending(runtime, placement, drag_json, "drag cancelled");
         }
-        clear_editor_drag_create(runtime);
-        clear_editor_placement_preview(runtime);
-        publish_editor_placement_preview(runtime, obj_get(placement, "outputs"), false, drag_json, NULL,
-                                         should_commit ? "drag brush created" : "drag cancelled");
     }
     return true;
 }

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -385,6 +385,19 @@ static void editor_drag_cancel_pending(slayer3d_game_data_runtime *runtime, yyjs
     clear_editor_drag_create(runtime);
 }
 
+bool editor_cancel_pending_brush_preview(slayer3d_game_data_runtime *runtime, const char *message)
+{
+    if (runtime == NULL || !runtime->editor_drag_create.active)
+        return false;
+
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    yyjson_val *placement = obj_get(editor, "placement");
+    yyjson_val *drag_json = editor_drag_create_json(placement);
+    editor_drag_cancel_pending(runtime, placement, drag_json,
+                               message != NULL && message[0] != '\0' ? message : "brush preview cancelled");
+    return true;
+}
+
 static float editor_placement_elevation(slayer3d_game_data_runtime *runtime, yyjson_val *placement)
 {
     const float authored_elevation = json_float(placement, "default_elevation", 0.0f);
@@ -597,7 +610,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     const char *mode = scene_state_string(runtime, "editor.mode", "select");
     if (SDL_strcmp(mode, "select") != 0 && SDL_strcmp(mode, "brush") != 0)
     {
-        clear_editor_drag_create(runtime);
+        (void)editor_cancel_pending_brush_preview(runtime, "brush preview cancelled");
         return true;
     }
 

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -200,6 +200,20 @@ static int editor_drag_axis_from_normal(slayer3d_vec3 normal)
     return 1;
 }
 
+static float editor_drag_normal_component(slayer3d_vec3 normal, int axis)
+{
+    switch (axis)
+    {
+    case 0:
+        return normal.x;
+    case 2:
+        return normal.z;
+    case 1:
+    default:
+        return normal.y;
+    }
+}
+
 static int editor_drag_extrusion_axis_from_work_plane(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
                                                       yyjson_val *drag_json)
 {
@@ -225,6 +239,36 @@ static int editor_drag_extrusion_axis_from_work_plane(slayer3d_game_data_runtime
         axis = editor_drag_axis_from_normal(work_plane_normal);
     }
     return axis;
+}
+
+static bool editor_drag_selection_can_start(const slayer3d_game_data_editor_selection *selection)
+{
+    return selection != NULL && selection->hit &&
+           (selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID ||
+            selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD);
+}
+
+static int editor_drag_extrusion_axis_from_selection(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                                                     yyjson_val *drag_json,
+                                                     const slayer3d_game_data_editor_selection *selection)
+{
+    if (selection != NULL && selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD &&
+        slayer3d_vec3_length_squared(selection->normal) > 0.000001f)
+    {
+        return editor_drag_axis_from_normal(selection->normal);
+    }
+    return editor_drag_extrusion_axis_from_work_plane(runtime, editor, drag_json);
+}
+
+static int editor_drag_initial_depth_cells(const slayer3d_game_data_editor_selection *selection, int extrusion_axis)
+{
+    if (selection != NULL && selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD)
+    {
+        const float normal_component = editor_drag_normal_component(selection->normal, extrusion_axis);
+        if (normal_component < -0.0001f)
+            return -1;
+    }
+    return 1;
 }
 
 static int editor_drag_depth_cells(const editor_drag_create_state *drag)
@@ -682,7 +726,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         return false;
 
     const char *mode = scene_state_string(runtime, "editor.mode", "select");
-    if (SDL_strcmp(mode, "select") != 0 && SDL_strcmp(mode, "brush") != 0)
+    if (SDL_strcmp(mode, "brush") != 0)
     {
         (void)editor_cancel_pending_brush_preview(runtime, "brush preview cancelled");
         return true;
@@ -716,8 +760,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         editor_drag_cancel_pending(runtime, placement, drag_json, "brush preview replaced");
     }
 
-    if (!drag->active && left_pressed && hover_selection != NULL && hover_selection->hit &&
-        hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_INVALID)
+    if (!drag->active && left_pressed && editor_drag_selection_can_start(hover_selection))
     {
         const float grid_size = editor_placement_grid_size(runtime, placement, drag_json,
                                                            json_float(placement, "default_grid_size", 16.0f));
@@ -735,8 +778,8 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         drag->contents = brush_flags_from_json(obj_get(drag_json, "contents"), brush_content_flag_from_string,
                                                SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
         drag->grid_size = grid_size;
-        drag->extrusion_axis = editor_drag_extrusion_axis_from_work_plane(runtime, editor, drag_json);
-        drag->depth_cells = 1;
+        drag->extrusion_axis = editor_drag_extrusion_axis_from_selection(runtime, editor, drag_json, hover_selection);
+        drag->depth_cells = editor_drag_initial_depth_cells(hover_selection, drag->extrusion_axis);
         drag->start_cell[0] = editor_drag_cell(hover_selection->point.x, grid_size);
         drag->start_cell[1] = editor_drag_cell(hover_selection->point.y, grid_size);
         drag->start_cell[2] = editor_drag_cell(hover_selection->point.z, grid_size);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -159,6 +159,74 @@ static int editor_drag_extrusion_axis(const editor_drag_create_state *drag)
     return drag->extrusion_axis;
 }
 
+static const char *editor_drag_axis_name(int axis)
+{
+    switch (axis)
+    {
+    case 0:
+        return "x";
+    case 2:
+        return "z";
+    case 1:
+    default:
+        return "y";
+    }
+}
+
+static bool editor_drag_axis_from_name(const char *name, int *out_axis)
+{
+    if (name == NULL || out_axis == NULL)
+        return false;
+    if (SDL_strcmp(name, "x") == 0)
+        *out_axis = 0;
+    else if (SDL_strcmp(name, "y") == 0)
+        *out_axis = 1;
+    else if (SDL_strcmp(name, "z") == 0)
+        *out_axis = 2;
+    else
+        return false;
+    return true;
+}
+
+static int editor_drag_axis_from_normal(slayer3d_vec3 normal)
+{
+    normal.x = SDL_fabsf(normal.x);
+    normal.y = SDL_fabsf(normal.y);
+    normal.z = SDL_fabsf(normal.z);
+    if (normal.x >= normal.y && normal.x >= normal.z)
+        return 0;
+    if (normal.z >= normal.y)
+        return 2;
+    return 1;
+}
+
+static int editor_drag_extrusion_axis_from_work_plane(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                                                      yyjson_val *drag_json)
+{
+    int axis = 1;
+    const char *authored_axis = json_string(drag_json, "extrusion_axis", NULL);
+    if (editor_drag_axis_from_name(authored_axis, &axis))
+        return axis;
+
+    const char *axis_key = json_string(drag_json, "extrusion_axis_key", NULL);
+    if (runtime != NULL && axis_key != NULL && axis_key[0] != '\0' &&
+        editor_drag_axis_from_name(
+            slayer3d_properties_get_string(slayer3d_game_data_scene_state(runtime), axis_key, ""), &axis))
+    {
+        return axis;
+    }
+
+    yyjson_val *selection_json = obj_get(editor, "selection");
+    slayer3d_vec3 work_plane_normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    float work_plane_distance = 0.0f;
+    if (editor_work_plane_desc_from_trace_json(runtime, obj_get(selection_json, "trace"), &work_plane_normal,
+                                               &work_plane_distance))
+    {
+        axis = editor_drag_axis_from_normal(work_plane_normal);
+    }
+    return axis;
+}
+
 static int editor_drag_depth_cells(const editor_drag_create_state *drag)
 {
     if (drag == NULL || drag->depth_cells == 0)
@@ -195,14 +263,20 @@ static void editor_drag_update_current_cell(editor_drag_create_state *drag,
 {
     if (drag == NULL || hover_selection == NULL || !hover_selection->hit)
         return;
-    const int x = editor_drag_cell(hover_selection->point.x, drag->grid_size);
-    const int y = drag->start_cell[1];
-    const int z = editor_drag_cell(hover_selection->point.z, drag->grid_size);
-    if (drag->current_cell[0] != x || drag->current_cell[1] != y || drag->current_cell[2] != z)
+
+    const int extrusion_axis = editor_drag_extrusion_axis(drag);
+    const int next_cell[3] = {
+        extrusion_axis == 0 ? drag->start_cell[0] : editor_drag_cell(hover_selection->point.x, drag->grid_size),
+        extrusion_axis == 1 ? drag->start_cell[1] : editor_drag_cell(hover_selection->point.y, drag->grid_size),
+        extrusion_axis == 2 ? drag->start_cell[2] : editor_drag_cell(hover_selection->point.z, drag->grid_size)};
+    if (drag->current_cell[0] != next_cell[0] || drag->current_cell[1] != next_cell[1] ||
+        drag->current_cell[2] != next_cell[2])
+    {
         drag->moved = true;
-    drag->current_cell[0] = x;
-    drag->current_cell[1] = y;
-    drag->current_cell[2] = z;
+    }
+    drag->current_cell[0] = next_cell[0];
+    drag->current_cell[1] = next_cell[1];
+    drag->current_cell[2] = next_cell[2];
 }
 
 static float editor_drag_mouse_y(slayer3d_input_manager *input, float fallback)
@@ -355,7 +429,7 @@ static void editor_drag_publish_preview(slayer3d_game_data_runtime *runtime, yyj
         preview->scene = slayer3d_game_data_active_scene(runtime);
         preview->mode = json_string(drag_json, "mode", "drag_box");
         preview->kind = json_string(drag_json, "kind", "box");
-        preview->axis = "y";
+        preview->axis = editor_drag_axis_name(editor_drag_extrusion_axis(drag));
         preview->world_name = drag->world_name;
         preview->material_name = drag->material_name;
         preview->contents = drag->contents;
@@ -661,7 +735,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         drag->contents = brush_flags_from_json(obj_get(drag_json, "contents"), brush_content_flag_from_string,
                                                SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
         drag->grid_size = grid_size;
-        drag->extrusion_axis = 1;
+        drag->extrusion_axis = editor_drag_extrusion_axis_from_work_plane(runtime, editor, drag_json);
         drag->depth_cells = 1;
         drag->start_cell[0] = editor_drag_cell(hover_selection->point.x, grid_size);
         drag->start_cell[1] = editor_drag_cell(hover_selection->point.y, grid_size);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -1,5 +1,7 @@
 #include "game_data_internal.h"
 
+#include <SDL3/SDL_keyboard.h>
+
 void clear_editor_placement_preview(slayer3d_game_data_runtime *runtime)
 {
     if (runtime == NULL)
@@ -150,17 +152,39 @@ static int editor_drag_cell(float value, float grid_size)
     return (int)SDL_floorf(value / SDL_max(grid_size, 0.001f));
 }
 
+static int editor_drag_extrusion_axis(const editor_drag_create_state *drag)
+{
+    if (drag == NULL || drag->extrusion_axis < 0 || drag->extrusion_axis > 2)
+        return 1;
+    return drag->extrusion_axis;
+}
+
+static int editor_drag_depth_cells(const editor_drag_create_state *drag)
+{
+    if (drag == NULL || drag->depth_cells == 0)
+        return 1;
+    return drag->depth_cells;
+}
+
 static void editor_drag_source_bounds(const brush_world_runtime *world_runtime, const editor_drag_create_state *drag,
                                       int out_min[3], int out_max[3])
 {
-    const int min_cell[3] = {SDL_min(drag->start_cell[0], drag->current_cell[0]),
-                             SDL_min(drag->start_cell[1], drag->current_cell[1]),
-                             SDL_min(drag->start_cell[2], drag->current_cell[2])};
-    const int max_cell[3] = {SDL_max(drag->start_cell[0], drag->current_cell[0]) + 1,
-                             SDL_max(drag->start_cell[1], drag->current_cell[1]) + 1,
-                             SDL_max(drag->start_cell[2], drag->current_cell[2]) + 1};
+    const int extrusion_axis = editor_drag_extrusion_axis(drag);
+    const int depth_cells = editor_drag_depth_cells(drag);
+    int min_cell[3] = {0, 0, 0};
+    int max_cell[3] = {0, 0, 0};
     for (int axis = 0; axis < 3; ++axis)
     {
+        if (axis == extrusion_axis)
+        {
+            min_cell[axis] = SDL_min(drag->start_cell[axis], drag->start_cell[axis] + depth_cells);
+            max_cell[axis] = SDL_max(drag->start_cell[axis], drag->start_cell[axis] + depth_cells);
+        }
+        else
+        {
+            min_cell[axis] = SDL_min(drag->start_cell[axis], drag->current_cell[axis]);
+            max_cell[axis] = SDL_max(drag->start_cell[axis], drag->current_cell[axis]) + 1;
+        }
         out_min[axis] = editor_source_units_from_meters_public(world_runtime, (float)min_cell[axis] * drag->grid_size);
         out_max[axis] = editor_source_units_from_meters_public(world_runtime, (float)max_cell[axis] * drag->grid_size);
     }
@@ -179,6 +203,34 @@ static void editor_drag_update_current_cell(editor_drag_create_state *drag,
     drag->current_cell[0] = x;
     drag->current_cell[1] = y;
     drag->current_cell[2] = z;
+}
+
+static float editor_drag_mouse_y(slayer3d_input_manager *input, float fallback)
+{
+    float mouse_x = 0.0f;
+    float mouse_y = fallback;
+    return input != NULL && slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y) ? mouse_y : fallback;
+}
+
+static void editor_drag_set_adjusting_depth(editor_drag_create_state *drag, slayer3d_input_manager *input)
+{
+    if (drag == NULL)
+        return;
+    drag->depth_drag_start_mouse_y = editor_drag_mouse_y(input, 0.0f);
+    drag->depth_drag_start_cell = editor_drag_depth_cells(drag);
+    drag->phase = EDITOR_DRAG_CREATE_ADJUSTING_DEPTH;
+}
+
+static void editor_drag_update_depth(editor_drag_create_state *drag, slayer3d_input_manager *input)
+{
+    if (drag == NULL || input == NULL)
+        return;
+    const float mouse_y = editor_drag_mouse_y(input, drag->depth_drag_start_mouse_y);
+    const float units_per_pixel = SDL_max(drag->grid_size, 0.001f) / 48.0f;
+    const float meters_delta = (drag->depth_drag_start_mouse_y - mouse_y) * units_per_pixel;
+    const int cell_delta = (int)SDL_lroundf(meters_delta / SDL_max(drag->grid_size, 0.001f));
+    const int depth = drag->depth_drag_start_cell + cell_delta;
+    drag->depth_cells = depth != 0 ? depth : (cell_delta < 0 ? -1 : 1);
 }
 
 static bool editor_drag_preview_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *drag_json,
@@ -222,7 +274,7 @@ static void editor_drag_publish_preview(slayer3d_game_data_runtime *runtime, yyj
         preview->scene = slayer3d_game_data_active_scene(runtime);
         preview->mode = json_string(drag_json, "mode", "drag_box");
         preview->kind = json_string(drag_json, "kind", "box");
-        preview->axis = "xyz";
+        preview->axis = "y";
         preview->world_name = drag->world_name;
         preview->material_name = drag->material_name;
         preview->contents = drag->contents;
@@ -478,6 +530,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
     const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
     const bool cancel_pressed = slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_ESCAPE);
+    const bool shift_held = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
     editor_drag_create_state *drag = &runtime->editor_drag_create;
 
     if (drag->active && cancel_pressed)
@@ -512,6 +565,8 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         drag->contents = brush_flags_from_json(obj_get(drag_json, "contents"), brush_content_flag_from_string,
                                                SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID);
         drag->grid_size = grid_size;
+        drag->extrusion_axis = 1;
+        drag->depth_cells = 1;
         drag->start_cell[0] = editor_drag_cell(hover_selection->point.x, grid_size);
         drag->start_cell[1] = editor_drag_cell(hover_selection->point.y, grid_size);
         drag->start_cell[2] = editor_drag_cell(hover_selection->point.z, grid_size);
@@ -529,12 +584,22 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
 
     if (drag->phase == EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT)
         editor_drag_update_current_cell(drag, hover_selection);
+    else if (drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT && shift_held)
+        editor_drag_set_adjusting_depth(drag, input);
+    else if (drag->phase == EDITOR_DRAG_CREATE_ADJUSTING_DEPTH)
+    {
+        if (shift_held)
+            editor_drag_update_depth(drag, input);
+        else
+            drag->phase = EDITOR_DRAG_CREATE_PENDING_FOOTPRINT;
+    }
 
     editor_brush_source_prefab_result result;
     const bool valid = editor_drag_preview_source_box(runtime, drag_json, drag, &result);
-    const char *base_message = drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT
-                                   ? "Hold Shift and move mouse to set brush depth"
-                                   : json_string(drag_json, "message", "drag brush preview");
+    const char *base_message =
+        drag->phase == EDITOR_DRAG_CREATE_ADJUSTING_DEPTH     ? "Release Shift to keep depth, Enter to create brush"
+        : drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT ? "Hold Shift and move mouse to set brush depth"
+                                                              : json_string(drag_json, "message", "drag brush preview");
     char message[256];
     if (valid && result.warning[0] != '\0')
         SDL_snprintf(message, sizeof(message), "%s; %s", base_message, result.warning);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -798,6 +798,7 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
         (void)slayer3d_game_data_clear_active_editor_selection(runtime);
         SDL_zero(*drag);
         drag->active = true;
+        drag->commit_on_release = SDL_strcmp(mode, "select") == 0;
         drag->phase = EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT;
         drag->scene = slayer3d_game_data_active_scene(runtime);
         drag->world_name = json_string(drag_json, "world", "brush.editor_shell.target");
@@ -862,6 +863,11 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     {
         if (valid && drag->moved)
         {
+            if (drag->commit_on_release)
+            {
+                (void)editor_drag_commit_source_box(runtime, placement, drag_json, drag, &result);
+                return true;
+            }
             drag->phase = EDITOR_DRAG_CREATE_PENDING_FOOTPRINT;
             editor_drag_publish_preview(runtime, placement, drag_json, drag, &result,
                                         "Hold Shift and move mouse to set brush depth", valid);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -235,6 +235,87 @@ static void editor_drag_update_depth(editor_drag_create_state *drag, slayer3d_in
 
 static bool editor_drag_preview_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *drag_json,
                                            editor_drag_create_state *drag,
+                                           editor_brush_source_prefab_result *out_result);
+static void editor_drag_publish_preview(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                        yyjson_val *drag_json, editor_drag_create_state *drag,
+                                        const editor_brush_source_prefab_result *result, const char *message,
+                                        bool valid);
+
+static bool editor_drag_select_created_brush(slayer3d_game_data_runtime *runtime, const char *world_name,
+                                             const char *brush_name)
+{
+    if (runtime == NULL || world_name == NULL || world_name[0] == '\0' || brush_name == NULL || brush_name[0] == '\0')
+    {
+        return false;
+    }
+
+    const brush_world_runtime *world_runtime = find_brush_world_runtime(runtime, world_name);
+    const slayer3d_game_data_brush_world *world = world_runtime != NULL ? &world_runtime->desc : NULL;
+    if (world == NULL)
+        return false;
+
+    for (int i = 0; i < world->brush_count; ++i)
+    {
+        if (world->brushes[i].name == NULL || SDL_strcmp(world->brushes[i].name, brush_name) != 0)
+            continue;
+
+        slayer3d_game_data_editor_selection selection;
+        if (!editor_selection_from_brush_index(runtime, world_name, i, -1, &selection))
+            return false;
+        selection = resolved_editor_selection(runtime, &selection);
+        clear_editor_selected_brushes(runtime);
+        if (!add_editor_selected_brush(runtime, &selection))
+            return false;
+        update_active_editor_selection_from_selected_brushes(runtime);
+
+        yyjson_val *selection_json = obj_get(active_editor_tooling_root(runtime), "selection");
+        publish_editor_selection(runtime, obj_get(selection_json, "outputs"), &runtime->editor_active_selection);
+        return true;
+    }
+    return false;
+}
+
+static bool editor_drag_commit_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *placement,
+                                          yyjson_val *drag_json, editor_drag_create_state *drag,
+                                          editor_brush_source_prefab_result *preview_result)
+{
+    if (runtime == NULL || drag_json == NULL || drag == NULL)
+        return false;
+
+    editor_brush_source_prefab_result result;
+    SDL_zero(result);
+    if (preview_result == NULL)
+        preview_result = &result;
+    if (!editor_drag_preview_source_box(runtime, drag_json, drag, preview_result))
+    {
+        const char *message =
+            preview_result->warning[0] != '\0' ? preview_result->warning : "Invalid brush: preview cannot be created";
+        editor_drag_publish_preview(runtime, placement, drag_json, drag, preview_result, message, false);
+        editor_publish_console_message(runtime, message);
+        return false;
+    }
+
+    if (!slayer3d_game_data_create_editor_source_box_brush(runtime, drag->world_name, drag->material_name,
+                                                           drag->contents, drag->source_min, drag->source_max,
+                                                           preview_result))
+    {
+        const char *message = preview_result->warning[0] != '\0' ? preview_result->warning : "brush create failed";
+        editor_drag_publish_preview(runtime, placement, drag_json, drag, preview_result, message, false);
+        editor_publish_console_message(runtime, message);
+        return false;
+    }
+    (void)editor_drag_select_created_brush(runtime, drag->world_name, preview_result->brush_name);
+
+    drag->phase = EDITOR_DRAG_CREATE_COMMITTED;
+    clear_editor_placement_preview(runtime);
+    publish_editor_placement_preview(runtime, obj_get(placement, "outputs"), false, drag_json, NULL, "Brush created");
+    editor_publish_console_message(runtime, "Brush created");
+    clear_editor_drag_create(runtime);
+    return true;
+}
+
+static bool editor_drag_preview_source_box(slayer3d_game_data_runtime *runtime, yyjson_val *drag_json,
+                                           editor_drag_create_state *drag,
                                            editor_brush_source_prefab_result *out_result)
 {
     if (out_result != NULL)
@@ -530,6 +611,8 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
     const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
     const bool cancel_pressed = slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_ESCAPE);
+    const bool commit_pressed = slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RETURN) ||
+                                slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_KP_ENTER);
     const bool shift_held = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
     editor_drag_create_state *drag = &runtime->editor_drag_create;
 
@@ -608,6 +691,13 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
     else
         SDL_strlcpy(message, base_message, sizeof(message));
     editor_drag_publish_preview(runtime, placement, drag_json, drag, &result, message, valid);
+
+    if ((drag->phase == EDITOR_DRAG_CREATE_PENDING_FOOTPRINT || drag->phase == EDITOR_DRAG_CREATE_ADJUSTING_DEPTH) &&
+        commit_pressed)
+    {
+        (void)editor_drag_commit_source_box(runtime, placement, drag_json, drag, &result);
+        return true;
+    }
 
     if (drag->phase == EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT && (left_released || !left_down))
     {

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -149,6 +149,7 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
 
     if (SDL_strcmp(mode, "vertex") != 0)
         (void)slayer3d_game_data_clear_editor_vertex_selection(runtime);
+    (void)editor_cancel_pending_brush_preview(runtime, "brush preview cancelled");
     slayer3d_properties_set_string(runtime->scene_state, "editor.mode", mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.mode", tool_mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -63,6 +63,10 @@ typedef struct editor_drag_create_state
     const char *material_name;
     unsigned int contents;
     float grid_size;
+    int extrusion_axis;
+    int depth_cells;
+    int depth_drag_start_cell;
+    float depth_drag_start_mouse_y;
     int start_cell[3];
     int current_cell[3];
     int source_min[3];

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -57,6 +57,7 @@ typedef struct editor_drag_create_state
 {
     bool active;
     bool moved;
+    bool commit_on_release;
     editor_drag_create_phase phase;
     const char *scene;
     const char *world_name;

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -43,10 +43,21 @@ typedef struct editor_placement_preview_state
     char source_warning[256];
 } editor_placement_preview_state;
 
+typedef enum editor_drag_create_phase
+{
+    EDITOR_DRAG_CREATE_IDLE = 0,
+    EDITOR_DRAG_CREATE_DRAWING_FOOTPRINT,
+    EDITOR_DRAG_CREATE_PENDING_FOOTPRINT,
+    EDITOR_DRAG_CREATE_ADJUSTING_DEPTH,
+    EDITOR_DRAG_CREATE_COMMITTED,
+    EDITOR_DRAG_CREATE_CANCELED
+} editor_drag_create_phase;
+
 typedef struct editor_drag_create_state
 {
     bool active;
     bool moved;
+    editor_drag_create_phase phase;
     const char *scene;
     const char *world_name;
     const char *material_name;

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -970,6 +970,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.selection.clear", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.selection.clear", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.tool.set_mode", validate_editor_tool_set_mode_action),
+        ACTION_RULE_EXACT_HANDLER("editor.placement_preview.cancel", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.delete_selected", validate_editor_vertex_delete_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.vertex.merge_selected_to_hover",
                                   validate_editor_vertex_merge_selected_to_hover_action),

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -341,9 +341,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
                                         "scene editor placement default_elevation"))
         return false;
 
-    static const char *const output_keys[] = {"active_key", "valid_key", "mode_key",       "kind_key",
-                                              "axis_key",   "world_key", "material_key",   "message_key",
-                                              "anchor_key", "snap_key",  "bounds_min_key", "bounds_max_key"};
+    static const char *const output_keys[] = {
+        "active_key",  "valid_key",  "mode_key", "kind_key",       "axis_key",       "world_key", "material_key",
+        "message_key", "anchor_key", "snap_key", "bounds_min_key", "bounds_max_key", "state_key"};
     if (!validate_optional_output_keys(ctx, placement, placement_path, "scene editor placement", output_keys,
                                        SDL_arraysize(output_keys)))
         return false;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19797,7 +19797,7 @@ TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoSelectModeDragDoesNotCreatePendingFootprint)
+TEST(GameDataRuntime, EditorShellDojoSelectModeDragCreatesPendingFootprintInEmptySpace)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19864,7 +19864,8 @@ TEST(GameDataRuntime, EditorShellDojoSelectModeDragDoesNotCreatePendingFootprint
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 4);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
 
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;
@@ -19873,7 +19874,18 @@ TEST(GameDataRuntime, EditorShellDojoSelectModeDragDoesNotCreatePendingFootprint
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "canceled");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -20165,6 +20177,72 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragUsesActiveWorkPlaneAxis)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_z", 0.0f), 1.0f, 0.001f);
     EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_x", 0.0f), 0.0f);
     EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f), 0.0f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoSelectModeBrushFaceDragDoesNotStartSecondaryFootprint)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    ASSERT_NE(editor, nullptr);
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    slayer3d_game_data_editor_selection hover{};
+    hover.hit = true;
+    hover.type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+    hover.world_name = "brush.editor_shell.target";
+    hover.element_name = "brush.target.cube";
+    hover.material_name = "mat.editor.wall";
+    hover.face_index = 2;
+    hover.normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    hover.point = slayer3d_vec3_make(0.25f, 2.0f, 0.25f);
+
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 600.0f;
+    motion.motion.y = 360.0f;
+    slayer3d_input_process_event(input, &motion);
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+
+    bool consumed = true;
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+    EXPECT_FALSE(consumed);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+
+    hover.point = slayer3d_vec3_make(1.75f, 2.0f, 1.75f);
+    motion.motion.x = 720.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    consumed = true;
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+    EXPECT_FALSE(consumed);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -20216,6 +20216,134 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolShiftAdjustsPendingFootprintDepth)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushToolEnterCommitsPendingFootprintAsSourceBrush)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    const int undo_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.undo");
+    ASSERT_GE(mode_brush_signal, 0);
+    ASSERT_GE(undo_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 660.0f;
+    motion.motion.y = 360.0f;
+    slayer3d_input_process_event(input, &motion);
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_SHIFT;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 286.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = -144.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 5);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const float committed_height =
+        slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f);
+    ASSERT_GT(committed_height, 1.0f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 7);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    slayer3d_game_data_brush_world brush_world = world();
+    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
+    const slayer3d_game_data_brush &created = brush_world.brushes[brush_world.brush_count - 1];
+    ASSERT_NE(created.name, nullptr);
+    ASSERT_TRUE(created.has_bounds);
+    EXPECT_NEAR(created.bounds.max.y - created.bounds.min.y, committed_height, 0.001f);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "committed");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+
+    slayer3d_game_data_editor_selection selection{};
+    ASSERT_TRUE(slayer3d_game_data_get_active_editor_selection(runtime, &selection));
+    EXPECT_STREQ(selection.element_name, created.name);
+
+    slayer3d_signal_emit(bus, undo_signal, nullptr);
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -848,6 +848,54 @@ void select_editor_shell_test_cube(slayer3d_game_data_runtime *runtime)
     select_editor_shell_test_brush(runtime, "brush.target.cube");
 }
 
+void configure_editor_shell_drag_camera(slayer3d_game_data_runtime *runtime)
+{
+    ASSERT_NE(runtime, nullptr);
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+}
+
+void drag_editor_shell_pending_brush(slayer3d_game_data_runtime *runtime, slayer3d_input_manager *input, float start_x,
+                                     float start_y, float end_x, float end_y, int &frame)
+{
+    ASSERT_NE(runtime, nullptr);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = start_x;
+    motion.motion.y = start_y;
+    slayer3d_input_process_event(input, &motion);
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = start_x;
+    mouse.button.y = start_y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, ++frame);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = end_x;
+    motion.motion.y = end_y;
+    motion.motion.xrel = end_x - start_x;
+    motion.motion.yrel = end_y - start_y;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, ++frame);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = end_x;
+    mouse.button.y = end_y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, ++frame);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+}
+
 std::filesystem::path fps_template_data_path()
 {
     return demo_data_path("templates/fps", "fps_template.game.json");
@@ -20356,6 +20404,158 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolEnterCommitsPendingFootprintAsSour
     EXPECT_EQ(world().brush_count, initial_brush_count);
 
     SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushToolToolSwitchCancelsPendingFootprint)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    configure_editor_shell_drag_camera(runtime);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    const int mode_select_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.select");
+    ASSERT_GE(mode_brush_signal, 0);
+    ASSERT_GE(mode_select_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    int frame = 0;
+    drag_editor_shell_pending_brush(runtime, input, 660.0f, 360.0f, 780.0f, 430.0f, frame);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    ASSERT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+
+    slayer3d_signal_emit(bus, mode_select_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "canceled");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""),
+                 "brush preview cancelled");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushToolDeleteCancelsPendingFootprintBeforeDeletingSelection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    configure_editor_shell_drag_camera(runtime);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    const int delete_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.delete_selected");
+    ASSERT_GE(mode_brush_signal, 0);
+    ASSERT_GE(delete_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    int frame = 0;
+    drag_editor_shell_pending_brush(runtime, input, 660.0f, 360.0f, 780.0f, 430.0f, frame);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+
+    seed_editor_shell_test_cube(runtime);
+    select_editor_shell_test_cube(runtime);
+    ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int brush_count_with_selection = world().brush_count;
+
+    slayer3d_signal_emit(bus, delete_signal, nullptr);
+    EXPECT_EQ(world().brush_count, brush_count_with_selection);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "canceled");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""),
+                 "brush preview cancelled");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushToolNewDragReplacesPendingFootprint)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    configure_editor_shell_drag_camera(runtime);
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    int frame = 0;
+    drag_editor_shell_pending_brush(runtime, input, 660.0f, 360.0f, 780.0f, 430.0f, frame);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    const slayer3d_value *first_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(first_min, nullptr);
+    ASSERT_EQ(first_min->type, SLAYER3D_VALUE_VEC3);
+    const slayer3d_vec3 first_bounds_min = first_min->as_vec3;
+
+    drag_editor_shell_pending_brush(runtime, input, 560.0f, 360.0f, 650.0f, 440.0f, frame);
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    const slayer3d_value *second_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(second_min, nullptr);
+    ASSERT_EQ(second_min->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_GT(slayer3d_vec3_length(slayer3d_vec3_sub(second_min->as_vec3, first_bounds_min)), 0.1f);
+
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19920,19 +19920,35 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragLeavesPendingSourceBrushFootpr
     struct DragPreviewDebug
     {
         int edges = 0;
+        int footprint_edges = 0;
+        int axis_guides = 0;
     } drag_preview_debug;
     auto count_drag_preview = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) {
         auto *debug = static_cast<DragPreviewDebug *>(userdata);
-        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE &&
-            primitive->element_name != nullptr && SDL_strcmp(primitive->element_name, "drag_box") == 0)
+        if (primitive == nullptr || primitive->element_name == nullptr ||
+            SDL_strcmp(primitive->element_name, "drag_box") != 0)
         {
-            debug->edges++;
+            return true;
+        }
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE)
+        {
+            ++debug->edges;
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_FOOTPRINT_EDGE)
+        {
+            ++debug->footprint_edges;
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLACEMENT_PREVIEW_AXIS)
+        {
+            ++debug->axis_guides;
         }
         return true;
     };
     ASSERT_TRUE(
         slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_drag_preview, &drag_preview_debug));
     EXPECT_EQ(drag_preview_debug.edges, 24);
+    EXPECT_EQ(drag_preview_debug.footprint_edges, 4);
+    EXPECT_EQ(drag_preview_debug.axis_guides, 1);
 
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19975,6 +19975,97 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragLeavesPendingSourceBrushFootpr
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushToolDragNormalizesReversedFootprint)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 780.0f;
+    motion.motion.y = 430.0f;
+    slayer3d_input_process_event(input, &motion);
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 660.0f;
+    motion.motion.y = 360.0f;
+    motion.motion.xrel = -120.0f;
+    motion.motion.yrel = -70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    const slayer3d_value *preview_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *preview_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(preview_min, nullptr);
+    ASSERT_NE(preview_max, nullptr);
+    ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_LT(preview_min->as_vec3.x, preview_max->as_vec3.x);
+    EXPECT_LT(preview_min->as_vec3.y, preview_max->as_vec3.y);
+    EXPECT_LT(preview_min->as_vec3.z, preview_max->as_vec3.z);
+    EXPECT_GE(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_x", 0.0f), 1.0f);
+    EXPECT_GE(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f), 1.0f);
+    EXPECT_GE(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_z", 0.0f), 1.0f);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -157,6 +157,8 @@ extern "C"
     yyjson_val *active_editor_tooling_root(const slayer3d_game_data_runtime *runtime);
     void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
                                          const slayer3d_game_data_editor_selection *hover_selection);
+    bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *editor,
+                                   const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed);
     brush_world_runtime *find_brush_world_runtime_mutable(slayer3d_game_data_runtime *runtime, const char *name);
     int editor_brush_world_source_box_face_index_for_identity(const brush_world_runtime *world_runtime,
                                                               const char *brush_identity, int fallback_face_index,
@@ -19795,7 +19797,7 @@ TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoDragCreateRequiresMovementAndCancelsPendingFootprint)
+TEST(GameDataRuntime, EditorShellDojoSelectModeDragDoesNotCreatePendingFootprint)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19862,8 +19864,7 @@ TEST(GameDataRuntime, EditorShellDojoDragCreateRequiresMovementAndCancelsPending
     slayer3d_input_process_event(input, &motion);
     slayer3d_input_update(input, 4);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
 
     mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
     mouse.button.x = motion.motion.x;
@@ -19872,15 +19873,6 @@ TEST(GameDataRuntime, EditorShellDojoDragCreateRequiresMovementAndCancelsPending
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_EQ(world().brush_count, initial_brush_count);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
-                 "pending_footprint");
-    SDL_Event key{};
-    key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_ESCAPE;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 6);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
 
     slayer3d_game_data_destroy(runtime);
@@ -20173,6 +20165,114 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragUsesActiveWorkPlaneAxis)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_z", 0.0f), 1.0f, 0.001f);
     EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_x", 0.0f), 0.0f);
     EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f), 0.0f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushToolDragStartsOnHoveredBrushFace)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    ASSERT_NE(editor, nullptr);
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_game_data_editor_selection hover{};
+    hover.hit = true;
+    hover.type = SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD;
+    hover.world_name = "brush.editor_shell.target";
+    hover.element_name = "brush.target.cube";
+    hover.material_name = "mat.editor.wall";
+    hover.face_index = 2;
+    hover.normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    hover.point = slayer3d_vec3_make(0.25f, 2.0f, 0.25f);
+
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 600.0f;
+    motion.motion.y = 360.0f;
+    slayer3d_input_process_event(input, &motion);
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    bool consumed = false;
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+    EXPECT_TRUE(consumed);
+
+    hover.point = slayer3d_vec3_make(1.75f, 2.0f, 1.75f);
+    motion.motion.x = 720.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+    EXPECT_TRUE(consumed);
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "y");
+    const slayer3d_value *preview_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *preview_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(preview_min, nullptr);
+    ASSERT_NE(preview_max, nullptr);
+    ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(preview_min->as_vec3.y, 2.0f, 0.001f);
+    EXPECT_NEAR(preview_max->as_vec3.y, 3.0f, 0.001f);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_RETURN;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(update_editor_drag_create(runtime, editor, &hover, &consumed));
+
+    const slayer3d_game_data_brush_world brush_world = world();
+    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
+    const slayer3d_game_data_brush &created = brush_world.brushes[brush_world.brush_count - 1];
+    ASSERT_TRUE(created.has_bounds);
+    EXPECT_NEAR(created.bounds.min.y, 2.0f, 0.001f);
+    EXPECT_NEAR(created.bounds.max.y, 3.0f, 0.001f);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -20066,6 +20066,156 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragNormalizesReversedFootprint)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushToolShiftAdjustsPendingFootprintDepth)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    editor_camera->position = slayer3d_vec3_make(32.0f, 8.0f, 32.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "pitch", -0.6f);
+    slayer3d_properties_set_vec3(editor_camera->props, "camera_forward",
+                                 slayer3d_vec3_make(0.0f, -0.564642f, -0.825336f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 660.0f;
+    motion.motion.y = 360.0f;
+    slayer3d_input_process_event(input, &motion);
+
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 430.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 70.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    const float pending_height =
+        slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f);
+    ASSERT_NEAR(pending_height, 1.0f, 0.001f);
+    const slayer3d_value *pending_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    ASSERT_NE(pending_min, nullptr);
+    ASSERT_EQ(pending_min->type, SLAYER3D_VALUE_VEC3);
+    const float base_y = pending_min->as_vec3.y;
+
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_SHIFT;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "adjusting_depth");
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 286.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = -144.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 5);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "y");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "adjusting_depth");
+    const float adjusted_height =
+        slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f);
+    EXPECT_GT(adjusted_height, pending_height + 1.0f);
+
+    key.type = SDL_EVENT_KEY_UP;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_input_update(input, 6);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f),
+                adjusted_height, 0.001f);
+
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_SHIFT;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 7);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    ASSERT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "adjusting_depth");
+
+    motion.motion.x = 780.0f;
+    motion.motion.y = 670.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = 384.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 8);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    const slayer3d_value *negative_min =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    const slayer3d_value *negative_max =
+        slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(negative_min, nullptr);
+    ASSERT_NE(negative_max, nullptr);
+    ASSERT_EQ(negative_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(negative_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_LT(negative_min->as_vec3.y, base_y);
+    EXPECT_NEAR(negative_max->as_vec3.y, base_y, 0.001f);
+    EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f), 1.0f);
+    key.type = SDL_EVENT_KEY_UP;
+    key.key.scancode = SDL_SCANCODE_LSHIFT;
+    key.key.mod = SDL_KMOD_NONE;
+    slayer3d_input_process_event(input, &key);
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+
+    SDL_SetModState(SDL_KMOD_NONE);
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -20130,6 +20130,54 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragNormalizesReversedFootprint)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushToolDragUsesActiveWorkPlaneAxis)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    configure_editor_shell_drag_camera(runtime);
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_properties_set_vec3(scene_state, "editor.work_plane.normal", slayer3d_vec3_make(0.0f, 0.0f, 1.0f));
+    slayer3d_properties_set_float(scene_state, "editor.work_plane.distance", 0.0f);
+
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+
+    auto world = [&]() {
+        slayer3d_game_data_brush_world brush_world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
+        return brush_world;
+    };
+    const int initial_brush_count = world().brush_count;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    int frame = 0;
+    drag_editor_shell_pending_brush(runtime, input, 660.0f, 360.0f, 780.0f, 430.0f, frame);
+
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.axis", ""), "z");
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_z", 0.0f), 1.0f, 0.001f);
+    EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_x", 0.0f), 0.0f);
+    EXPECT_GT(slayer3d_properties_get_float(scene_state, "editor.placement_preview.dimension_y", 0.0f), 0.0f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushToolShiftAdjustsPendingFootprintDepth)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19747,7 +19747,7 @@ TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
+TEST(GameDataRuntime, EditorShellDojoDragCreateRequiresMovementAndCancelsPendingFootprint)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19777,18 +19777,6 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
-    auto find_brush_bounds = [&](const std::string &name) {
-        const slayer3d_game_data_brush_world brush_world = world();
-        for (int i = 0; i < brush_world.brush_count; ++i)
-        {
-            const slayer3d_game_data_brush &brush = brush_world.brushes[i];
-            if (brush.name != nullptr && name == brush.name)
-                return brush.bounds;
-        }
-        ADD_FAILURE() << "brush not found: " << name;
-        return slayer3d_bounding_box{slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec3_make(0.0f, 0.0f, 0.0f)};
-    };
-
     const int initial_brush_count = world().brush_count;
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
@@ -19835,167 +19823,23 @@ TEST(GameDataRuntime, EditorShellDojoDragCreatesAndNudgesSourceBrush)
     slayer3d_input_process_event(input, &mouse);
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    slayer3d_game_data_brush_world brush_world = world();
-    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
-    const slayer3d_game_data_brush &created_brush = brush_world.brushes[brush_world.brush_count - 1];
-    ASSERT_NE(created_brush.name, nullptr);
-    const std::string created_name = created_brush.name;
-    EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
-
-    char select_action_json[512];
-    SDL_snprintf(select_action_json, sizeof(select_action_json),
-                 R"json({"world":"brush.editor_shell.target","element":"%s"})json", created_name.c_str());
-    yyjson_doc *select_doc = yyjson_read(select_action_json, SDL_strlen(select_action_json), 0);
-    ASSERT_NE(select_doc, nullptr);
-    ASSERT_TRUE(slayer3d_game_data_select_editor_brush_action(runtime, yyjson_doc_get_root(select_doc)));
-    yyjson_doc_free(select_doc);
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_x", 0.0f),
-                created_brush.bounds.max.x - created_brush.bounds.min.x, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_y", 0.0f),
-                created_brush.bounds.max.y - created_brush.bounds.min.y, 0.001f);
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.selection.dimension_z", 0.0f),
-                created_brush.bounds.max.z - created_brush.bounds.min.z, 0.001f);
-    EXPECT_STRNE(slayer3d_properties_get_string(scene_state, "editor.selection.element_stable_id", ""), "");
-    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
-    ASSERT_NE(bus, nullptr);
-    const int clear_selection_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.selection.clear");
-    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
-    ASSERT_GE(clear_selection_signal, 0);
-    ASSERT_GE(mode_brush_signal, 0);
-    slayer3d_signal_emit(bus, clear_selection_signal, nullptr);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", -1), 0);
-    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
-
-    const slayer3d_bounding_box before_drag_move = find_brush_bounds(created_name);
-    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
-    mouse.button.button = SDL_BUTTON_LEFT;
-    mouse.button.x = motion.motion.x;
-    mouse.button.y = motion.motion.y;
-    slayer3d_input_process_event(input, &mouse);
+    EXPECT_EQ(world().brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    slayer3d_input_process_event(input, &key);
     slayer3d_input_update(input, 6);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), created_name.c_str());
-    motion.motion.x = 820.0f;
-    motion.motion.y = 430.0f;
-    motion.motion.xrel = 40.0f;
-    motion.motion.yrel = 0.0f;
-    slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, 7);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    const float live_drag_dx = slayer3d_properties_get_float(scene_state, "editor.brush.drag.delta_x", 0.0f);
-    const float live_drag_dz = slayer3d_properties_get_float(scene_state, "editor.brush.drag.delta_z", 0.0f);
-    EXPECT_GT(SDL_fabsf(live_drag_dx) + SDL_fabsf(live_drag_dz), 0.001f);
-    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
-    mouse.button.x = motion.motion.x;
-    mouse.button.y = motion.motion.y;
-    slayer3d_input_process_event(input, &mouse);
-    slayer3d_input_update(input, 8);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    const slayer3d_bounding_box after_drag_move = find_brush_bounds(created_name);
-    const float drag_dx = after_drag_move.min.x - before_drag_move.min.x;
-    const float drag_dz = after_drag_move.min.z - before_drag_move.min.z;
-    EXPECT_GT(SDL_fabsf(drag_dx) + SDL_fabsf(drag_dz), 0.001f);
-    EXPECT_NEAR(drag_dx, SDL_roundf(drag_dx), 0.001f);
-    EXPECT_NEAR(drag_dz, SDL_roundf(drag_dz), 0.001f);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag moved brush");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.console.line0", ""), "drag moved brush");
-
-    const slayer3d_bounding_box before_nudge = find_brush_bounds(created_name);
-    SDL_Event key{};
-    Uint64 key_frame = 9;
-    auto press_key = [&](SDL_Scancode scancode, SDL_Keymod modifiers = SDL_KMOD_NONE) {
-        SDL_SetModState(modifiers);
-        key.type = SDL_EVENT_KEY_DOWN;
-        key.key.scancode = scancode;
-        key.key.mod = modifiers;
-        slayer3d_input_process_event(input, &key);
-        slayer3d_input_update(input, key_frame++);
-        EXPECT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-        key.type = SDL_EVENT_KEY_UP;
-        slayer3d_input_process_event(input, &key);
-        SDL_SetModState(SDL_KMOD_NONE);
-        slayer3d_input_update(input, key_frame++);
-    };
-
-    press_key(SDL_SCANCODE_RIGHT);
-    slayer3d_bounding_box after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.z, before_nudge.min.z + 1.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.z, before_nudge.max.z + 1.0f, 0.001f);
-
-    press_key(SDL_SCANCODE_PAGEUP);
-    after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.y, before_nudge.min.y + 1.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.y, before_nudge.max.y + 1.0f, 0.001f);
-
-    const slayer3d_bounding_box before_up = after_nudge;
-    press_key(SDL_SCANCODE_UP);
-    after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.x, before_up.min.x + 1.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.x, before_up.max.x + 1.0f, 0.001f);
-
-    press_key(SDL_SCANCODE_DOWN);
-    after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.x, before_up.min.x, 0.001f);
-    EXPECT_NEAR(after_nudge.max.x, before_up.max.x, 0.001f);
-
-    const slayer3d_bounding_box before_vertical_modifier = after_nudge;
-    press_key(SDL_SCANCODE_UP, SDL_KMOD_CTRL);
-    after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.y, before_vertical_modifier.min.y + 1.0f, 0.001f);
-    EXPECT_NEAR(after_nudge.max.y, before_vertical_modifier.max.y + 1.0f, 0.001f);
-
-    const slayer3d_bounding_box before_alt_drag = after_nudge;
-    SDL_SetModState(SDL_KMOD_ALT);
-    key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_LALT;
-    key.key.mod = SDL_KMOD_ALT;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, key_frame++);
-    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
-    mouse.button.button = SDL_BUTTON_LEFT;
-    mouse.button.x = 820.0f;
-    mouse.button.y = 430.0f;
-    slayer3d_input_process_event(input, &mouse);
-    slayer3d_input_update(input, key_frame++);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    motion.motion.x = 820.0f;
-    motion.motion.y = 330.0f;
-    motion.motion.xrel = 0.0f;
-    motion.motion.yrel = -100.0f;
-    slayer3d_input_process_event(input, &motion);
-    slayer3d_input_update(input, key_frame++);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
-    mouse.button.x = motion.motion.x;
-    mouse.button.y = motion.motion.y;
-    slayer3d_input_process_event(input, &mouse);
-    key.type = SDL_EVENT_KEY_UP;
-    key.key.scancode = SDL_SCANCODE_LALT;
-    key.key.mod = SDL_KMOD_NONE;
-    slayer3d_input_process_event(input, &key);
-    SDL_SetModState(SDL_KMOD_NONE);
-    slayer3d_input_update(input, key_frame++);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    after_nudge = find_brush_bounds(created_name);
-    EXPECT_NEAR(after_nudge.min.x, before_alt_drag.min.x, 0.001f);
-    EXPECT_NEAR(after_nudge.min.z, before_alt_drag.min.z, 0.001f);
-    EXPECT_GT(after_nudge.min.y, before_alt_drag.min.y + 0.5f);
-    const slayer3d_value *selection_bounds_min =
-        slayer3d_properties_get_value(scene_state, "editor.selection.bounds_min");
-    ASSERT_NE(selection_bounds_min, nullptr);
-    ASSERT_EQ(selection_bounds_min->type, SLAYER3D_VALUE_VEC3);
-    EXPECT_NEAR(selection_bounds_min->as_vec3.y, after_nudge.min.y, 0.001f);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
+TEST(GameDataRuntime, EditorShellDojoBrushToolDragLeavesPendingSourceBrushFootprint)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -20098,18 +19942,34 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragCreatesSourceBrushFromPreview)
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
 
     const slayer3d_game_data_brush_world brush_world = world();
-    ASSERT_EQ(brush_world.brush_count, initial_brush_count + 1);
-    const slayer3d_game_data_brush &created_brush = brush_world.brushes[brush_world.brush_count - 1];
-    EXPECT_NEAR(created_brush.bounds.min.x, expected_min.x, 0.001f);
-    EXPECT_NEAR(created_brush.bounds.min.y, expected_min.y, 0.001f);
-    EXPECT_NEAR(created_brush.bounds.min.z, expected_min.z, 0.001f);
-    EXPECT_NEAR(created_brush.bounds.max.x, expected_max.x, 0.001f);
-    EXPECT_NEAR(created_brush.bounds.max.y, expected_max.y, 0.001f);
-    EXPECT_NEAR(created_brush.bounds.max.z, expected_max.z, 0.001f);
-    ASSERT_NE(created_brush.faces, nullptr);
-    EXPECT_STREQ(created_brush.faces[0].material_name, "mat.editor.floor");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag brush created");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.console.line0", ""), "drag brush created");
+    ASSERT_EQ(brush_world.brush_count, initial_brush_count);
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""),
+                 "Hold Shift and move mouse to set brush depth");
+    preview_min = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_min");
+    preview_max = slayer3d_properties_get_value(scene_state, "editor.placement_preview.bounds_max");
+    ASSERT_NE(preview_min, nullptr);
+    ASSERT_NE(preview_max, nullptr);
+    ASSERT_EQ(preview_min->type, SLAYER3D_VALUE_VEC3);
+    ASSERT_EQ(preview_max->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(preview_min->as_vec3.x, expected_min.x, 0.001f);
+    EXPECT_NEAR(preview_min->as_vec3.y, expected_min.y, 0.001f);
+    EXPECT_NEAR(preview_min->as_vec3.z, expected_min.z, 0.001f);
+    EXPECT_NEAR(preview_max->as_vec3.x, expected_max.x, 0.001f);
+    EXPECT_NEAR(preview_max->as_vec3.y, expected_max.y, 0.001f);
+    EXPECT_NEAR(preview_max->as_vec3.z, expected_max.z, 0.001f);
+
+    SDL_Event key{};
+    key.type = SDL_EVENT_KEY_DOWN;
+    key.key.scancode = SDL_SCANCODE_ESCAPE;
+    slayer3d_input_process_event(input, &key);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "canceled");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19797,7 +19797,7 @@ TEST(GameDataRuntime, EditorShellDojoAllowsOverlappingWallPreviewWithSourceModel
     slayer3d_game_session_destroy(session);
 }
 
-TEST(GameDataRuntime, EditorShellDojoSelectModeDragCreatesPendingFootprintInEmptySpace)
+TEST(GameDataRuntime, EditorShellDojoSelectModeDragAutoCommitsBrushInEmptySpace)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
     ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
@@ -19873,19 +19873,10 @@ TEST(GameDataRuntime, EditorShellDojoSelectModeDragCreatesPendingFootprintInEmpt
     slayer3d_input_process_event(input, &mouse);
     slayer3d_input_update(input, 5);
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
-    EXPECT_EQ(world().brush_count, initial_brush_count);
-    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
-                 "pending_footprint");
-
-    SDL_Event key{};
-    key.type = SDL_EVENT_KEY_DOWN;
-    key.key.scancode = SDL_SCANCODE_ESCAPE;
-    slayer3d_input_process_event(input, &key);
-    slayer3d_input_update(input, 6);
-    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_EQ(world().brush_count, initial_brush_count + 1);
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", true));
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "canceled");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""), "committed");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.message", ""), "Brush created");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -20351,6 +20342,77 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragStartsOnHoveredBrushFace)
     ASSERT_TRUE(created.has_bounds);
     EXPECT_NEAR(created.bounds.min.y, 2.0f, 0.001f);
     EXPECT_NEAR(created.bounds.max.y, 3.0f, 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
+TEST(GameDataRuntime, EditorShellDojoBrushToolFaceDragUsesToolingBeforeBrushMove)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_signal_bus *bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(bus, nullptr);
+    const int mode_brush_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.brush");
+    ASSERT_GE(mode_brush_signal, 0);
+    slayer3d_signal_emit(bus, mode_brush_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "brush");
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    motion.motion.xrel = 0.0f;
+    motion.motion.yrel = 0.0f;
+    SDL_Event mouse{};
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    mouse.button.button = SDL_BUTTON_LEFT;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.mode", ""), "drag_box");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "drawing_footprint");
+    EXPECT_STRNE(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "drag moved brush");
+
+    motion.motion.x = 700.0f;
+    motion.motion.y = 380.0f;
+    motion.motion.xrel = 60.0f;
+    motion.motion.yrel = 40.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+
+    mouse.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    mouse.button.x = motion.motion.x;
+    mouse.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &mouse);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.state", ""),
+                 "pending_footprint");
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- Add an explicit brush drag-create state machine for idle, drawing footprint, pending footprint, depth adjustment, committed, and canceled phases
- Keep brush drag previews pending after mouse release instead of immediately committing geometry
- Publish placement preview state to editor data and validate the new output key
- Update editor shell tests for click-without-drag, pending footprint, replacement/cancel behavior, and preview bounds

## Tests
- ./scripts/check_clang_format.sh
- cmake --build build/debug --target slayer3d_game_data_test
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojo*'
- ./build/debug/tests/slayer3d_game_data_test

Closes none. Part of #439.

## Manual verification
In the editor, select Brush Tool, drag in empty grid space, and release. The preview should remain as an uncommitted footprint. Press Escape to cancel it. Shift extrusion and Enter commit are intentionally reserved for the next slices.