### PR TITLE
Add Windows MSVC CI build

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,0 +1,79 @@
+name: Windows MSVC
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  static-debug:
+    name: MSVC static Debug
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      BUILD_DIR: build\windows-msvc
+      BUILD_CONFIG: Debug
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path logs | Out-Null
+          cmake -S . -B "$env:BUILD_DIR" `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -DSLAYER3D_BUILD_TESTS=ON `
+            -DSLAYER3D_BUILD_DEMOS=ON `
+            -DSLAYER3D_BUILD_BENCHMARKS=OFF `
+            -DSLAYER3D_SDL_LINKAGE=static 2>&1 | Tee-Object logs\configure.log
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Build
+        shell: pwsh
+        run: |
+          cmake --build "$env:BUILD_DIR" --config "$env:BUILD_CONFIG" --parallel 2>&1 | Tee-Object logs\build.log
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Verify SDL is statically linked
+        shell: pwsh
+        run: |
+          dumpbin /DEPENDENTS "$env:BUILD_DIR\$env:BUILD_CONFIG\slayer3d_editor.exe" | Tee-Object logs\editor-dependencies.log
+          if (Select-String -Path logs\editor-dependencies.log -Pattern 'SDL3\.dll') {
+            Write-Error 'slayer3d_editor.exe imports SDL3.dll; expected static SDL linkage.'
+            exit 1
+          }
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          ctest --test-dir "$env:BUILD_DIR" -C "$env:BUILD_CONFIG" --output-on-failure 2>&1 | Tee-Object logs\ctest.log
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Smoke test editor help
+        shell: pwsh
+        run: |
+          & "$env:BUILD_DIR\$env:BUILD_CONFIG\slayer3d_editor.exe" -h 2>&1 | Tee-Object logs\editor-help.log
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msvc-logs
+          path: logs
+          retention-days: 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ else()
     option(SLAYER3D_BUILD_TESTS "Build Slayer 3D tests" OFF)
 endif()
 option(SLAYER3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
+set(SLAYER3D_SDL_LINKAGE
+    "static"
+    CACHE STRING "SDL3 link mode: static, shared, or auto")
+set_property(CACHE SLAYER3D_SDL_LINKAGE PROPERTY STRINGS static shared auto)
 option(SLAYER3D_ENABLE_NETWORKING "Enable SDL3_net-based network transport" ON)
 option(SLAYER3D_COMPRESS_PACKS "Compress Slayer 3D asset packs by default" ON)
 set(SLAYER3D_PACK_PASSWORD
@@ -40,11 +44,34 @@ include(Slayer3DCompilerWarnings)
 include(Slayer3DSanitizers)
 include(Slayer3DAssets)
 
-if(NOT TARGET SDL3::SDL3)
-    find_package(SDL3 3.2 CONFIG QUIET COMPONENTS SDL3)
+if(NOT SLAYER3D_SDL_LINKAGE STREQUAL "static" AND NOT SLAYER3D_SDL_LINKAGE STREQUAL "shared"
+   AND NOT SLAYER3D_SDL_LINKAGE STREQUAL "auto")
+    message(FATAL_ERROR "SLAYER3D_SDL_LINKAGE must be 'static', 'shared', or 'auto'.")
 endif()
 
-if(NOT TARGET SDL3::SDL3 AND SLAYER3D_FETCH_SDL3)
+function(slayer3d_copy_runtime_dlls target_name)
+    if(WIN32)
+        add_custom_command(
+            TARGET ${target_name}
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E $<IF:$<BOOL:$<TARGET_RUNTIME_DLLS:${target_name}>>,copy_if_different,true>
+                    $<TARGET_RUNTIME_DLLS:${target_name}> $<TARGET_FILE_DIR:${target_name}>
+            COMMAND_EXPAND_LISTS
+        )
+    endif()
+endfunction()
+
+if(NOT TARGET SDL3::SDL3 AND NOT TARGET SDL3::SDL3-static AND NOT TARGET SDL3::SDL3-shared)
+    if(SLAYER3D_SDL_LINKAGE STREQUAL "static")
+        find_package(SDL3 3.2 CONFIG QUIET COMPONENTS SDL3-static)
+    elseif(SLAYER3D_SDL_LINKAGE STREQUAL "shared")
+        find_package(SDL3 3.2 CONFIG QUIET COMPONENTS SDL3-shared)
+    else()
+        find_package(SDL3 3.2 CONFIG QUIET COMPONENTS SDL3)
+    endif()
+endif()
+
+if(NOT TARGET SDL3::SDL3 AND NOT TARGET SDL3::SDL3-static AND NOT TARGET SDL3::SDL3-shared AND SLAYER3D_FETCH_SDL3)
     FetchContent_Declare(
         SDL3
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
@@ -52,12 +79,18 @@ if(NOT TARGET SDL3::SDL3 AND SLAYER3D_FETCH_SDL3)
         GIT_SHALLOW TRUE
     )
 
-    if(IOS)
+    if(IOS AND SLAYER3D_SDL_LINKAGE STREQUAL "shared")
+        message(FATAL_ERROR "iOS app bundles require SLAYER3D_SDL_LINKAGE=static or auto.")
+    endif()
+    if(SLAYER3D_SDL_LINKAGE STREQUAL "static" OR IOS)
         # iOS app bundles cannot rely on a build-tree SDL dylib at runtime.
-        # Force a static SDL so the simulator/device app can launch without
-        # embedding extra runtime artifacts into the .app.
+        # Prefer static SDL by default so build-tree tools do not require
+        # embedding extra runtime artifacts.
         set(SDL_SHARED OFF CACHE BOOL "" FORCE)
         set(SDL_STATIC ON CACHE BOOL "" FORCE)
+    elseif(SLAYER3D_SDL_LINKAGE STREQUAL "shared")
+        set(SDL_SHARED ON CACHE BOOL "" FORCE)
+        set(SDL_STATIC OFF CACHE BOOL "" FORCE)
     endif()
 
     set(SDL_TEST_LIBRARY OFF CACHE BOOL "" FORCE)
@@ -68,7 +101,7 @@ if(NOT TARGET SDL3::SDL3 AND SLAYER3D_FETCH_SDL3)
     set(SLAYER3D_USING_FETCHED_SDL3 ON)
 endif()
 
-if(NOT TARGET SDL3::SDL3 AND NOT TARGET SDL3::SDL3-static)
+if(NOT TARGET SDL3::SDL3 AND NOT TARGET SDL3::SDL3-static AND NOT TARGET SDL3::SDL3-shared)
     message(FATAL_ERROR "SDL3 was not found. Provide SDL3 via a parent target, find_package(SDL3), or enable SLAYER3D_FETCH_SDL3.")
 endif()
 
@@ -76,11 +109,25 @@ if(EMSCRIPTEN)
     set(SLAYER3D_ENABLE_NETWORKING OFF CACHE BOOL "Enable SDL3_net-based network transport" FORCE)
 endif()
 
-set(SLAYER3D_SDL_TARGET SDL3::SDL3)
-if(NOT TARGET ${SLAYER3D_SDL_TARGET} AND TARGET SDL3::SDL3-static)
+if(SLAYER3D_SDL_LINKAGE STREQUAL "static")
+    if(NOT TARGET SDL3::SDL3-static)
+        message(FATAL_ERROR "SLAYER3D_SDL_LINKAGE=static requires SDL3::SDL3-static.")
+    endif()
     set(SLAYER3D_SDL_TARGET SDL3::SDL3-static)
-elseif(IOS AND TARGET SDL3::SDL3-static)
-    set(SLAYER3D_SDL_TARGET SDL3::SDL3-static)
+elseif(SLAYER3D_SDL_LINKAGE STREQUAL "shared")
+    if(NOT TARGET SDL3::SDL3-shared)
+        message(FATAL_ERROR "SLAYER3D_SDL_LINKAGE=shared requires SDL3::SDL3-shared.")
+    endif()
+    set(SLAYER3D_SDL_TARGET SDL3::SDL3-shared)
+else()
+    set(SLAYER3D_SDL_TARGET SDL3::SDL3)
+    if(IOS AND TARGET SDL3::SDL3-static)
+        set(SLAYER3D_SDL_TARGET SDL3::SDL3-static)
+    elseif(NOT TARGET ${SLAYER3D_SDL_TARGET} AND TARGET SDL3::SDL3-static)
+        set(SLAYER3D_SDL_TARGET SDL3::SDL3-static)
+    elseif(NOT TARGET ${SLAYER3D_SDL_TARGET} AND TARGET SDL3::SDL3-shared)
+        set(SLAYER3D_SDL_TARGET SDL3::SDL3-shared)
+    endif()
 endif()
 
 if(SLAYER3D_ENABLE_NETWORKING)
@@ -417,6 +464,7 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     target_include_directories(slayer3d_pack PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)
     slayer3d_enable_warnings(slayer3d_pack)
     slayer3d_enable_sanitizers(slayer3d_pack)
+    slayer3d_copy_runtime_dlls(slayer3d_pack)
 
     add_executable(slayer3d_bundle tools/slayer3d_bundle.c tools/slayer3d_bundle_cli.c tools/slayer3d_fused.c)
     target_link_libraries(slayer3d_bundle PRIVATE Slayer3D::slayer3d slayer3d_argtable3)
@@ -424,6 +472,7 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     target_include_directories(slayer3d_bundle PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)
     slayer3d_enable_warnings(slayer3d_bundle)
     slayer3d_enable_sanitizers(slayer3d_bundle)
+    slayer3d_copy_runtime_dlls(slayer3d_bundle)
 
     add_executable(
         slayer3d_runner
@@ -439,6 +488,7 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     target_compile_definitions(slayer3d_runner PRIVATE SLAYER3D_MEDIA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/media")
     slayer3d_enable_warnings(slayer3d_runner)
     slayer3d_enable_sanitizers(slayer3d_runner)
+    slayer3d_copy_runtime_dlls(slayer3d_runner)
 
     add_executable(
         slayer3d_editor
@@ -465,6 +515,7 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     )
     slayer3d_enable_warnings(slayer3d_editor)
     slayer3d_enable_sanitizers(slayer3d_editor)
+    slayer3d_copy_runtime_dlls(slayer3d_editor)
 endif()
 
 if(SLAYER3D_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 option(SLAYER3D_FETCH_SDL3 "Fetch SDL3 if it is not already available" ON)
 set(SLAYER3D_SDL_LINKAGE
-    "static"
+    "auto"
     CACHE STRING "SDL3 link mode: static, shared, or auto")
 set_property(CACHE SLAYER3D_SDL_LINKAGE PROPERTY STRINGS static shared auto)
 option(SLAYER3D_ENABLE_NETWORKING "Enable SDL3_net-based network transport" ON)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,12 +6,4 @@ if(NOT WIN32)
     target_link_libraries(slayer3d_bench PRIVATE m)
 endif()
 target_compile_features(slayer3d_bench PRIVATE c_std_17)
-
-if(WIN32)
-    add_custom_command(
-        TARGET slayer3d_bench
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:slayer3d_bench> $<TARGET_FILE_DIR:slayer3d_bench>
-        COMMAND_EXPAND_LISTS
-    )
-endif()
+slayer3d_copy_runtime_dlls(slayer3d_bench)

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal EnableExtensions
+
+set ROOT=%~dp0
+set BUILD_DIR=%ROOT%build\windows-debug
+
+if not exist %BUILD_DIR% (
+    mkdir %BUILD_DIR%
+)
+
+cmake -S %ROOT% -B %BUILD_DIR% -DSLAYER3D_BUILD_TESTS=ON -DSLAYER3D_BUILD_DEMOS=ON -DSLAYER3D_BUILD_BENCHMARKS=ON
+if errorlevel 1 exit /b %errorlevel%
+
+cmake --build %BUILD_DIR% --config Debug --target ALL_BUILD
+exit /b %errorlevel%

--- a/demos/gui_demo/CMakeLists.txt
+++ b/demos/gui_demo/CMakeLists.txt
@@ -9,3 +9,5 @@ set_target_properties(gui_demo PROPERTIES
 if(NOT WIN32)
     target_link_libraries(gui_demo PRIVATE m)
 endif()
+
+slayer3d_copy_runtime_dlls(gui_demo)

--- a/src/asset.c
+++ b/src/asset.c
@@ -336,11 +336,13 @@ static bool build_compressed_pack_bytes(const uint8_t *raw_data, size_t raw_size
     }
 
     const mz_ulong compressed_bound = mz_compressBound((mz_ulong)raw_size);
+#if ULONG_MAX > (SIZE_MAX - SLAYER3D_PACK_COMPRESSED_HEADER_SIZE)
     if ((size_t)compressed_bound > SIZE_MAX - SLAYER3D_PACK_COMPRESSED_HEADER_SIZE)
     {
         set_asset_error(error_buffer, error_buffer_size, "asset pack is too large");
         return false;
     }
+#endif
 
     uint8_t *data = (uint8_t *)SDL_malloc(SLAYER3D_PACK_COMPRESSED_HEADER_SIZE + (size_t)compressed_bound);
     if (data == NULL)

--- a/src/asset.c
+++ b/src/asset.c
@@ -336,7 +336,7 @@ static bool build_compressed_pack_bytes(const uint8_t *raw_data, size_t raw_size
     }
 
     const mz_ulong compressed_bound = mz_compressBound((mz_ulong)raw_size);
-    if (compressed_bound > (mz_ulong)(SIZE_MAX - SLAYER3D_PACK_COMPRESSED_HEADER_SIZE))
+    if ((size_t)compressed_bound > SIZE_MAX - SLAYER3D_PACK_COMPRESSED_HEADER_SIZE)
     {
         set_asset_error(error_buffer, error_buffer_size, "asset pack is too large");
         return false;

--- a/src/gl_funcs.h
+++ b/src/gl_funcs.h
@@ -8,6 +8,8 @@
 
 #include <SDL3/SDL.h>
 
+#include <stddef.h>
+
 /* GL types. */
 typedef unsigned int GLenum;
 typedef unsigned int GLuint;
@@ -16,8 +18,14 @@ typedef int GLsizei;
 typedef float GLfloat;
 typedef unsigned char GLboolean;
 typedef char GLchar;
-typedef signed long long GLsizeiptr;
+typedef ptrdiff_t GLsizeiptr;
 typedef unsigned int GLbitfield;
+
+#if defined(_WIN32)
+#define SLAYER3D_GL_APIENTRY __stdcall
+#else
+#define SLAYER3D_GL_APIENTRY
+#endif
 
 /* GL constants. */
 #define GL_FALSE 0
@@ -96,92 +104,96 @@ typedef unsigned int GLbitfield;
 #define GL_RG16F 0x822F
 
 /* Function pointer types. */
-typedef void (*PFNGLCLEARPROC)(GLbitfield);
-typedef void (*PFNGLCLEARCOLORPROC)(GLfloat, GLfloat, GLfloat, GLfloat);
-typedef void (*PFNGLENABLEPROC)(GLenum);
-typedef void (*PFNGLDISABLEPROC)(GLenum);
-typedef void (*PFNGLDEPTHFUNCPROC)(GLenum);
-typedef void (*PFNGLDEPTHMASKPROC)(GLboolean);
-typedef void (*PFNGLCOLORMASKPROC)(GLboolean, GLboolean, GLboolean, GLboolean);
-typedef void (*PFNGLCULLFACEPROC)(GLenum);
-typedef void (*PFNGLFRONTFACEPROC)(GLenum);
-typedef void (*PFNGLVIEWPORTPROC)(GLint, GLint, GLsizei, GLsizei);
-typedef void (*PFNGLBLENDFUNCPROC)(GLenum, GLenum);
-typedef void (*PFNGLSCISSORPROC)(GLint, GLint, GLsizei, GLsizei);
-typedef GLenum (*PFNGLGETERRORPROC)(void);
-typedef void (*PFNGLFLUSHPROC)(void);
-typedef void (*PFNGLFINISHPROC)(void);
-typedef GLuint (*PFNGLCREATESHADERPROC)(GLenum);
-typedef void (*PFNGLSHADERSOURCEPROC)(GLuint, GLsizei, const GLchar **, const GLint *);
-typedef void (*PFNGLCOMPILESHADERPROC)(GLuint);
-typedef void (*PFNGLGETSHADERIVPROC)(GLuint, GLenum, GLint *);
-typedef void (*PFNGLGETSHADERINFOLOGPROC)(GLuint, GLsizei, GLsizei *, GLchar *);
-typedef void (*PFNGLDELETESHADERPROC)(GLuint);
-typedef GLuint (*PFNGLCREATEPROGRAMPROC)(void);
-typedef void (*PFNGLATTACHSHADERPROC)(GLuint, GLuint);
-typedef void (*PFNGLLINKPROGRAMPROC)(GLuint);
-typedef void (*PFNGLGETPROGRAMIVPROC)(GLuint, GLenum, GLint *);
-typedef void (*PFNGLGETPROGRAMINFOLOGPROC)(GLuint, GLsizei, GLsizei *, GLchar *);
-typedef void (*PFNGLUSEPROGRAMPROC)(GLuint);
-typedef void (*PFNGLDELETEPROGRAMPROC)(GLuint);
-typedef GLint (*PFNGLGETUNIFORMLOCATIONPROC)(GLuint, const GLchar *);
-typedef void (*PFNGLUNIFORM1IPROC)(GLint, GLint);
-typedef void (*PFNGLUNIFORM1FPROC)(GLint, GLfloat);
-typedef void (*PFNGLUNIFORM2FPROC)(GLint, GLfloat, GLfloat);
-typedef void (*PFNGLUNIFORM3FPROC)(GLint, GLfloat, GLfloat, GLfloat);
-typedef void (*PFNGLUNIFORM4FPROC)(GLint, GLfloat, GLfloat, GLfloat, GLfloat);
-typedef void (*PFNGLUNIFORMMATRIX3FVPROC)(GLint, GLsizei, GLboolean, const GLfloat *);
-typedef void (*PFNGLUNIFORMMATRIX4FVPROC)(GLint, GLsizei, GLboolean, const GLfloat *);
-typedef void (*PFNGLGENVERTEXARRAYSPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLBINDVERTEXARRAYPROC)(GLuint);
-typedef void (*PFNGLDELETEVERTEXARRAYSPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLGENBUFFERSPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLBINDBUFFERPROC)(GLenum, GLuint);
-typedef void (*PFNGLBUFFERDATAPROC)(GLenum, GLsizeiptr, const void *, GLenum);
-typedef void (*PFNGLDELETEBUFFERSPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint);
-typedef void (*PFNGLVERTEXATTRIBPOINTERPROC)(GLuint, GLint, GLenum, GLboolean, GLsizei, const void *);
-typedef void (*PFNGLDRAWARRAYSPROC)(GLenum, GLint, GLsizei);
-typedef void (*PFNGLDRAWELEMENTSPROC)(GLenum, GLsizei, GLenum, const void *);
-typedef void (*PFNGLDRAWARRAYSINSTANCEDPROC)(GLenum, GLint, GLsizei, GLsizei);
-typedef void (*PFNGLDRAWELEMENTSINSTANCEDPROC)(GLenum, GLsizei, GLenum, const void *, GLsizei);
-typedef void (*PFNGLVERTEXATTRIBDIVISORPROC)(GLuint, GLuint);
-typedef void (*PFNGLGENTEXTURESPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLBINDTEXTUREPROC)(GLenum, GLuint);
-typedef void (*PFNGLTEXIMAGE2DPROC)(GLenum, GLint, GLint, GLsizei, GLsizei, GLint, GLenum, GLenum, const void *);
-typedef void (*PFNGLTEXIMAGE3DPROC)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum, GLenum,
-                                    const void *);
-typedef void (*PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum, GLenum, GLuint, GLint, GLint);
-typedef void (*PFNGLTEXPARAMETERIPROC)(GLenum, GLenum, GLint);
-typedef void (*PFNGLTEXPARAMETERFVPROC)(GLenum, GLenum, const GLfloat *);
-typedef void (*PFNGLDELETETEXTURESPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLACTIVETEXTUREPROC)(GLenum);
-typedef void (*PFNGLGENFRAMEBUFFERSPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLBINDFRAMEBUFFERPROC)(GLenum, GLuint);
-typedef void (*PFNGLFRAMEBUFFERTEXTURE2DPROC)(GLenum, GLenum, GLenum, GLuint, GLint);
-typedef GLenum (*PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum);
-typedef void (*PFNGLDELETEFRAMEBUFFERSPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLGENRENDERBUFFERSPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLBINDRENDERBUFFERPROC)(GLenum, GLuint);
-typedef void (*PFNGLRENDERBUFFERSTORAGEPROC)(GLenum, GLenum, GLsizei, GLsizei);
-typedef void (*PFNGLFRAMEBUFFERRENDERBUFFERPROC)(GLenum, GLenum, GLenum, GLuint);
-typedef void (*PFNGLDELETERENDERBUFFERSPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLBLITFRAMEBUFFERPROC)(GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLbitfield, GLenum);
-typedef GLint (*PFNGLGETATTRIBLOCATIONPROC)(GLuint, const GLchar *);
-typedef void (*PFNGLREADPIXELSPROC)(GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, void *);
-typedef void (*PFNGLTEXSUBIMAGE2DPROC)(GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, const void *);
-typedef void (*PFNGLBINDBUFFERBASEPROC)(GLenum, GLuint, GLuint);
-typedef void (*PFNGLUNIFORMBLOCKBINDINGPROC)(GLuint, GLuint, GLuint);
-typedef GLuint (*PFNGLGETUNIFORMBLOCKINDEXPROC)(GLuint, const char *);
-typedef void (*PFNGLDRAWBUFFERPROC)(GLenum);
-typedef void (*PFNGLREADBUFFERPROC)(GLenum);
-typedef void (*PFNGLUNIFORM1FVPROC)(GLint, GLsizei, const GLfloat *);
-typedef void (*PFNGLGENERATEMIPMAPPROC)(GLenum);
-typedef void (*PFNGLGENQUERIESPROC)(GLsizei, GLuint *);
-typedef void (*PFNGLDELETEQUERIESPROC)(GLsizei, const GLuint *);
-typedef void (*PFNGLBEGINQUERYPROC)(GLenum, GLuint);
-typedef void (*PFNGLENDQUERYPROC)(GLenum);
-typedef void (*PFNGLGETQUERYOBJECTUIVPROC)(GLuint, GLenum, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLCLEARPROC)(GLbitfield);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLCLEARCOLORPROC)(GLfloat, GLfloat, GLfloat, GLfloat);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLENABLEPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDISABLEPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDEPTHFUNCPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDEPTHMASKPROC)(GLboolean);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLCOLORMASKPROC)(GLboolean, GLboolean, GLboolean, GLboolean);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLCULLFACEPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFRONTFACEPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLVIEWPORTPROC)(GLint, GLint, GLsizei, GLsizei);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBLENDFUNCPROC)(GLenum, GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLSCISSORPROC)(GLint, GLint, GLsizei, GLsizei);
+typedef GLenum(SLAYER3D_GL_APIENTRY *PFNGLGETERRORPROC)(void);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFLUSHPROC)(void);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFINISHPROC)(void);
+typedef GLuint(SLAYER3D_GL_APIENTRY *PFNGLCREATESHADERPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLSHADERSOURCEPROC)(GLuint, GLsizei, const GLchar **, const GLint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLCOMPILESHADERPROC)(GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGETSHADERIVPROC)(GLuint, GLenum, GLint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGETSHADERINFOLOGPROC)(GLuint, GLsizei, GLsizei *, GLchar *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETESHADERPROC)(GLuint);
+typedef GLuint(SLAYER3D_GL_APIENTRY *PFNGLCREATEPROGRAMPROC)(void);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLATTACHSHADERPROC)(GLuint, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLLINKPROGRAMPROC)(GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGETPROGRAMIVPROC)(GLuint, GLenum, GLint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGETPROGRAMINFOLOGPROC)(GLuint, GLsizei, GLsizei *, GLchar *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUSEPROGRAMPROC)(GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETEPROGRAMPROC)(GLuint);
+typedef GLint(SLAYER3D_GL_APIENTRY *PFNGLGETUNIFORMLOCATIONPROC)(GLuint, const GLchar *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM1IPROC)(GLint, GLint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM1FPROC)(GLint, GLfloat);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM2FPROC)(GLint, GLfloat, GLfloat);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM3FPROC)(GLint, GLfloat, GLfloat, GLfloat);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM4FPROC)(GLint, GLfloat, GLfloat, GLfloat, GLfloat);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORMMATRIX3FVPROC)(GLint, GLsizei, GLboolean, const GLfloat *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORMMATRIX4FVPROC)(GLint, GLsizei, GLboolean, const GLfloat *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENVERTEXARRAYSPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDVERTEXARRAYPROC)(GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETEVERTEXARRAYSPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENBUFFERSPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDBUFFERPROC)(GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBUFFERDATAPROC)(GLenum, GLsizeiptr, const void *, GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETEBUFFERSPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLENABLEVERTEXATTRIBARRAYPROC)(GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLVERTEXATTRIBPOINTERPROC)(GLuint, GLint, GLenum, GLboolean, GLsizei,
+                                                                 const void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDRAWARRAYSPROC)(GLenum, GLint, GLsizei);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDRAWELEMENTSPROC)(GLenum, GLsizei, GLenum, const void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDRAWARRAYSINSTANCEDPROC)(GLenum, GLint, GLsizei, GLsizei);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDRAWELEMENTSINSTANCEDPROC)(GLenum, GLsizei, GLenum, const void *, GLsizei);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLVERTEXATTRIBDIVISORPROC)(GLuint, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENTEXTURESPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDTEXTUREPROC)(GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLTEXIMAGE2DPROC)(GLenum, GLint, GLint, GLsizei, GLsizei, GLint, GLenum, GLenum,
+                                                        const void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLTEXIMAGE3DPROC)(GLenum, GLint, GLint, GLsizei, GLsizei, GLsizei, GLint, GLenum,
+                                                        GLenum, const void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFRAMEBUFFERTEXTURELAYERPROC)(GLenum, GLenum, GLuint, GLint, GLint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLTEXPARAMETERIPROC)(GLenum, GLenum, GLint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLTEXPARAMETERFVPROC)(GLenum, GLenum, const GLfloat *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETETEXTURESPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLACTIVETEXTUREPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENFRAMEBUFFERSPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDFRAMEBUFFERPROC)(GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFRAMEBUFFERTEXTURE2DPROC)(GLenum, GLenum, GLenum, GLuint, GLint);
+typedef GLenum(SLAYER3D_GL_APIENTRY *PFNGLCHECKFRAMEBUFFERSTATUSPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETEFRAMEBUFFERSPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENRENDERBUFFERSPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDRENDERBUFFERPROC)(GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLRENDERBUFFERSTORAGEPROC)(GLenum, GLenum, GLsizei, GLsizei);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLFRAMEBUFFERRENDERBUFFERPROC)(GLenum, GLenum, GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETERENDERBUFFERSPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBLITFRAMEBUFFERPROC)(GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLint,
+                                                             GLbitfield, GLenum);
+typedef GLint(SLAYER3D_GL_APIENTRY *PFNGLGETATTRIBLOCATIONPROC)(GLuint, const GLchar *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLREADPIXELSPROC)(GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLTEXSUBIMAGE2DPROC)(GLenum, GLint, GLint, GLint, GLsizei, GLsizei, GLenum,
+                                                           GLenum, const void *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBINDBUFFERBASEPROC)(GLenum, GLuint, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORMBLOCKBINDINGPROC)(GLuint, GLuint, GLuint);
+typedef GLuint(SLAYER3D_GL_APIENTRY *PFNGLGETUNIFORMBLOCKINDEXPROC)(GLuint, const char *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDRAWBUFFERPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLREADBUFFERPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLUNIFORM1FVPROC)(GLint, GLsizei, const GLfloat *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENERATEMIPMAPPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGENQUERIESPROC)(GLsizei, GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLDELETEQUERIESPROC)(GLsizei, const GLuint *);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLBEGINQUERYPROC)(GLenum, GLuint);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLENDQUERYPROC)(GLenum);
+typedef void(SLAYER3D_GL_APIENTRY *PFNGLGETQUERYOBJECTUIVPROC)(GLuint, GLenum, GLuint *);
 /* Global function pointers. */
 #if defined(__GNUC__) || defined(__clang__)
 #define SLAYER3D_GL_FUNCS_MAYBE_UNUSED __attribute__((unused))

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -32,6 +32,11 @@ static const char *gl_version_prefix_for_context(const slayer3d_gl_context *ctx)
     return (ctx != NULL && ctx->is_es) ? "#version 300 es\nprecision highp float;\n" : "#version 330\n";
 }
 
+static bool csm_shadow_pass_enabled(void)
+{
+    return false;
+}
+
 /* ------------------------------------------------------------------ */
 /* White color buffer                                                  */
 /* ------------------------------------------------------------------ */
@@ -1885,13 +1890,14 @@ static void ibl_render_cube(slayer3d_gl_funcs *gl, GLuint vao)
     gl->DrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, NULL);
 }
 
+extern float *stbi_loadf(const char *, int *, int *, int *, int);
+extern void stbi_image_free(void *);
+
 bool slayer3d_gl_load_environment_map(slayer3d_gl_context *ctx, const char *hdr_path)
 {
     slayer3d_gl_funcs *gl = &ctx->gl;
     int w, h, nc;
 
-    extern float *stbi_loadf(const char *, int *, int *, int *, int);
-    extern void stbi_image_free(void *);
     float *data = stbi_loadf(hdr_path, &w, &h, &nc, 0);
     if (!data)
     {
@@ -2986,7 +2992,7 @@ static bool gl_present(slayer3d_render_context *context)
 
     /* Shadow pass: render original VP into layer 0 (backward compatible),
      * then CSM cascades 1-3 into layers 1-3 for Slice 3. */
-    if (0 && ctx->shadow_program)
+    if (ctx->shadow_program && csm_shadow_pass_enabled())
     {
         compute_csm_matrices(ctx, context);
 
@@ -3267,7 +3273,7 @@ void slayer3d_gl_read_pixel(slayer3d_gl_context *ctx, int x, int y, unsigned cha
         slayer3d_gl_funcs *gl = &ctx->gl;
         flush_scene_ubo(ctx);
         prepare_skin_palette_buffer(ctx);
-        if (0 && ctx->shadow_program)
+        if (ctx->shadow_program && csm_shadow_pass_enabled())
         {
             compute_csm_matrices(ctx, ctx->current_ctx);
 

--- a/src/input.c
+++ b/src/input.c
@@ -2022,6 +2022,7 @@ slayer3d_demo_player *slayer3d_demo_playback_load(const char *path)
 
     if (tick_count > 0)
     {
+#if SIZE_MAX < UINT64_MAX
         if ((size_t)tick_count > SIZE_MAX / sizeof(*player->snapshots))
         {
             slayer3d_demo_playback_free(player);
@@ -2029,6 +2030,7 @@ slayer3d_demo_player *slayer3d_demo_playback_load(const char *path)
             SDL_SetError("SLAYER3D demo file is too large.");
             return NULL;
         }
+#endif
 
         snapshot_bytes = (size_t)tick_count * sizeof(*player->snapshots);
         player->snapshots = (slayer3d_input_snapshot *)SDL_malloc(snapshot_bytes);

--- a/src/input.c
+++ b/src/input.c
@@ -2022,7 +2022,7 @@ slayer3d_demo_player *slayer3d_demo_playback_load(const char *path)
 
     if (tick_count > 0)
     {
-        if (tick_count > (Uint32)(SIZE_MAX / sizeof(*player->snapshots)))
+        if ((size_t)tick_count > SIZE_MAX / sizeof(*player->snapshots))
         {
             slayer3d_demo_playback_free(player);
             SDL_CloseIO(stream);

--- a/src/rasterizer.c
+++ b/src/rasterizer.c
@@ -263,7 +263,7 @@ static float slayer3d_clip_distance(slayer3d_vec4 v, slayer3d_clip_plane plane)
     case SLAYER3D_CLIP_FAR:
         return v.w - v.z;
     default:
-        SDL_assert(0 && "unreachable: unknown clip plane");
+        SDL_assert(plane >= SLAYER3D_CLIP_LEFT && plane <= SLAYER3D_CLIP_FAR);
         return 0.0f;
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ function(slayer3d_add_test target_name source_file test_label)
             GTest::gtest_main
     )
 
-    target_compile_features(${target_name} PRIVATE cxx_std_17)
+    target_compile_features(${target_name} PRIVATE cxx_std_20)
     target_compile_definitions(
         ${target_name}
         PRIVATE
@@ -49,14 +49,7 @@ function(slayer3d_add_test target_name source_file test_label)
         target_link_options(${target_name} PRIVATE "--emrun")
     endif()
 
-    if(WIN32)
-        add_custom_command(
-            TARGET ${target_name}
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${target_name}> $<TARGET_FILE_DIR:${target_name}>
-            COMMAND_EXPAND_LISTS
-        )
-    endif()
+    slayer3d_copy_runtime_dlls(${target_name})
 
     set(_slayer3d_test_timeout 15)
     if(test_label STREQUAL "render")
@@ -137,7 +130,7 @@ if(ANDROID)
             android
     )
 
-    target_compile_features(main PRIVATE cxx_std_17)
+    target_compile_features(main PRIVATE cxx_std_20)
     target_include_directories(main PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_compile_definitions(
         main
@@ -162,7 +155,7 @@ elseif(IOS)
             GTest::gtest
     )
 
-    target_compile_features(slayer3d_ios_tests PRIVATE cxx_std_17)
+    target_compile_features(slayer3d_ios_tests PRIVATE cxx_std_20)
     target_include_directories(slayer3d_ios_tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_compile_definitions(
         slayer3d_ios_tests

--- a/tests/test_action.cpp
+++ b/tests/test_action.cpp
@@ -117,10 +117,10 @@ TEST(Action, SetPropertyColor)
     a.set_property.target = props;
     a.set_property.key = "tint";
     a.set_property.value.type = SLAYER3D_VALUE_COLOR;
-    a.set_property.value.as_color = (slayer3d_color){255, 0, 0, 255};
+    a.set_property.value.as_color = slayer3d_color{255, 0, 0, 255};
 
     slayer3d_action_execute(&a, NULL, NULL);
-    slayer3d_color c = slayer3d_properties_get_color(props, "tint", (slayer3d_color){0, 0, 0, 0});
+    slayer3d_color c = slayer3d_properties_get_color(props, "tint", slayer3d_color{0, 0, 0, 0});
     EXPECT_EQ(c.r, 255);
     EXPECT_EQ(c.g, 0);
 

--- a/tests/test_actor_registry.cpp
+++ b/tests/test_actor_registry.cpp
@@ -212,7 +212,7 @@ TEST(ActorRegistry, UpdateEvaluatesSpatialTriggers)
     sensor->triggers[0].edge = SLAYER3D_TRIGGER_EDGE_ENTER;
     sensor->triggers[0].emit_signal_id = 1;
     sensor->triggers[0].enabled = true;
-    sensor->triggers[0].spatial.zone = (slayer3d_bounding_box){{0, 0, 0}, {10, 10, 10}};
+    sensor->triggers[0].spatial.zone = slayer3d_bounding_box{{0, 0, 0}, {10, 10, 10}};
     sensor->trigger_count = 1;
 
     /* Outside → no fire. */
@@ -284,7 +284,7 @@ TEST(ActorRegistry, InactiveActorsSkipped)
     sensor->triggers[0].edge = SLAYER3D_TRIGGER_EDGE_ENTER;
     sensor->triggers[0].emit_signal_id = 1;
     sensor->triggers[0].enabled = true;
-    sensor->triggers[0].spatial.zone = (slayer3d_bounding_box){{0, 0, 0}, {10, 10, 10}};
+    sensor->triggers[0].spatial.zone = slayer3d_bounding_box{{0, 0, 0}, {10, 10, 10}};
     sensor->trigger_count = 1;
     sensor->active = false;
 

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -794,7 +794,7 @@ TEST_F(SLAYER3DDrawingFixture, BillboardRespondsToPointLight)
     ASSERT_TRUE(slayer3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}));
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     const SDL_Point billboard_center = ProjectPointToFramebuffer(ctx, cam, slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
@@ -819,7 +819,7 @@ TEST_F(SLAYER3DDrawingFixture, BillboardRespondsToPointLight)
     ASSERT_TRUE(slayer3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}));
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     const ColorRegionStats lit = SampleColorRegion(ctx, billboard_center, sample_radius);

--- a/tests/test_drawing3d.cpp
+++ b/tests/test_drawing3d.cpp
@@ -793,8 +793,8 @@ TEST_F(SLAYER3DDrawingFixture, BillboardRespondsToPointLight)
 
     ASSERT_TRUE(slayer3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}));
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     const SDL_Point billboard_center = ProjectPointToFramebuffer(ctx, cam, slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
@@ -818,8 +818,8 @@ TEST_F(SLAYER3DDrawingFixture, BillboardRespondsToPointLight)
 
     ASSERT_TRUE(slayer3d_clear_render_context(ctx, kBlack));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}));
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     const ColorRegionStats lit = SampleColorRegion(ctx, billboard_center, sample_radius);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14523,11 +14523,11 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
     for (const Case &test_case : cases)
     {
         const std::filesystem::path dir = unique_test_dir(test_case.name);
-        write_text(dir / "scenes" / "play.scene.json",
-                   test_case.scene_json != nullptr ? test_case.scene_json : R"json({
+        const char *scene_json = test_case.scene_json != nullptr ? test_case.scene_json : R"json({
   "schema": "slayer3d.scene.v0",
   "name": "scene.play"
-})json");
+})json";
+        write_text(dir / "scenes" / "play.scene.json", scene_json);
         std::string brush_world_section = test_case.brush_world_json;
         const size_t section_start = brush_world_section.find("\"brush_worlds\"");
         const size_t section_end = brush_world_section.rfind('}');

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -19517,7 +19517,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     click_editor(click.button.x, click.button.y, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 9);
     ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.selection.element", ""), floor_brush_name.c_str());
-    const int brush_count_before_floor_lower = world().brush_count;
+    const slayer3d_game_data_brush_world brush_world_before_floor_lower = world();
+    const int brush_count_before_floor_lower = brush_world_before_floor_lower.brush_count;
     const slayer3d_bounding_box floor_bounds_before_lower = brush_bounds(floor_brush_name);
     press_editor_key(SDL_SCANCODE_LEFTBRACKET, 11);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.transaction.valid", false));
@@ -19937,7 +19938,8 @@ TEST(GameDataRuntime, EditorShellDojoSelectModeDragAutoCommitsBrushInEmptySpace)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
-    const int initial_brush_count = world().brush_count;
+    const slayer3d_game_data_brush_world initial_world = world();
+    const int initial_brush_count = initial_world.brush_count;
     slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
     ASSERT_NE(input, nullptr);
 
@@ -20380,7 +20382,8 @@ TEST(GameDataRuntime, EditorShellDojoBrushToolDragStartsOnHoveredBrushFace)
         EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &brush_world));
         return brush_world;
     };
-    const int initial_brush_count = world().brush_count;
+    const slayer3d_game_data_brush_world initial_world = world();
+    const int initial_brush_count = initial_world.brush_count;
 
     slayer3d_game_data_editor_selection hover{};
     hover.hit = true;
@@ -21148,7 +21151,8 @@ TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
 
     const slayer3d_bounding_box source_bounds = brush_bounds(source_result.brush_name);
-    const int initial_brush_count = brush_world().brush_count;
+    const slayer3d_game_data_brush_world initial_world = brush_world();
+    const int initial_brush_count = initial_world.brush_count;
     ASSERT_TRUE(
         slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(2.0f, 0.0f, 0.0f), false));
     ASSERT_EQ(brush_world().brush_count, initial_brush_count + 1);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -14523,7 +14523,8 @@ TEST(GameDataRuntime, RejectsInvalidBrushWorlds)
     for (const Case &test_case : cases)
     {
         const std::filesystem::path dir = unique_test_dir(test_case.name);
-        write_text(dir / "scenes" / "play.scene.json", test_case.scene_json != nullptr ? test_case.scene_json : R"json({
+        write_text(dir / "scenes" / "play.scene.json",
+                   test_case.scene_json != nullptr ? test_case.scene_json : R"json({
   "schema": "slayer3d.scene.v0",
   "name": "scene.play"
 })json");

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -2032,8 +2032,8 @@ TEST_F(GLRendererTest, BillboardVisibleWithTexture)
 
     slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2062,8 +2062,8 @@ TEST_F(GLRendererTest, BillboardVisibleFromOppositeViewDirection)
 
     slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2090,8 +2090,8 @@ TEST_F(GLRendererTest, BillboardPreservesTopToBottomTextureOrientation)
 
     slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2121,8 +2121,8 @@ TEST_F(GLRendererTest, BillboardTransparentPixelsDiscard)
 
     slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
+    ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), slayer3d_vec2{2.0f, 2.0f},
+                                        slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2433,11 +2433,9 @@ TEST_F(GLRendererTest, CSMAllLayersHaveDepthData)
     slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     /* Draw a large ground plane and several cubes at different distances. */
-    slayer3d_draw_plane(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec2{40, 40},
-                        slayer3d_color{200, 200, 200, 255});
+    slayer3d_draw_plane(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec2{40, 40}, slayer3d_color{200, 200, 200, 255});
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 1, 0), slayer3d_vec3_make(2, 2, 2), slayer3d_color{255, 0, 0, 255});
-    slayer3d_draw_cube(ctx, slayer3d_vec3_make(5, 1, -5), slayer3d_vec3_make(2, 2, 2),
-                       slayer3d_color{0, 255, 0, 255});
+    slayer3d_draw_cube(ctx, slayer3d_vec3_make(5, 1, -5), slayer3d_vec3_make(2, 2, 2), slayer3d_color{0, 255, 0, 255});
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(-8, 1, -10), slayer3d_vec3_make(2, 2, 2),
                        slayer3d_color{0, 0, 255, 255});
     slayer3d_end_mode_3d(ctx);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -207,7 +207,7 @@ TEST_F(GLRendererTest, RenderProfilesSelectRetroPostProcess)
     {
         slayer3d_render_profile profile = test_case.profile();
         ASSERT_TRUE(slayer3d_set_render_profile(ctx, &profile));
-        ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){4, 5, 6, 255}));
+        ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{4, 5, 6, 255}));
         int width = -1;
         int height = -1;
         slayer3d_gl_active_retro_virtual_resolution(ctx->gl, &width, &height);
@@ -289,10 +289,10 @@ TEST_F(GLRendererTest, DepthPrepassReplaysOpaqueLitTriangles)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];
@@ -351,12 +351,12 @@ TEST_F(GLRendererTest, StaticModelMeshesUseInstancedBackendDraws)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     for (int i = 0; i < 5; ++i)
     {
         ASSERT_TRUE(slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(-1.2f + 0.6f * (float)i, 0, 0), 1.0f,
-                                        (slayer3d_color){255, 255, 255, 255}));
+                                        slayer3d_color{255, 255, 255, 255}));
     }
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
@@ -430,10 +430,10 @@ TEST_F(GLRendererTest, SkinnedLitModelsUseGpuSkinningWhenJointBudgetAllows)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(0, 1, 0), 0.0f,
-                                            slayer3d_vec3_make(1, 1, 1), (slayer3d_color){255, 255, 255, 255}, joints));
+                                            slayer3d_vec3_make(1, 1, 1), slayer3d_color{255, 255, 255, 255}, joints));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];
@@ -507,13 +507,13 @@ TEST_F(GLRendererTest, SkinnedLitModelsWithSharedPoseUseInstancedBackendDraw)
 
     constexpr int instance_count = 5;
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     for (int i = 0; i < instance_count; ++i)
     {
         ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(-1.0f + 0.5f * (float)i, 0, 0),
                                                 slayer3d_vec3_make(0, 1, 0), 0.0f, slayer3d_vec3_make(1, 1, 1),
-                                                (slayer3d_color){255, 255, 255, 255}, joints));
+                                                slayer3d_color{255, 255, 255, 255}, joints));
     }
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
@@ -604,7 +604,7 @@ TEST_F(GLRendererTest, SkinnedCrowdBatchesSharedPoseGroupsAndUsesGpuPalette)
     constexpr int instances_per_pose = 16;
     constexpr int crowd_count = pose_count * instances_per_pose;
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     for (int pose = 0; pose < pose_count; ++pose)
     {
@@ -615,7 +615,7 @@ TEST_F(GLRendererTest, SkinnedCrowdBatchesSharedPoseGroupsAndUsesGpuPalette)
             const float y = -0.9f + 0.45f * (float)(index / 16);
             ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(x, y, 0),
                                                     slayer3d_vec3_make(0, 1, 0), 0.0f, slayer3d_vec3_make(1, 1, 1),
-                                                    (slayer3d_color){255, 255, 255, 255}, poses[pose]));
+                                                    slayer3d_color{255, 255, 255, 255}, poses[pose]));
         }
     }
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -695,7 +695,7 @@ TEST_F(GLRendererTest, SkinnedLitModelsFallBackToUniformsWhenPosePaletteIsFull)
 
     constexpr int draw_count = 5;
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     for (int i = 0; i < draw_count; ++i)
     {
@@ -703,7 +703,7 @@ TEST_F(GLRendererTest, SkinnedLitModelsFallBackToUniformsWhenPosePaletteIsFull)
         joints[0].m[12] = 0.01f * (float)i;
         ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(-0.8f + 0.4f * (float)i, 0, 0),
                                                 slayer3d_vec3_make(0, 1, 0), 0.0f, slayer3d_vec3_make(1, 1, 1),
-                                                (slayer3d_color){255, 255, 255, 255}, joints.data()));
+                                                slayer3d_color{255, 255, 255, 255}, joints.data()));
     }
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
@@ -774,10 +774,10 @@ TEST_F(GLRendererTest, SkinnedLitModelsFallBackToCpuWhenJointBudgetIsExceeded)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_draw_model_skinned(ctx, &model, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(0, 1, 0), 0.0f,
-                                            slayer3d_vec3_make(1, 1, 1), (slayer3d_color){255, 255, 255, 255},
+                                            slayer3d_vec3_make(1, 1, 1), slayer3d_color{255, 255, 255, 255},
                                             joints.data()));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
@@ -846,7 +846,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.45f, 0.45f, 0.45f));
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -859,7 +859,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "brush.visibility.enabled", true);
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -876,7 +876,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
 
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -893,7 +893,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     side_cam.target.x = 0.75f;
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, side_cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &side_cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -904,7 +904,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
 
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -951,7 +951,7 @@ TEST_F(GLRendererTest, BrushVisibilityOcclusionCullsHiddenBrushSubmodels)
     slayer3d_properties_set_bool(slayer3d_game_data_mutable_scene_state(runtime), "brush.visibility.enabled", true);
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -1026,7 +1026,7 @@ TEST_F(GLRendererTest, BrushVisibilityDrawsFullyVisibleCompileChunks)
     ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.45f, 0.45f, 0.45f));
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -1101,7 +1101,7 @@ TEST_F(GLRendererTest, BrushVisibilityFrustumCullsOffscreenBrushesBeforeSubmissi
     ASSERT_TRUE(slayer3d_set_ambient_light(ctx, 0.45f, 0.45f, 0.45f));
     slayer3d_reset_render_stats(ctx);
     slayer3d_game_data_reset_brush_diagnostics(runtime);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_game_data_draw_brush_worlds_with_assets_and_camera(runtime, ctx, nullptr, &cam));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
@@ -1453,10 +1453,10 @@ TEST_F(GLRendererTest, DepthPrepassDisabledDoesNotReplayEligibleMeshes)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];
@@ -1503,13 +1503,13 @@ TEST_F(GLRendererTest, DepthPrepassReducesMainGeometrySamplesInOverdrawCase)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     auto draw_overdraw_stack = [&](int layer_count) {
-        ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+        ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
         ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
         for (int i = 0; i < layer_count; ++i)
         {
             const float z = -0.14f + (float)i * 0.02f;
             ASSERT_TRUE(slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, z), 1.0f,
-                                            (slayer3d_color){255, 255, 255, 255}));
+                                            slayer3d_color{255, 255, 255, 255}));
         }
         ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
         unsigned char px[4];
@@ -1564,10 +1564,10 @@ TEST_F(GLRendererTest, PhongCubeVisibleWithoutIBL)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){8, 32, 96, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{8, 32, 96, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){255, 255, 255, 255});
+                       slayer3d_color{255, 255, 255, 255});
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -1589,10 +1589,10 @@ TEST_F(GLRendererTest, AmbientOnlyPhongCubeUsesLitPath)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){255, 255, 255, 255});
+                       slayer3d_color{255, 255, 255, 255});
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -1635,10 +1635,10 @@ TEST_F(GLRendererTest, AmbientOnlyPhongModelUsesLitPath)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -1696,14 +1696,14 @@ TEST_F(GLRendererTest, PerObjectLightSelectionCapsShaderLightsPerDraw)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(-1.2f, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(-1.2f, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0.0f, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0.0f, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(1.2f, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(1.2f, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];
@@ -1775,10 +1775,10 @@ TEST_F(GLRendererTest, PerObjectLightSelectionChoosesRelevantLocalLight)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_reset_render_stats(ctx);
-    ASSERT_TRUE(slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255}));
+    ASSERT_TRUE(slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255}));
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(
-        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, (slayer3d_color){255, 255, 255, 255}));
+        slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0, 0, 0), 1.0f, slayer3d_color{255, 255, 255, 255}));
     ASSERT_TRUE(slayer3d_end_mode_3d(ctx));
 
     unsigned char px[4];
@@ -1828,10 +1828,10 @@ TEST_F(GLRendererTest, Line3DVisibleOnGLBackend)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     slayer3d_draw_line_3d(ctx, slayer3d_vec3_make(-1.5f, 0.0f, 0.0f), slayer3d_vec3_make(1.5f, 0.0f, 0.0f),
-                          (slayer3d_color){255, 32, 32, 255});
+                          slayer3d_color{255, 32, 32, 255});
     slayer3d_end_mode_3d(ctx);
 
     bool found_red = false;
@@ -1894,10 +1894,10 @@ TEST_F(GLRendererTest, BackfaceCullingHidesCubeInteriorAcrossFrames)
 
     for (int frame = 0; frame < 2; ++frame)
     {
-        slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+        slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
         slayer3d_begin_mode_3d(ctx, cam);
         slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(4, 4, 4),
-                           (slayer3d_color){255, 0, 0, 255});
+                           slayer3d_color{255, 0, 0, 255});
         slayer3d_end_mode_3d(ctx);
 
         unsigned char px[4];
@@ -1940,9 +1940,9 @@ TEST_F(GLRendererTest, LevelInteriorVisibleWithBackfaceCulling)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_level(ctx, &level, nullptr, (slayer3d_color){255, 255, 255, 255})) << SDL_GetError();
+    ASSERT_TRUE(slayer3d_draw_level(ctx, &level, nullptr, slayer3d_color{255, 255, 255, 255})) << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -2004,9 +2004,9 @@ TEST_F(GLRendererTest, LightmappedLevelRendersWithoutVertexColorFallback)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
-    ASSERT_TRUE(slayer3d_draw_level(ctx, &level, nullptr, (slayer3d_color){255, 255, 255, 255})) << SDL_GetError();
+    ASSERT_TRUE(slayer3d_draw_level(ctx, &level, nullptr, slayer3d_color{255, 255, 255, 255})) << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -2030,10 +2030,10 @@ TEST_F(GLRendererTest, BillboardVisibleWithTexture)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}))
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2060,10 +2060,10 @@ TEST_F(GLRendererTest, BillboardVisibleFromOppositeViewDirection)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}))
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2088,10 +2088,10 @@ TEST_F(GLRendererTest, BillboardPreservesTopToBottomTextureOrientation)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}))
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2119,10 +2119,10 @@ TEST_F(GLRendererTest, BillboardTransparentPixelsDiscard)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(slayer3d_draw_billboard(ctx, &texture, slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
-                                        (slayer3d_vec2){2.0f, 2.0f}, (slayer3d_color){255, 255, 255, 255}))
+                                        slayer3d_vec2{2.0f, 2.0f}, slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
 
@@ -2151,8 +2151,8 @@ TEST_F(GLRendererTest, MuzzleFlashParticleShaderProducesNonClearPixels)
     config.lifetime_max = 1.0f;
     config.size_start = 1.4f;
     config.size_end = 1.4f;
-    config.color_start = (slayer3d_color){255, 225, 120, 255};
-    config.color_end = (slayer3d_color){255, 80, 16, 255};
+    config.color_start = slayer3d_color{255, 225, 120, 255};
+    config.color_end = slayer3d_color{255, 80, 16, 255};
     config.max_particles = 1;
     config.render_style = SLAYER3D_PARTICLE_RENDER_MUZZLE_FLASH;
     config.camera_facing = true;
@@ -2162,7 +2162,7 @@ TEST_F(GLRendererTest, MuzzleFlashParticleShaderProducesNonClearPixels)
     ASSERT_NE(emitter, nullptr) << SDL_GetError();
     slayer3d_particle_emitter_emit(emitter, 1);
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     ASSERT_TRUE(slayer3d_begin_mode_3d(ctx, cam));
     ASSERT_TRUE(slayer3d_draw_particles(ctx, emitter)) << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
@@ -2199,7 +2199,7 @@ TEST_F(GLRendererTest, TexturedSkyboxShowsTopFaceWithBackfaceCulling)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     ASSERT_TRUE(slayer3d_set_backface_culling_enabled(ctx, true));
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     ASSERT_TRUE(slayer3d_draw_skybox_textured(ctx, &skybox)) << SDL_GetError();
     slayer3d_end_mode_3d(ctx);
@@ -2260,7 +2260,7 @@ TEST_F(GLRendererTest, TexturedSkyboxMatchesSeamConsistentDirections)
         cam.fovy = 60.0f;
         cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-        slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+        slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
         slayer3d_begin_mode_3d(ctx, cam);
         ASSERT_TRUE(slayer3d_draw_skybox_textured(ctx, &skybox)) << SDL_GetError();
         slayer3d_end_mode_3d(ctx);
@@ -2354,10 +2354,10 @@ TEST_F(GLRendererTest, ShadowPassProducesNonUniformDepth)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     slayer3d_set_ambient_light(ctx, 0.3f, 0.3f, 0.3f);
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){255, 255, 255, 255});
+                       slayer3d_color{255, 255, 255, 255});
     slayer3d_end_mode_3d(ctx);
 
     /* The center pixel should show the lit cube (not black). */
@@ -2393,10 +2393,10 @@ TEST_F(GLRendererTest, ShadowWorksOnFirstFrame)
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
     /* First frame ever — shadow pass is now automatic. */
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){255, 255, 255, 255});
+                       slayer3d_color{255, 255, 255, 255});
     slayer3d_end_mode_3d(ctx);
 
     unsigned char px[4];
@@ -2430,16 +2430,16 @@ TEST_F(GLRendererTest, CSMAllLayersHaveDepthData)
     cam.fovy = 60.0f;
     cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
 
-    slayer3d_clear_render_context(ctx, (slayer3d_color){0, 0, 0, 255});
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
     slayer3d_begin_mode_3d(ctx, cam);
     /* Draw a large ground plane and several cubes at different distances. */
-    slayer3d_draw_plane(ctx, slayer3d_vec3_make(0, 0, 0), (slayer3d_vec2){40, 40},
-                        (slayer3d_color){200, 200, 200, 255});
-    slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 1, 0), slayer3d_vec3_make(2, 2, 2), (slayer3d_color){255, 0, 0, 255});
+    slayer3d_draw_plane(ctx, slayer3d_vec3_make(0, 0, 0), slayer3d_vec2{40, 40},
+                        slayer3d_color{200, 200, 200, 255});
+    slayer3d_draw_cube(ctx, slayer3d_vec3_make(0, 1, 0), slayer3d_vec3_make(2, 2, 2), slayer3d_color{255, 0, 0, 255});
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(5, 1, -5), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){0, 255, 0, 255});
+                       slayer3d_color{0, 255, 0, 255});
     slayer3d_draw_cube(ctx, slayer3d_vec3_make(-8, 1, -10), slayer3d_vec3_make(2, 2, 2),
-                       (slayer3d_color){0, 0, 255, 255});
+                       slayer3d_color{0, 0, 255, 255});
     slayer3d_end_mode_3d(ctx);
 
     /* The center pixel should show the lit scene (not black). */

--- a/tests/test_level.cpp
+++ b/tests/test_level.cpp
@@ -979,7 +979,7 @@ TEST(SLAYER3DDrawModelCulling, SkipsOffscreenChunkBeforeMaterialValidation)
 
     SDL_ClearError();
     EXPECT_TRUE(slayer3d_draw_model(ctx, &model, slayer3d_vec3_make(0.0f, 0.0f, 0.0f), 1.0f,
-                                    (slayer3d_color){255, 255, 255, 255}))
+                                    slayer3d_color{255, 255, 255, 255}))
         << SDL_GetError();
     EXPECT_TRUE(slayer3d_end_mode_3d(ctx)) << SDL_GetError();
 

--- a/tests/test_lighting.cpp
+++ b/tests/test_lighting.cpp
@@ -405,8 +405,8 @@ TEST(SLAYER3DPBRShading, RoughnessAffectsSpecular)
 
     float rs, gs, bs, rr, gr, br;
     /* View from directly above → specular highlight should be stronger for smooth. */
-    p_smooth.camera_pos = (slayer3d_vec3){0.0f, 5.0f, 0.0f};
-    p_rough.camera_pos = (slayer3d_vec3){0.0f, 5.0f, 0.0f};
+    p_smooth.camera_pos = slayer3d_vec3{0.0f, 5.0f, 0.0f};
+    p_rough.camera_pos = slayer3d_vec3{0.0f, 5.0f, 0.0f};
     slayer3d_shade_fragment_pbr(&p_smooth, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rs, &gs, &bs);
     slayer3d_shade_fragment_pbr(&p_rough, 1.0f, 1.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, &rr, &gr, &br);
 

--- a/tests/test_parity.cpp
+++ b/tests/test_parity.cpp
@@ -64,7 +64,7 @@ static void render_lit_triangle(slayer3d_render_context *ctx)
     slayer3d_begin_mode_3d(ctx, cam);
 
     slayer3d_draw_triangle_3d(ctx, slayer3d_vec3_make(-0.5f, -0.5f, 0.0f), slayer3d_vec3_make(0.5f, -0.5f, 0.0f),
-                              slayer3d_vec3_make(0.0f, 0.5f, 0.0f), (slayer3d_color){255, 128, 64, 255});
+                              slayer3d_vec3_make(0.0f, 0.5f, 0.0f), slayer3d_color{255, 128, 64, 255});
 
     slayer3d_end_mode_3d(ctx);
 }

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -196,7 +196,7 @@ TEST(Properties, SetAndGetColor)
     slayer3d_properties *p = slayer3d_properties_create();
     slayer3d_color red = {255, 0, 0, 255};
     slayer3d_properties_set_color(p, "tint", red);
-    slayer3d_color result = slayer3d_properties_get_color(p, "tint", (slayer3d_color){0, 0, 0, 0});
+    slayer3d_color result = slayer3d_properties_get_color(p, "tint", slayer3d_color{0, 0, 0, 0});
     EXPECT_EQ(result.r, 255);
     EXPECT_EQ(result.g, 0);
     EXPECT_EQ(result.b, 0);

--- a/tests/test_scene.cpp
+++ b/tests/test_scene.cpp
@@ -293,7 +293,7 @@ TEST(SLAYER3DActor, NullActorPropertyAccessIsSafe)
     slayer3d_actor_set_rotation(nullptr, slayer3d_vec3_make(0, 1, 0), 1.0f);
     slayer3d_actor_set_scale(nullptr, slayer3d_vec3_make(1, 1, 1));
     slayer3d_actor_set_visible(nullptr, true);
-    slayer3d_actor_set_tint(nullptr, (slayer3d_color){255, 255, 255, 255});
+    slayer3d_actor_set_tint(nullptr, slayer3d_color{255, 255, 255, 255});
 
     slayer3d_vec3 pos = slayer3d_actor_get_position(nullptr);
     EXPECT_FLOAT_EQ(pos.x, 0.0f);

--- a/tests/test_trigger.cpp
+++ b/tests/test_trigger.cpp
@@ -47,7 +47,7 @@ static slayer3d_trigger make_spatial_trigger(slayer3d_bounding_box zone, slayer3
 
 static slayer3d_bounding_box make_box(float x0, float y0, float z0, float x1, float y1, float z1)
 {
-    return (slayer3d_bounding_box){{x0, y0, z0}, {x1, y1, z1}};
+    return slayer3d_bounding_box{{x0, y0, z0}, {x1, y1, z1}};
 }
 
 /* ================================================================== */

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -11,22 +11,18 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/walterschell/Lua.git
     GIT_TAG v5.4.7
     GIT_SHALLOW TRUE
+    SOURCE_SUBDIR slayer3d_no_upstream_cmake
 )
-FetchContent_GetProperties(slayer3d_lua_source)
-if(NOT slayer3d_lua_source_POPULATED)
-    FetchContent_Populate(slayer3d_lua_source)
-endif()
 
 FetchContent_Declare(
     slayer3d_miniz_source
     GIT_REPOSITORY https://github.com/richgel999/miniz.git
     GIT_TAG 3.1.0
     GIT_SHALLOW TRUE
+    SOURCE_SUBDIR slayer3d_no_upstream_cmake
 )
-FetchContent_GetProperties(slayer3d_miniz_source)
-if(NOT slayer3d_miniz_source_POPULATED)
-    FetchContent_Populate(slayer3d_miniz_source)
-endif()
+
+FetchContent_MakeAvailable(slayer3d_lua_source slayer3d_miniz_source)
 
 set(SLAYER3D_MINIZ_HEADER "${slayer3d_miniz_source_SOURCE_DIR}/miniz.h")
 if(EXISTS "${SLAYER3D_MINIZ_HEADER}")
@@ -74,8 +70,6 @@ if(UNIX AND NOT EMSCRIPTEN)
 endif()
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_lua PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_lua PRIVATE /w)
 endif()
 
 add_library(slayer3d_cgltf OBJECT cgltf/cgltf_impl.c)
@@ -83,8 +77,6 @@ target_include_directories(slayer3d_cgltf PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/cgl
 set_target_properties(slayer3d_cgltf PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_cgltf PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_cgltf PRIVATE /w)
 endif()
 
 add_library(slayer3d_ufbx OBJECT ufbx/ufbx.c)
@@ -92,8 +84,6 @@ target_include_directories(slayer3d_ufbx PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/ufbx
 set_target_properties(slayer3d_ufbx PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_ufbx PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_ufbx PRIVATE /w)
 endif()
 
 add_library(slayer3d_stb OBJECT stb/stb_impl.c stb/stb_truetype_impl.c)
@@ -101,8 +91,6 @@ target_include_directories(slayer3d_stb PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/stb)
 set_target_properties(slayer3d_stb PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_stb PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_stb PRIVATE /w)
 endif()
 
 if(APPLE)
@@ -115,8 +103,6 @@ target_include_directories(slayer3d_miniaudio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 set_target_properties(slayer3d_miniaudio PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_miniaudio PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_miniaudio PRIVATE /w)
 endif()
 
 add_library(slayer3d_yyjson OBJECT yyjson/yyjson.c)
@@ -124,8 +110,6 @@ target_include_directories(slayer3d_yyjson PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/yy
 set_target_properties(slayer3d_yyjson PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_yyjson PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_yyjson PRIVATE /w)
 endif()
 
 add_library(
@@ -146,8 +130,6 @@ target_compile_definitions(slayer3d_miniz PRIVATE MINIZ_NO_ARCHIVE_APIS MINIZ_NO
                                                 MINIZ_NO_ZLIB_COMPATIBLE_NAMES)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_miniz PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_miniz PRIVATE /w)
 endif()
 
 add_library(slayer3d_crypto OBJECT crypto/slayer3d_crypto.c)
@@ -177,6 +159,4 @@ target_include_directories(slayer3d_argtable3 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 set_target_properties(slayer3d_argtable3 PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(slayer3d_argtable3 PRIVATE -w)
-elseif(MSVC)
-    target_compile_options(slayer3d_argtable3 PRIVATE /w)
 endif()


### PR DESCRIPTION
## Summary
- add a Windows/MSVC GitHub Actions workflow that configures Visual Studio 2022 x64, builds static SDL, runs CTest, checks editor static linkage, and smoke-tests editor help
- fix MSVC warning-as-error failures encountered during the local Windows build
- include the supporting Windows build/test cleanup needed for the MSVC suite to pass

## Local verification
- cmake configure with Visual Studio 2022 x64, tests enabled, demos enabled, benchmarks disabled, static SDL
- cmake --build build\windows-msvc-vs2022 --config Debug --parallel
- ctest --test-dir build\windows-msvc-vs2022 -C Debug --output-on-failure passed: 1374/1374 tests, 1 skipped
- build\windows-msvc-vs2022\Debug\slayer3d_editor.exe -h
- dumpbin /DEPENDENTS build\windows-msvc-vs2022\Debug\slayer3d_editor.exe showed no SDL3.dll dependency

## Notes
- clang-format was not available on PATH in the local shell.
