### PR TITLE
Make brush keyboard nudging camera-relative

### DIFF
--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -101,6 +101,149 @@ static void publish_editor_drag_move_feedback(slayer3d_game_data_runtime *runtim
     slayer3d_properties_set_vec3(runtime->scene_state, "editor.brush.drag.delta", delta);
 }
 
+static int editor_dominant_axis_index(slayer3d_vec3 v)
+{
+    const float abs_x = SDL_fabsf(v.x);
+    const float abs_y = SDL_fabsf(v.y);
+    const float abs_z = SDL_fabsf(v.z);
+    if (abs_x >= abs_y && abs_x >= abs_z)
+        return 0;
+    if (abs_y >= abs_z)
+        return 1;
+    return 2;
+}
+
+static slayer3d_vec3 editor_dominant_axis_vector(slayer3d_vec3 v)
+{
+    const int axis = editor_dominant_axis_index(v);
+    const float value = axis == 0 ? v.x : (axis == 1 ? v.y : v.z);
+    const float sign = value < 0.0f ? -1.0f : 1.0f;
+    switch (axis)
+    {
+    case 0:
+        return slayer3d_vec3_make(sign, 0.0f, 0.0f);
+    case 1:
+        return slayer3d_vec3_make(0.0f, sign, 0.0f);
+    default:
+        return slayer3d_vec3_make(0.0f, 0.0f, sign);
+    }
+}
+
+static bool editor_vec3_same_direction(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return SDL_fabsf(a.x - b.x) <= 0.0001f && SDL_fabsf(a.y - b.y) <= 0.0001f && SDL_fabsf(a.z - b.z) <= 0.0001f;
+}
+
+static bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
+                                slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic)
+{
+    if (out_forward != NULL)
+        *out_forward = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (out_right != NULL)
+        *out_right = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (out_up != NULL)
+        *out_up = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (out_orthographic != NULL)
+        *out_orthographic = false;
+    if (runtime == NULL)
+        return false;
+
+    slayer3d_camera3d camera;
+    if (!slayer3d_game_data_get_camera(runtime, slayer3d_game_data_active_camera(runtime), &camera))
+        return false;
+
+    const slayer3d_vec3 forward = slayer3d_vec3_normalize(slayer3d_vec3_sub(camera.target, camera.position));
+    const slayer3d_vec3 right = slayer3d_vec3_normalize(slayer3d_vec3_cross(forward, camera.up));
+    const slayer3d_vec3 up = slayer3d_vec3_normalize(slayer3d_vec3_cross(right, forward));
+    if (slayer3d_vec3_length_squared(forward) <= 0.000001f || slayer3d_vec3_length_squared(right) <= 0.000001f ||
+        slayer3d_vec3_length_squared(up) <= 0.000001f)
+    {
+        return false;
+    }
+
+    if (out_forward != NULL)
+        *out_forward = forward;
+    if (out_right != NULL)
+        *out_right = right;
+    if (out_up != NULL)
+        *out_up = up;
+    if (out_orthographic != NULL)
+        *out_orthographic = camera.projection == SLAYER3D_CAMERA_ORTHOGRAPHIC;
+    return true;
+}
+
+static slayer3d_vec3 editor_perspective_camera_forward_nudge_axis(slayer3d_vec3 forward, slayer3d_vec3 up)
+{
+    slayer3d_vec3 projected = slayer3d_vec3_make(forward.x, 0.0f, forward.z);
+    if (slayer3d_vec3_length_squared(projected) <= 0.000001f)
+    {
+        projected = slayer3d_vec3_make(up.x, 0.0f, up.z);
+        if (forward.y > 0.0f)
+            projected = slayer3d_vec3_negate(projected);
+    }
+    if (slayer3d_vec3_length_squared(projected) <= 0.000001f)
+        return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    return editor_dominant_axis_vector(projected);
+}
+
+static slayer3d_vec3 editor_perspective_camera_right_nudge_axis(slayer3d_vec3 right, slayer3d_vec3 forward_axis)
+{
+    slayer3d_vec3 axis = editor_dominant_axis_vector(right);
+    if (editor_vec3_same_direction(axis, forward_axis))
+    {
+        axis = slayer3d_vec3_cross(axis, slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
+        if (slayer3d_vec3_length_squared(axis) <= 0.000001f)
+            axis = slayer3d_vec3_make(0.0f, 0.0f, 1.0f);
+    }
+    return editor_dominant_axis_vector(axis);
+}
+
+static slayer3d_vec3 editor_camera_relative_brush_nudge_axis(const slayer3d_game_data_runtime *runtime,
+                                                             SDL_Scancode scancode)
+{
+    slayer3d_vec3 forward;
+    slayer3d_vec3 right;
+    slayer3d_vec3 up;
+    bool orthographic = false;
+    if (!editor_camera_basis(runtime, &forward, &right, &up, &orthographic))
+    {
+        if (scancode == SDL_SCANCODE_LEFT)
+            return slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
+        if (scancode == SDL_SCANCODE_RIGHT)
+            return slayer3d_vec3_make(0.0f, 0.0f, 1.0f);
+        if (scancode == SDL_SCANCODE_UP)
+            return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+        if (scancode == SDL_SCANCODE_DOWN)
+            return slayer3d_vec3_make(-1.0f, 0.0f, 0.0f);
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    }
+
+    if (orthographic)
+    {
+        if (scancode == SDL_SCANCODE_UP)
+            return editor_dominant_axis_vector(up);
+        if (scancode == SDL_SCANCODE_DOWN)
+            return slayer3d_vec3_negate(editor_dominant_axis_vector(up));
+        if (scancode == SDL_SCANCODE_RIGHT)
+            return editor_dominant_axis_vector(right);
+        if (scancode == SDL_SCANCODE_LEFT)
+            return slayer3d_vec3_negate(editor_dominant_axis_vector(right));
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    }
+
+    const slayer3d_vec3 forward_axis = editor_perspective_camera_forward_nudge_axis(forward, up);
+    const slayer3d_vec3 right_axis = editor_perspective_camera_right_nudge_axis(right, forward_axis);
+    if (scancode == SDL_SCANCODE_UP)
+        return forward_axis;
+    if (scancode == SDL_SCANCODE_DOWN)
+        return slayer3d_vec3_negate(forward_axis);
+    if (scancode == SDL_SCANCODE_RIGHT)
+        return right_axis;
+    if (scancode == SDL_SCANCODE_LEFT)
+        return slayer3d_vec3_negate(right_axis);
+    return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+}
+
 static bool editor_set_face_resize_preview(slayer3d_game_data_runtime *runtime,
                                            const slayer3d_game_data_editor_selection *selection, float distance)
 {
@@ -432,6 +575,23 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime, bool *
              (transform_modifier && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN)))
     {
         offset.y = -grid_size;
+    }
+    else if (!source_handle_mode && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT) && !transform_modifier)
+    {
+        offset = slayer3d_vec3_scale(editor_camera_relative_brush_nudge_axis(runtime, SDL_SCANCODE_LEFT), grid_size);
+    }
+    else if (!source_handle_mode && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_RIGHT) &&
+             !transform_modifier)
+    {
+        offset = slayer3d_vec3_scale(editor_camera_relative_brush_nudge_axis(runtime, SDL_SCANCODE_RIGHT), grid_size);
+    }
+    else if (!source_handle_mode && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_UP) && !transform_modifier)
+    {
+        offset = slayer3d_vec3_scale(editor_camera_relative_brush_nudge_axis(runtime, SDL_SCANCODE_UP), grid_size);
+    }
+    else if (!source_handle_mode && slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_DOWN) && !transform_modifier)
+    {
+        offset = slayer3d_vec3_scale(editor_camera_relative_brush_nudge_axis(runtime, SDL_SCANCODE_DOWN), grid_size);
     }
     else if (slayer3d_input_is_scancode_pressed(input, SDL_SCANCODE_LEFT) && !transform_modifier)
     {

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -21934,6 +21934,93 @@ TEST(GameDataRuntime, EditorShellDojoBrushSelectionSupportsAdditiveModifiers)
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoBrushKeyboardNudgeUsesCameraRelativeDirection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    seed_editor_shell_test_cube(runtime);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    select_editor_shell_test_cube(runtime);
+
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_properties_set_float(scene_state, "editor.grid.size", 1.0f);
+
+    auto brush_bounds = [&]() {
+        slayer3d_game_data_brush_world world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, "brush.target.cube") == 0)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush.target.cube not found";
+        return slayer3d_bounding_box{};
+    };
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    int frame = 0;
+    auto press_key = [&](SDL_Scancode scancode) {
+        SDL_Event key{};
+        key.type = SDL_EVENT_KEY_DOWN;
+        key.key.scancode = scancode;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, ++frame);
+        ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+        key.type = SDL_EVENT_KEY_UP;
+        slayer3d_input_process_event(input, &key);
+        slayer3d_input_update(input, ++frame);
+        ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    };
+
+    slayer3d_camera3d default_camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &default_camera));
+    const slayer3d_vec3 default_forward =
+        slayer3d_vec3_normalize(slayer3d_vec3_sub(default_camera.target, default_camera.position));
+    ASSERT_GT(default_forward.x, 0.0f);
+    ASSERT_GT(SDL_fabsf(default_forward.x), SDL_fabsf(default_forward.z));
+
+    const slayer3d_bounding_box before = brush_bounds();
+    press_key(SDL_SCANCODE_UP);
+    const slayer3d_bounding_box after_default_up = brush_bounds();
+    EXPECT_NEAR(after_default_up.min.x, before.min.x + 1.0f, 0.001f);
+    EXPECT_NEAR(after_default_up.max.x, before.max.x + 1.0f, 0.001f);
+    EXPECT_NEAR(after_default_up.min.z, before.min.z, 0.001f);
+    EXPECT_NEAR(after_default_up.max.z, before.max.z, 0.001f);
+
+    slayer3d_registered_actor *editor_camera = slayer3d_game_data_find_actor(runtime, "entity.editor_shell.camera");
+    ASSERT_NE(editor_camera, nullptr);
+    const float yaw = slayer3d_properties_get_float(editor_camera->props, "yaw", 0.0f);
+    slayer3d_properties_set_float(editor_camera->props, "yaw", yaw + 3.14159265f);
+
+    slayer3d_camera3d reversed_camera{};
+    ASSERT_TRUE(slayer3d_game_data_get_camera(runtime, "camera.editor_shell.viewport", &reversed_camera));
+    const slayer3d_vec3 reversed_forward =
+        slayer3d_vec3_normalize(slayer3d_vec3_sub(reversed_camera.target, reversed_camera.position));
+    ASSERT_LT(reversed_forward.x, 0.0f);
+    ASSERT_GT(SDL_fabsf(reversed_forward.x), SDL_fabsf(reversed_forward.z));
+
+    press_key(SDL_SCANCODE_UP);
+    const slayer3d_bounding_box after_reversed_up = brush_bounds();
+    EXPECT_NEAR(after_reversed_up.min.x, before.min.x, 0.001f);
+    EXPECT_NEAR(after_reversed_up.max.x, before.max.x, 0.001f);
+    EXPECT_NEAR(after_reversed_up.min.z, before.min.z, 0.001f);
+    EXPECT_NEAR(after_reversed_up.max.z, before.max.z, 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "moved 1 selected brush");
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();


### PR DESCRIPTION
## Summary
- Resolve brush arrow-key nudges from the active editor camera instead of fixed world X/Z directions.
- Match TrenchBroom-style behavior: perspective views use projected camera forward/right dominant axes, while orthographic views use screen up/right.
- Add an EditorShellDojo regression that reverses the editor camera yaw and verifies Up nudges in the reversed world direction.

Closes #452

## Verification
- cmake --build build/debug --target slayer3d_game_data_test
- scripts/check_clang_format.sh
- ctest --test-dir build/debug --output-on-failure -R 'GameDataRuntime.EditorShellDojoBrushKeyboardNudgeUsesCameraRelativeDirection'\n- ctest --test-dir build/debug --output-on-failure -R 'GameDataRuntime.EditorShellDojo'