### PR TITLE
Editor: implement scale tool

### DIFF
--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -297,6 +297,12 @@
         "tool_mode": "rotate",
         "message": "rotate tool",
         "button": { "x": 598, "y": 45, "w": 100, "h": 28 }
+      },
+      {
+        "mode": "scale",
+        "tool_mode": "scale",
+        "message": "scale tool",
+        "button": { "x": 704, "y": 45, "w": 88, "h": 28 }
       }
     ],
     "palette": {
@@ -361,6 +367,7 @@
         "vertex_handles",
         "edge_handles",
         "rotate_handles",
+        "scale_handles",
         "command_preview",
         "clip_preview",
         "markers"
@@ -517,6 +524,16 @@
             "interactive": true,
             "action": "editor.tool.rotate",
             "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "rotate" }
+          },
+          {
+            "id": "ui.editor_shell.tool_toolbar.scale.button",
+            "type": "button",
+            "w": 88,
+            "h": 28,
+            "text": "Scale",
+            "interactive": true,
+            "action": "editor.tool.scale",
+            "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "scale" }
           },
           {
             "id": "ui.editor_shell.tool_toolbar.entity.button",

--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -131,6 +131,12 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_ROTATE_ARC = 33,
         /** @brief Rotate tool non-mutating transformed source preview edge. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_ROTATE_PREVIEW_EDGE = 34,
+        /** @brief Scale tool bounds-handle marker line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HANDLE = 35,
+        /** @brief Scale tool hovered or active bounds-handle marker line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HOVER_HANDLE = 36,
+        /** @brief Scale tool non-mutating transformed source preview edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_PREVIEW_EDGE = 37,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -163,6 +169,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_EDGE_HANDLES = 1u << 12,
         /** @brief Emit rotate tool pivot and axis handles. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES = 1u << 13,
+        /** @brief Emit scale tool bounds handles. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES = 1u << 14,
         /** @brief Emit every supported editor debug primitive. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
@@ -172,7 +180,7 @@ extern "C"
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_DIAGNOSTIC_MARKERS |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_FACE | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_VERTEX_HANDLES |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_CLIP_PREVIEW | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_EDGE_HANDLES |
-            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES,
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES,
     };
 
     /** @brief One renderer-agnostic editor debug line segment. */

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -290,6 +290,18 @@ static bool editor_selection_rotate_selected_action(slayer3d_game_data_runtime *
     return slayer3d_game_data_rotate_selected_editor_brushes(runtime, pivot, axis, angle_radians);
 }
 
+static bool editor_selection_scale_selected_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    slayer3d_vec3 anchor = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (obj_get(action, "anchor") != NULL)
+        anchor = json_vec3(action, "anchor", anchor);
+    else if (!editor_selected_brushes_bounds_center(runtime, &anchor))
+        return false;
+
+    const slayer3d_vec3 factors = json_vec3(action, "factors", slayer3d_vec3_make(1.0f, 1.0f, 1.0f));
+    return slayer3d_game_data_scale_selected_editor_brushes(runtime, anchor, factors);
+}
+
 bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
@@ -536,6 +548,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 
     if (SDL_strcmp(type, "editor.selection.rotate_selected") == 0)
         return editor_selection_rotate_selected_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.selection.scale_selected") == 0)
+        return editor_selection_scale_selected_action(runtime, action);
 
     if (SDL_strcmp(type, "editor.selection.run") == 0)
     {

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -3774,6 +3774,134 @@ bool editor_brush_world_rotate_source_box(brush_world_runtime *world_runtime, co
     return true;
 }
 
+static bool scale_source_vertex_coord(const int coord[3], const float anchor[3], slayer3d_vec3 factors, int snap_units,
+                                      int out_coord[3])
+{
+    if (coord == NULL || anchor == NULL || out_coord == NULL)
+        return false;
+    return source_rotation_coord(anchor[0] + ((float)coord[0] - anchor[0]) * factors.x, snap_units, &out_coord[0]) &&
+           source_rotation_coord(anchor[1] + ((float)coord[1] - anchor[1]) * factors.y, snap_units, &out_coord[1]) &&
+           source_rotation_coord(anchor[2] + ((float)coord[2] - anchor[2]) * factors.z, snap_units, &out_coord[2]);
+}
+
+bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                         slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
+                                         int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed brush scale requires a source model");
+        return false;
+    }
+    if (SDL_isnan(anchor.x) || SDL_isinf(anchor.x) || SDL_isnan(anchor.y) || SDL_isinf(anchor.y) ||
+        SDL_isnan(anchor.z) || SDL_isinf(anchor.z) || SDL_isnan(factors.x) || SDL_isinf(factors.x) ||
+        SDL_isnan(factors.y) || SDL_isinf(factors.y) || SDL_isnan(factors.z) || SDL_isinf(factors.z))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush scale requires finite anchor and factors");
+        return false;
+    }
+    if (factors.x <= 0.000001f || factors.y <= 0.000001f || factors.z <= 0.000001f)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush scale requires positive factors");
+        return false;
+    }
+    if (SDL_fabsf(factors.x - 1.0f) <= 0.000001f && SDL_fabsf(factors.y - 1.0f) <= 0.000001f &&
+        SDL_fabsf(factors.z - 1.0f) <= 0.000001f)
+    {
+        return true;
+    }
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_name);
+    if (source_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        return false;
+    }
+
+    editor_brush_source_vertex_model model;
+    if (!editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model, error_buffer,
+                                                    error_buffer_size))
+    {
+        return false;
+    }
+
+    const float meters_per_unit =
+        world_runtime->editor_source_meters_per_unit > 0.0f ? world_runtime->editor_source_meters_per_unit : 0.001f;
+    const float anchor_source[3] = {
+        anchor.x / meters_per_unit,
+        anchor.y / meters_per_unit,
+        anchor.z / meters_per_unit,
+    };
+
+    int scaled_vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    SDL_zeroa(scaled_vertices);
+    const int snap_units = source_snap_units(world_runtime);
+    for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+    {
+        if (!scale_source_vertex_coord(model.vertices[vertex].coord, anchor_source, factors, snap_units,
+                                       scaled_vertices[vertex]))
+        {
+            set_error(error_buffer, error_buffer_size, "source brush scale would overflow the source grid");
+            return false;
+        }
+    }
+
+    slayer3d_game_data_brush rebuilt;
+    if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_name, &scaled_vertices[0][0],
+                                                                    model.vertex_count, &rebuilt, error_buffer,
+                                                                    error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&rebuilt);
+
+    editor_brush_source_box_runtime snapshot;
+    SDL_zero(snapshot);
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    if (!copy_editor_brush_source_box_runtime(box, &snapshot))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to snapshot source brush scale");
+        return false;
+    }
+
+    char *old_prefab = box->prefab;
+    box->prefab = SDL_strdup("convex");
+    if (box->prefab == NULL)
+    {
+        box->prefab = old_prefab;
+        free_editor_brush_source_box(&snapshot);
+        set_error(error_buffer, error_buffer_size, "failed to allocate source brush scale metadata");
+        return false;
+    }
+    SDL_free(old_prefab);
+    box->vertex_count = model.vertex_count;
+    for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+    {
+        box->vertices[vertex][0] = scaled_vertices[vertex][0];
+        box->vertices[vertex][1] = scaled_vertices[vertex][1];
+        box->vertices[vertex][2] = scaled_vertices[vertex][2];
+    }
+    for (int vertex = model.vertex_count; vertex < SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY; ++vertex)
+    {
+        box->vertices[vertex][0] = 0;
+        box->vertices[vertex][1] = 0;
+        box->vertices[vertex][2] = 0;
+    }
+    source_box_update_bounds_from_vertices(box);
+
+    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
+        !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box(box);
+        *box = snapshot;
+        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+        return false;
+    }
+
+    free_editor_brush_source_box(&snapshot);
+    return true;
+}
+
 bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                int error_buffer_size)

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -119,6 +119,9 @@ bool editor_brush_world_rotate_source_box_y_quarter_turns(brush_world_runtime *w
 bool editor_brush_world_rotate_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                           slayer3d_vec3 pivot, slayer3d_vec3 axis, float angle_radians,
                                           char *error_buffer, int error_buffer_size);
+bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                         slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
+                                         int error_buffer_size);
 int editor_brush_world_source_box_face_index_for_identity(const brush_world_runtime *world_runtime,
                                                           const char *brush_identity, int fallback_face_index,
                                                           const char *face_identity);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -426,6 +426,182 @@ void reset_editor_rotate_tool_state(slayer3d_game_data_runtime *runtime, const c
                                                    : (has_pivot ? "rotate tool" : "select a brush before rotate tool"));
 }
 
+void reset_editor_scale_tool_state(slayer3d_game_data_runtime *runtime, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    slayer3d_bounding_box bounds;
+    const bool has_bounds = editor_selected_bounds(runtime, &bounds);
+    const slayer3d_vec3 anchor = has_bounds ? slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f)
+                                            : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.ready", has_bounds);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.dragging", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.hovered", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.live_preview", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.valid", has_bounds);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.proportional", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.center_anchor", false);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.anchor", anchor);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.factors", slayer3d_vec3_make(1.0f, 1.0f, 1.0f));
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.handle_axes",
+                                 slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_string(runtime->scene_state, "editor.scale.handle", "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.scale.message",
+                                   message != NULL ? message
+                                                   : (has_bounds ? "scale tool" : "select a brush before scale tool"));
+}
+
+static slayer3d_vec3 editor_scale_bounds_point(slayer3d_bounding_box bounds, slayer3d_vec3 signs)
+{
+    const slayer3d_vec3 center = slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
+    return slayer3d_vec3_make(signs.x < -0.5f ? bounds.min.x : (signs.x > 0.5f ? bounds.max.x : center.x),
+                              signs.y < -0.5f ? bounds.min.y : (signs.y > 0.5f ? bounds.max.y : center.y),
+                              signs.z < -0.5f ? bounds.min.z : (signs.z > 0.5f ? bounds.max.z : center.z));
+}
+
+static int editor_scale_active_axis_count(slayer3d_vec3 signs)
+{
+    int count = 0;
+    if (SDL_fabsf(signs.x) > 0.5f)
+        count++;
+    if (SDL_fabsf(signs.y) > 0.5f)
+        count++;
+    if (SDL_fabsf(signs.z) > 0.5f)
+        count++;
+    return count;
+}
+
+static const char *editor_scale_handle_name(slayer3d_vec3 signs)
+{
+    const int axes = editor_scale_active_axis_count(signs);
+    return axes == 1 ? "side" : (axes == 2 ? "edge" : (axes == 3 ? "corner" : ""));
+}
+
+static bool editor_pick_scale_handle_at(slayer3d_game_data_runtime *runtime, float mouse_x, float mouse_y,
+                                        slayer3d_bounding_box bounds, slayer3d_vec3 *out_signs)
+{
+    if (runtime == NULL || out_signs == NULL)
+        return false;
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    yyjson_val *selection = obj_get(editor, "selection");
+    yyjson_val *trace = obj_get(selection, "trace");
+    editor_trace_viewport_config viewport;
+    if (!editor_trace_select_viewport_at(runtime, trace, mouse_x, mouse_y, &viewport))
+        return false;
+    slayer3d_camera3d camera;
+    if (!slayer3d_game_data_get_camera(runtime, viewport.camera, &camera))
+        return false;
+
+    int best_x = 0;
+    int best_y = 0;
+    int best_z = 0;
+    float best_distance = FLT_MAX;
+    for (int sx = -1; sx <= 1; ++sx)
+    {
+        for (int sy = -1; sy <= 1; ++sy)
+        {
+            for (int sz = -1; sz <= 1; ++sz)
+            {
+                if (sx == 0 && sy == 0 && sz == 0)
+                    continue;
+                float screen_x = 0.0f;
+                float screen_y = 0.0f;
+                const slayer3d_vec3 point =
+                    editor_scale_bounds_point(bounds, slayer3d_vec3_make((float)sx, (float)sy, (float)sz));
+                if (!editor_project_world_to_viewport(&camera, &viewport, point, &screen_x, &screen_y))
+                    continue;
+                const float dx = mouse_x - (viewport.x + screen_x);
+                const float dy = mouse_y - (viewport.y + screen_y);
+                const float distance = dx * dx + dy * dy;
+                if (distance < best_distance)
+                {
+                    best_distance = distance;
+                    best_x = sx;
+                    best_y = sy;
+                    best_z = sz;
+                }
+            }
+        }
+    }
+    const float handle_pick_radius_pixels = 18.0f;
+    if (best_distance > handle_pick_radius_pixels * handle_pick_radius_pixels)
+        return false;
+    *out_signs = slayer3d_vec3_make((float)best_x, (float)best_y, (float)best_z);
+    return true;
+}
+
+static slayer3d_vec3 editor_scale_anchor_for_handle(slayer3d_bounding_box bounds, slayer3d_vec3 signs,
+                                                    bool center_anchor)
+{
+    if (center_anchor)
+        return slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
+    return editor_scale_bounds_point(bounds, slayer3d_vec3_scale(signs, -1.0f));
+}
+
+static slayer3d_vec3 editor_scale_drag_factors(const editor_drag_move_state *drag, float mouse_x, float mouse_y)
+{
+    slayer3d_vec3 factors = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    if (drag == NULL)
+        return factors;
+    const float sx = drag->scale_start_handle.x - drag->scale_anchor.x;
+    const float sy = drag->scale_start_handle.y - drag->scale_anchor.y;
+    const float sz = drag->scale_start_handle.z - drag->scale_anchor.z;
+    const float start_len = SDL_sqrtf(sx * sx + sy * sy + sz * sz);
+    if (start_len <= 0.000001f)
+        return factors;
+
+    const float mouse_delta = ((mouse_x - drag->start_mouse_x) - (mouse_y - drag->start_mouse_y)) * 0.01f;
+    float factor = 1.0f + mouse_delta;
+    if (factor < 0.05f)
+        factor = 0.05f;
+    factor = SDL_roundf(factor * 20.0f) / 20.0f;
+
+    const bool proportional = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0 || drag->scale_proportional;
+    if (proportional)
+    {
+        factors = slayer3d_vec3_make(factor, factor, factor);
+    }
+    else
+    {
+        if (SDL_fabsf(drag->scale_handle_signs.x) > 0.5f)
+            factors.x = factor;
+        if (SDL_fabsf(drag->scale_handle_signs.y) > 0.5f)
+            factors.y = factor;
+        if (SDL_fabsf(drag->scale_handle_signs.z) > 0.5f)
+            factors.z = factor;
+    }
+    return factors;
+}
+
+static void publish_editor_scale_drag_state(slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag,
+                                            bool valid, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    const bool active = drag != NULL && drag->active && drag->scale_drag;
+    const slayer3d_vec3 factors = active ? drag->scale_factors : slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.ready", runtime->editor_selected_brush_count > 0);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.dragging", active);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.hovered", drag != NULL && drag->scale_hovered);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.live_preview",
+                                 active && (SDL_fabsf(factors.x - 1.0f) > 0.000001f ||
+                                            SDL_fabsf(factors.y - 1.0f) > 0.000001f ||
+                                            SDL_fabsf(factors.z - 1.0f) > 0.000001f));
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.valid", valid);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.proportional", active && drag->scale_proportional);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.center_anchor",
+                                 active && drag->scale_center_anchor);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.anchor",
+                                 active ? drag->scale_anchor : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.factors", factors);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.handle_axes",
+                                 drag != NULL ? drag->scale_handle_signs : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_string(
+        runtime->scene_state, "editor.scale.handle",
+        drag != NULL && drag->scale_hovered ? editor_scale_handle_name(drag->scale_handle_signs) : "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.scale.message", message != NULL ? message : "");
+}
+
 static void publish_editor_rotate_drag_state(slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag,
                                              bool valid, const char *message)
 {
@@ -859,6 +1035,139 @@ static bool editor_handle_rotate_drag(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
+static bool editor_update_scale_hover_state(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_scale(runtime) ||
+        runtime->editor_drag_move.scale_drag)
+    {
+        return false;
+    }
+    slayer3d_vec3 signs = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    bool hovered = false;
+    slayer3d_bounding_box bounds;
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input != NULL && editor_selected_bounds(runtime, &bounds))
+    {
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        if (slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+            hovered = editor_pick_scale_handle_at(runtime, mouse_x, mouse_y, bounds, &signs);
+    }
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.hovered", hovered);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.handle_axes", signs);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.scale.handle",
+                                   hovered ? editor_scale_handle_name(signs) : "");
+    return hovered;
+}
+
+static bool editor_handle_scale_drag(slayer3d_game_data_runtime *runtime,
+                                     const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
+{
+    (void)hover_selection;
+    if (out_consumed != NULL)
+        *out_consumed = false;
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_scale(runtime))
+    {
+        if (runtime != NULL && runtime->editor_drag_move.active && runtime->editor_drag_move.scale_drag)
+            clear_editor_drag_move(runtime);
+        return true;
+    }
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input == NULL)
+        return true;
+    (void)editor_update_scale_hover_state(runtime);
+
+    editor_drag_move_state *drag = &runtime->editor_drag_move;
+    const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
+    const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
+
+    if (!drag->active && left_pressed && editor_selected_brushes_active_for_scene(runtime) &&
+        runtime->editor_selected_brush_count > 0)
+    {
+        slayer3d_bounding_box bounds;
+        if (!editor_selected_bounds(runtime, &bounds))
+            return true;
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
+        slayer3d_vec3 signs = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        if (!editor_pick_scale_handle_at(runtime, mouse_x, mouse_y, bounds, &signs))
+            return true;
+
+        SDL_zero(*drag);
+        drag->active = true;
+        drag->scale_drag = true;
+        drag->scene = slayer3d_game_data_active_scene(runtime);
+        drag->scale_start_bounds = bounds;
+        drag->scale_handle_signs = signs;
+        drag->scale_center_anchor = (SDL_GetModState() & SDL_KMOD_ALT) != 0;
+        drag->scale_proportional = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
+        drag->scale_anchor = editor_scale_anchor_for_handle(bounds, signs, drag->scale_center_anchor);
+        drag->scale_start_handle = editor_scale_bounds_point(bounds, signs);
+        drag->scale_factors = slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+        drag->scale_hovered = true;
+        drag->scale_preview_valid = true;
+        drag->start_mouse_x = mouse_x;
+        drag->start_mouse_y = mouse_y;
+        publish_editor_scale_drag_state(runtime, drag, true, "scale drag");
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    if (!drag->active || !drag->scale_drag)
+        return true;
+    if (out_consumed != NULL)
+        *out_consumed = true;
+
+    drag->scale_center_anchor = (SDL_GetModState() & SDL_KMOD_ALT) != 0;
+    drag->scale_proportional = (SDL_GetModState() & SDL_KMOD_SHIFT) != 0;
+    drag->scale_anchor =
+        editor_scale_anchor_for_handle(drag->scale_start_bounds, drag->scale_handle_signs, drag->scale_center_anchor);
+    drag->scale_start_handle = editor_scale_bounds_point(drag->scale_start_bounds, drag->scale_handle_signs);
+
+    float mouse_x = drag->start_mouse_x;
+    float mouse_y = drag->start_mouse_y;
+    (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
+    drag->scale_factors = editor_scale_drag_factors(drag, mouse_x, mouse_y);
+    drag->moved = SDL_fabsf(drag->scale_factors.x - 1.0f) > 0.000001f ||
+                  SDL_fabsf(drag->scale_factors.y - 1.0f) > 0.000001f ||
+                  SDL_fabsf(drag->scale_factors.z - 1.0f) > 0.000001f;
+    publish_editor_scale_drag_state(runtime, drag, true, drag->moved ? "scale preview" : "scale drag");
+
+    if (left_released || !left_down)
+    {
+        const slayer3d_vec3 anchor = drag->scale_anchor;
+        const slayer3d_vec3 factors = drag->scale_factors;
+        const bool moved = drag->moved;
+        if (moved)
+        {
+            if (slayer3d_game_data_scale_selected_editor_brushes(runtime, anchor, factors))
+            {
+                update_active_editor_selection_from_selected_brushes(runtime);
+                slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.valid", true);
+                slayer3d_properties_set_string(runtime->scene_state, "editor.scale.message", "scaled selection");
+                editor_publish_console_message(runtime, "scaled selection");
+            }
+            else
+            {
+                slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.valid", false);
+                slayer3d_properties_set_string(runtime->scene_state, "editor.scale.message", "scale rejected");
+                slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "scale rejected");
+            }
+        }
+        clear_editor_drag_move(runtime);
+        slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.dragging", false);
+        slayer3d_properties_set_bool(runtime->scene_state, "editor.scale.live_preview", false);
+        slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.anchor", anchor);
+        slayer3d_properties_set_vec3(runtime->scene_state, "editor.scale.factors", factors);
+    }
+
+    return true;
+}
+
 static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
                                     const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
 {
@@ -983,8 +1292,8 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime, bool *
     const bool vertex_mode = editor_mode_is_vertex(runtime);
     const bool edge_mode = editor_mode_is_edge(runtime);
     const bool source_handle_mode = vertex_mode || edge_mode;
-    const bool brush_transform_mode =
-        editor_mode_is_select(runtime) || editor_mode_is_brush(runtime) || editor_mode_is_rotate(runtime);
+    const bool brush_transform_mode = editor_mode_is_select(runtime) || editor_mode_is_brush(runtime) ||
+                                      editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime);
     if (!brush_transform_mode && !source_handle_mode)
         return true;
 
@@ -1471,6 +1780,15 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
         publish_editor_selected_brush_count(runtime);
         return true;
     }
+    bool scale_drag_consumed = false;
+    if (!editor_handle_scale_drag(runtime, &hover_selection, &scale_drag_consumed))
+        return false;
+    if (scale_drag_consumed)
+    {
+        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+        publish_editor_selected_brush_count(runtime);
+        return true;
+    }
     bool face_drag_consumed = false;
     if (!editor_handle_face_drag(runtime, &hover_selection, &face_drag_consumed))
         return false;
@@ -1554,7 +1872,7 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     }
 
     if ((editor_mode_is_brush(runtime) || editor_mode_is_face(runtime) || editor_mode_is_edge(runtime) ||
-         editor_mode_is_vertex(runtime) || editor_mode_is_rotate(runtime)) &&
+         editor_mode_is_vertex(runtime) || editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime)) &&
         hover_selection.hit)
     {
         runtime->editor_active_selection = hover_selection;

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -300,6 +300,8 @@ static void free_editor_command_transaction_entry(editor_command_transaction_ent
     SDL_free((void *)entry->face_stable_id);
     if (entry->has_source_box_snapshot)
         free_editor_brush_source_box_runtime(&entry->source_box_snapshot);
+    if (entry->has_source_box_after_snapshot)
+        free_editor_brush_source_box_runtime(&entry->source_box_after_snapshot);
     for (int i = 0; i < entry->source_clip_before_count; ++i)
         free_editor_brush_source_box_runtime(&entry->source_clip_before[i]);
     for (int i = 0; i < entry->source_clip_after_count; ++i)
@@ -820,6 +822,42 @@ static bool apply_editor_brush_rotate(slayer3d_game_data_runtime *runtime,
         return true;
     }
     return false;
+}
+
+static bool apply_editor_source_box_snapshot(slayer3d_game_data_runtime *runtime,
+                                             const editor_command_transaction_entry *entry,
+                                             const editor_brush_source_box_runtime *snapshot)
+{
+    if (runtime == NULL || entry == NULL || snapshot == NULL || entry->world_name == NULL ||
+        entry->element_name == NULL)
+        return false;
+
+    brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, entry->world_name);
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+        return false;
+
+    const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                     ? entry->element_stable_id
+                                     : entry->element_name;
+    const int current_index = editor_brush_world_find_source_box_index(world_runtime, brush_identity);
+    if (current_index >= 0 && !editor_brush_world_remove_source_box_at_index(world_runtime, current_index, NULL, 0))
+        return false;
+
+    const int restored_index = SDL_clamp(entry->brush_index, 0, world_runtime->editor_source_box_count);
+    if (!editor_brush_world_insert_source_box_at_index(world_runtime, restored_index, snapshot, NULL, 0))
+        return false;
+
+    editor_brush_world_mark_dirty(world_runtime);
+    return true;
+}
+
+static bool apply_editor_brush_scale(slayer3d_game_data_runtime *runtime, const editor_command_transaction_entry *entry,
+                                     bool forward)
+{
+    if (entry == NULL || !entry->has_source_box_snapshot || !entry->has_source_box_after_snapshot)
+        return false;
+    return apply_editor_source_box_snapshot(runtime, entry,
+                                            forward ? &entry->source_box_after_snapshot : &entry->source_box_snapshot);
 }
 
 static bool editor_float_finite(float value)
@@ -1701,6 +1739,7 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
     return (SDL_strcmp(entry->command, "translate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           (SDL_strcmp(entry->command, "scale") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "clip") == 0 && SDL_strcmp(entry->target, "selection") == 0) ||
            ((SDL_strcmp(entry->command, "create") == 0 || SDL_strcmp(entry->command, "duplicate") == 0) &&
@@ -1879,6 +1918,28 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
             return false;
         }
         if (!apply_editor_brush_rotate(runtime, entry, angle_radians))
+        {
+            free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+            return false;
+        }
+        refresh_editor_selections_from_snapshots(runtime, selected_snapshots, selected_snapshot_count,
+                                                 &active_snapshot);
+        free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
+        update_active_editor_selection_material_for_transaction(runtime, entry, forward, active_element_matches);
+        sync_editor_selection_after_transaction(runtime, entry, forward);
+        return true;
+    }
+    if (SDL_strcmp(entry->command, "scale") == 0)
+    {
+        editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        editor_selection_identity_snapshot active_snapshot;
+        int selected_snapshot_count = 0;
+        if (!capture_current_editor_selection_snapshots(runtime, selected_snapshots, &selected_snapshot_count,
+                                                        &active_snapshot))
+        {
+            return false;
+        }
+        if (!apply_editor_brush_scale(runtime, entry, forward))
         {
             free_current_editor_selection_snapshots(selected_snapshots, selected_snapshot_count, &active_snapshot);
             return false;
@@ -2925,6 +2986,105 @@ bool slayer3d_game_data_rotate_selected_editor_brushes(slayer3d_game_data_runtim
         char message[128];
         SDL_snprintf(message, sizeof(message),
                      applied_count == 1 ? "rotated 1 selected brush" : "rotated %d selected brushes", applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
+    if (last_entry != NULL && runtime->editor_selected_brush_count > 0)
+    {
+        runtime->editor_active_selection = runtime->editor_selected_brushes[runtime->editor_selected_brush_count - 1];
+        runtime->editor_selection_scene = active_scene;
+    }
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
+}
+
+bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
+                                                      slayer3d_vec3 factors)
+{
+    if (runtime == NULL || runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+        return false;
+    if (!editor_float_finite(anchor.x) || !editor_float_finite(anchor.y) || !editor_float_finite(anchor.z) ||
+        !editor_float_finite(factors.x) || !editor_float_finite(factors.y) || !editor_float_finite(factors.z) ||
+        factors.x <= 0.000001f || factors.y <= 0.000001f || factors.z <= 0.000001f)
+    {
+        return false;
+    }
+    if (SDL_fabsf(factors.x - 1.0f) <= 0.000001f && SDL_fabsf(factors.y - 1.0f) <= 0.000001f &&
+        SDL_fabsf(factors.z - 1.0f) <= 0.000001f)
+    {
+        return false;
+    }
+
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+        return false;
+
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int applied_count = 0;
+    editor_command_transaction_entry *last_entry = NULL;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+        if (!transaction_editor_selection_is_selectable_brush(selection))
+            goto fail;
+
+        editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+        if (entry == NULL)
+            goto fail;
+        if (!editor_prepare_transaction_common(entry, active_scene, "scale", "element", selection->world_name,
+                                               selection->element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+                                            &entry->element_stable_id))
+        {
+            goto fail;
+        }
+        entry->has_bounds = selection->has_bounds;
+        entry->bounds = selection->bounds;
+        SDL_snprintf(entry->message, sizeof(entry->message), "scaled %s", selection->element_name);
+
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection->world_name);
+        if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+            goto fail;
+        const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                         ? entry->element_stable_id
+                                         : entry->element_name;
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity, &entry->source_box_snapshot,
+                                                            &entry->brush_index, NULL, 0))
+        {
+            goto fail;
+        }
+        entry->has_source_box_snapshot = true;
+
+        if (!editor_brush_world_scale_source_box(world_runtime, brush_identity, anchor, factors, NULL, 0))
+            goto fail;
+        editor_brush_world_mark_dirty(world_runtime);
+
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity,
+                                                            &entry->source_box_after_snapshot, NULL, NULL, 0))
+        {
+            (void)apply_editor_source_box_snapshot(runtime, entry, &entry->source_box_snapshot);
+            goto fail;
+        }
+        entry->has_source_box_after_snapshot = true;
+
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
+        last_entry = entry;
+        applied_count++;
+    }
+
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "scaled 1 selected brush" : "scaled %d selected brushes", applied_count);
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
     if (last_entry != NULL && runtime->editor_selected_brush_count > 0)

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -126,6 +126,8 @@ static unsigned int editor_debug_flag_from_string(const char *value)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_EDGE_HANDLES;
     if (SDL_strcmp(value != NULL ? value : "", "rotate_handles") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES;
+    if (SDL_strcmp(value != NULL ? value : "", "scale_handles") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES;
     if (SDL_strcmp(value != NULL ? value : "", "clip_preview") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_CLIP_PREVIEW;
     return 0u;
@@ -1832,6 +1834,138 @@ static bool emit_editor_debug_rotate_preview_edges(editor_debug_iteration_contex
     return true;
 }
 
+static slayer3d_vec3 editor_debug_scale_bounds_point(slayer3d_bounding_box bounds, slayer3d_vec3 signs)
+{
+    const slayer3d_vec3 center = slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
+    return slayer3d_vec3_make(signs.x < -0.5f ? bounds.min.x : (signs.x > 0.5f ? bounds.max.x : center.x),
+                              signs.y < -0.5f ? bounds.min.y : (signs.y > 0.5f ? bounds.max.y : center.y),
+                              signs.z < -0.5f ? bounds.min.z : (signs.z > 0.5f ? bounds.max.z : center.z));
+}
+
+static bool editor_debug_scale_signs_match(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return SDL_fabsf(a.x - b.x) <= 0.001f && SDL_fabsf(a.y - b.y) <= 0.001f && SDL_fabsf(a.z - b.z) <= 0.001f;
+}
+
+static slayer3d_vec3 editor_debug_scale_point(slayer3d_vec3 point, slayer3d_vec3 anchor, slayer3d_vec3 factors)
+{
+    return slayer3d_vec3_make(anchor.x + (point.x - anchor.x) * factors.x, anchor.y + (point.y - anchor.y) * factors.y,
+                              anchor.z + (point.z - anchor.z) * factors.z);
+}
+
+static bool emit_editor_debug_scale_preview_edges(editor_debug_iteration_context *context,
+                                                  const slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
+                                                  slayer3d_vec3 factors)
+{
+    if (context == NULL || runtime == NULL ||
+        (SDL_fabsf(factors.x - 1.0f) <= 0.000001f && SDL_fabsf(factors.y - 1.0f) <= 0.000001f &&
+         SDL_fabsf(factors.z - 1.0f) <= 0.000001f))
+    {
+        return true;
+    }
+
+    const slayer3d_game_data_editor_debug_primitive_type old_type = context->type;
+    const slayer3d_color old_color = context->color;
+    context->type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_PREVIEW_EDGE;
+    context->color = (slayer3d_color){90, 245, 255, 245};
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        slayer3d_game_data_editor_selection selection =
+            resolved_editor_selection(runtime, &runtime->editor_selected_brushes[i]);
+        const brush_world_runtime *world = find_brush_world_runtime(runtime, selection.world_name);
+        const int source_index = editor_debug_source_index_for_selection(world, &selection);
+        editor_brush_source_vertex_model model;
+        if (source_index < 0 || !editor_brush_source_box_build_vertex_model(world, source_index, &model, NULL, 0))
+            continue;
+
+        context->world_name = selection.world_name;
+        context->element_name = selection.element_name;
+        context->face_index = -1;
+        for (int edge = 0; edge < model.edge_count; ++edge)
+        {
+            const editor_brush_source_edge *source_edge = &model.edges[edge];
+            const int a = source_edge->vertex_indices[0];
+            const int b = source_edge->vertex_indices[1];
+            if (a < 0 || a >= model.vertex_count || b < 0 || b >= model.vertex_count)
+                continue;
+            const slayer3d_vec3 start = slayer3d_vec3_add(selection.world_position,
+                                                          editor_source_vertex_coord_meters(world, &model.vertices[a]));
+            const slayer3d_vec3 end = slayer3d_vec3_add(selection.world_position,
+                                                        editor_source_vertex_coord_meters(world, &model.vertices[b]));
+            if (!emit_editor_debug_line(context, editor_debug_scale_point(start, anchor, factors),
+                                        editor_debug_scale_point(end, anchor, factors)))
+            {
+                context->type = old_type;
+                context->color = old_color;
+                return false;
+            }
+        }
+    }
+    context->type = old_type;
+    context->color = old_color;
+    return true;
+}
+
+static bool emit_editor_debug_scale_tool(const slayer3d_game_data_runtime *runtime,
+                                         const slayer3d_game_data_editor_debug_desc *desc,
+                                         slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    const unsigned int flags =
+        desc != NULL && desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if (runtime == NULL || runtime->scene_state == NULL || callback == NULL ||
+        (flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES) == 0u || !editor_mode_is_scale(runtime))
+    {
+        return true;
+    }
+
+    slayer3d_bounding_box bounds;
+    if (!editor_rotate_tool_selection_bounds(runtime, &bounds))
+        return true;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.face_index = -1;
+
+    const bool dragging = runtime->editor_drag_move.active && runtime->editor_drag_move.scale_drag;
+    const bool hovered = scene_state_bool(runtime, "editor.scale.hovered", false);
+    const slayer3d_vec3 active_signs =
+        dragging ? runtime->editor_drag_move.scale_handle_signs
+                 : slayer3d_properties_get_vec3(runtime->scene_state, "editor.scale.handle_axes",
+                                                slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const slayer3d_vec3 size = slayer3d_vec3_sub(bounds.max, bounds.min);
+    const float marker_size = SDL_max(SDL_max(size.x, SDL_max(size.y, size.z)) * 0.035f, 0.12f);
+    for (int sx = -1; sx <= 1; ++sx)
+    {
+        for (int sy = -1; sy <= 1; ++sy)
+        {
+            for (int sz = -1; sz <= 1; ++sz)
+            {
+                if (sx == 0 && sy == 0 && sz == 0)
+                    continue;
+                const slayer3d_vec3 signs = slayer3d_vec3_make((float)sx, (float)sy, (float)sz);
+                const bool highlighted = (dragging || hovered) && editor_debug_scale_signs_match(signs, active_signs);
+                context.type = highlighted ? SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HOVER_HANDLE
+                                           : SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HANDLE;
+                context.color =
+                    highlighted ? (slayer3d_color){255, 255, 255, 255} : (slayer3d_color){90, 220, 245, 220};
+                if (!emit_editor_debug_marker_cross(&context, editor_debug_scale_bounds_point(bounds, signs),
+                                                    marker_size))
+                    return false;
+            }
+        }
+    }
+
+    if (dragging)
+    {
+        if (!emit_editor_debug_scale_preview_edges(&context, runtime, runtime->editor_drag_move.scale_anchor,
+                                                   runtime->editor_drag_move.scale_factors))
+            return false;
+    }
+    return true;
+}
+
 static bool emit_editor_debug_rotate_tool(const slayer3d_game_data_runtime *runtime,
                                           const slayer3d_game_data_editor_debug_desc *desc,
                                           slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
@@ -1946,6 +2080,11 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
     }
     if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES) != 0u &&
         !emit_editor_debug_rotate_tool(runtime, desc, callback, userdata))
+    {
+        return true;
+    }
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES) != 0u &&
+        !emit_editor_debug_scale_tool(runtime, desc, callback, userdata))
     {
         return true;
     }

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -67,6 +67,7 @@ bool editor_mode_is_face(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_edge(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_vertex(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_rotate(const slayer3d_game_data_runtime *runtime);
+bool editor_mode_is_scale(const slayer3d_game_data_runtime *runtime);
 bool editor_selection_matches_brush(const slayer3d_game_data_editor_selection *selection, const char *world_name,
                                     const char *element_name);
 bool editor_hover_is_selected_brush(const slayer3d_game_data_runtime *runtime,
@@ -95,6 +96,8 @@ bool editor_handle_vertex_drag(slayer3d_game_data_runtime *runtime,
 bool editor_handle_vertex_add_to_source(slayer3d_game_data_runtime *runtime,
                                         const slayer3d_game_data_editor_selection *hover_selection,
                                         bool select_requested, bool *out_consumed);
+void reset_editor_rotate_tool_state(slayer3d_game_data_runtime *runtime, const char *message);
+void reset_editor_scale_tool_state(slayer3d_game_data_runtime *runtime, const char *message);
 bool editor_handle_vertex_selection(slayer3d_game_data_runtime *runtime,
                                     const slayer3d_game_data_editor_selection *hover_selection, bool select_requested,
                                     bool *out_consumed);
@@ -145,6 +148,8 @@ bool slayer3d_game_data_create_editor_source_box_brush(slayer3d_game_data_runtim
 bool slayer3d_game_data_translate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset);
 bool slayer3d_game_data_rotate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 pivot,
                                                        slayer3d_vec3 axis, float angle_radians);
+bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
+                                                      slayer3d_vec3 factors);
 bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);
 bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
                                                           bool use_last_offset);

--- a/src/game_data_editor_selection_helpers.c
+++ b/src/game_data_editor_selection_helpers.c
@@ -206,6 +206,12 @@ bool editor_mode_is_rotate(const slayer3d_game_data_runtime *runtime)
            SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "rotate") == 0;
 }
 
+bool editor_mode_is_scale(const slayer3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->scene_state != NULL &&
+           SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "scale") == 0;
+}
+
 bool editor_selection_matches_brush(const slayer3d_game_data_editor_selection *selection, const char *world_name,
                                     const char *element_name)
 {

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -64,6 +64,8 @@ static const char *editor_mode_for_tool_action(const char *action)
         return "vertex";
     if (SDL_strcmp(action, "editor.tool.rotate") == 0)
         return "rotate";
+    if (SDL_strcmp(action, "editor.tool.scale") == 0)
+        return "scale";
     if (SDL_strcmp(action, "editor.tool.texture") == 0)
         return "texture";
     return NULL;
@@ -128,6 +130,15 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
             message = selected_count > 0 ? "rotate tool" : "select a brush before rotate tool";
         }
     }
+    else if (SDL_strcmp(mode, "scale") == 0)
+    {
+        tool_mode = "scale";
+        if (message == NULL || message[0] == '\0')
+        {
+            const int selected_count = slayer3d_properties_get_int(runtime->scene_state, "editor.selection.count", 0);
+            message = selected_count > 0 ? "scale tool" : "select a brush before scale tool";
+        }
+    }
     else if (SDL_strcmp(mode, "texture") == 0)
     {
         tool_mode = "paint";
@@ -159,6 +170,8 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
         return slayer3d_game_data_enter_editor_clip_tool(runtime, message);
     if (SDL_strcmp(mode, "rotate") == 0)
         reset_editor_rotate_tool_state(runtime, message);
+    if (SDL_strcmp(mode, "scale") == 0)
+        reset_editor_scale_tool_state(runtime, message);
     return true;
 }
 

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -101,6 +101,7 @@ typedef struct editor_drag_move_state
     bool edge_drag;
     bool edge_lasso;
     bool rotate_drag;
+    bool scale_drag;
     bool vertex_toggle_on_click;
     bool lasso_additive;
     const char *scene;
@@ -122,6 +123,15 @@ typedef struct editor_drag_move_state
     bool rotate_screen_basis_valid;
     bool rotate_hovered;
     bool rotate_preview_valid;
+    slayer3d_bounding_box scale_start_bounds;
+    slayer3d_vec3 scale_anchor;
+    slayer3d_vec3 scale_handle_signs;
+    slayer3d_vec3 scale_factors;
+    slayer3d_vec3 scale_start_handle;
+    bool scale_center_anchor;
+    bool scale_proportional;
+    bool scale_hovered;
+    bool scale_preview_valid;
     int vertex_origin_count;
     editor_drag_vertex_origin vertex_toggle_origin;
     editor_drag_vertex_origin vertex_origins[SLAYER3D_EDITOR_DRAG_VERTEX_ORIGIN_CAPACITY];
@@ -408,6 +418,8 @@ typedef struct editor_command_transaction_entry
     int brush_index;
     bool has_source_box_snapshot;
     editor_brush_source_box_runtime source_box_snapshot;
+    bool has_source_box_after_snapshot;
+    editor_brush_source_box_runtime source_box_after_snapshot;
     int source_clip_before_count;
     int source_clip_after_count;
     int source_clip_before_indices[SLAYER3D_EDITOR_SOURCE_CLIP_BRUSH_CAPACITY];

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -986,6 +986,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.selection.delete_selected", validate_editor_selection_delete_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.resize_y", validate_editor_selection_resize_y_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.rotate_selected", validate_editor_selection_rotate_selected_action),
+        ACTION_RULE_EXACT_HANDLER("editor.selection.scale_selected", validate_editor_selection_scale_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.run", validate_editor_selection_run_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.preview", validate_editor_command_preview_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.clear_preview", validate_editor_command_clear_preview_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -158,7 +158,7 @@ static bool editor_tool_mode_valid(const char *mode)
     return mode != NULL &&
            (SDL_strcmp(mode, "select") == 0 || SDL_strcmp(mode, "brush") == 0 || SDL_strcmp(mode, "face") == 0 ||
             SDL_strcmp(mode, "edge") == 0 || SDL_strcmp(mode, "clip") == 0 || SDL_strcmp(mode, "vertex") == 0 ||
-            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "texture") == 0);
+            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "scale") == 0 || SDL_strcmp(mode, "texture") == 0);
 }
 
 bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *action, const char *json_path,
@@ -170,7 +170,7 @@ bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *a
     if (!editor_tool_mode_valid(mode))
         return validation_error(ctx, json_path,
                                 "editor.tool.set_mode mode must be one of select, brush, face, edge, clip, vertex, "
-                                "rotate, texture");
+                                "rotate, scale, texture");
     yyjson_val *message = obj_get(action, "message");
     if (message != NULL && (!yyjson_is_str(message) || yyjson_get_str(message)[0] == '\0'))
         return validation_error(ctx, json_path, "editor.tool.set_mode message must be non-empty");
@@ -358,6 +358,28 @@ bool validate_editor_selection_rotate_selected_action(validation_context *ctx, y
     if (angle_degrees != NULL &&
         (!yyjson_is_num(angle_degrees) || !validation_float_finite((float)yyjson_get_num(angle_degrees))))
         return validation_error(ctx, json_path, "editor.selection.rotate_selected angle_degrees must be finite");
+    return true;
+}
+
+bool validate_editor_selection_scale_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                     validation_names *names, const char *type)
+{
+    (void)names;
+    (void)type;
+    yyjson_val *anchor = obj_get(action, "anchor");
+    if (anchor != NULL && !is_vec_array(anchor, 3))
+        return validation_error(ctx, json_path, "editor.selection.scale_selected anchor must be a numeric vec3");
+    yyjson_val *factors = obj_get(action, "factors");
+    if (!is_vec_array(factors, 3))
+        return validation_error(ctx, json_path, "editor.selection.scale_selected factors must be a numeric vec3");
+    const float factor_x = (float)yyjson_get_num(yyjson_arr_get(factors, 0));
+    const float factor_y = (float)yyjson_get_num(yyjson_arr_get(factors, 1));
+    const float factor_z = (float)yyjson_get_num(yyjson_arr_get(factors, 2));
+    if (!validation_float_finite(factor_x) || !validation_float_finite(factor_y) ||
+        !validation_float_finite(factor_z) || factor_x <= 0.0f || factor_y <= 0.0f || factor_z <= 0.0f)
+    {
+        return validation_error(ctx, json_path, "editor.selection.scale_selected factors must be positive and finite");
+    }
     return true;
 }
 

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -29,6 +29,8 @@ bool validate_editor_selection_resize_y_action(validation_context *ctx, yyjson_v
                                                validation_names *names, const char *type);
 bool validate_editor_selection_rotate_selected_action(validation_context *ctx, yyjson_val *action,
                                                       const char *json_path, validation_names *names, const char *type);
+bool validate_editor_selection_scale_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                     validation_names *names, const char *type);
 bool validate_editor_selection_run_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                           validation_names *names, const char *type);
 bool validate_editor_command_preview_action(validation_context *ctx, yyjson_val *action, const char *json_path,

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -48,7 +48,8 @@ static bool editor_debug_flag_name_valid(const char *value)
                              SDL_strcmp(value, "game_objects") == 0 || SDL_strcmp(value, "markers") == 0 ||
                              SDL_strcmp(value, "diagnostic_markers") == 0 || SDL_strcmp(value, "selection_face") == 0 ||
                              SDL_strcmp(value, "vertex_handles") == 0 || SDL_strcmp(value, "edge_handles") == 0 ||
-                             SDL_strcmp(value, "rotate_handles") == 0 || SDL_strcmp(value, "clip_preview") == 0);
+                             SDL_strcmp(value, "rotate_handles") == 0 || SDL_strcmp(value, "scale_handles") == 0 ||
+                             SDL_strcmp(value, "clip_preview") == 0);
 }
 
 static bool validate_string_or_string_array_names(validation_context *ctx, yyjson_val *value, const char *path,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -217,6 +217,9 @@ extern "C"
     bool editor_brush_world_rotate_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                               slayer3d_vec3 pivot, slayer3d_vec3 axis, float angle_radians,
                                               char *error_buffer, int error_buffer_size);
+    bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                             slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
+                                             int error_buffer_size);
     bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                    slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                    int error_buffer_size);
@@ -300,6 +303,8 @@ extern "C"
                                                               slayer3d_vec3 offset);
     bool slayer3d_game_data_rotate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 pivot,
                                                            slayer3d_vec3 axis, float angle_radians);
+    bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
+                                                          slayer3d_vec3 factors);
     bool slayer3d_game_data_delete_selected_editor_brushes(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                                            const slayer3d_properties *payload);
     bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
@@ -22315,6 +22320,61 @@ TEST(GameDataRuntime, EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelecti
     EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 0.0f, 0.001f);
     EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.z, -3.0f, 0.001f);
 
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "scale", nullptr));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "scale");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "scale");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.scale.ready", false));
+    const slayer3d_value *scale_anchor = slayer3d_properties_get_value(scene_state, "editor.scale.anchor");
+    ASSERT_NE(scale_anchor, nullptr);
+    ASSERT_EQ(scale_anchor->type, SLAYER3D_VALUE_VEC3);
+    EXPECT_NEAR(scale_anchor->as_vec3.x, 0.5f, 0.001f);
+    EXPECT_NEAR(scale_anchor->as_vec3.y, 0.5f, 0.001f);
+    EXPECT_NEAR(scale_anchor->as_vec3.z, -2.5f, 0.001f);
+    struct ScaleDebugCapture
+    {
+        int handles = 0;
+        int hovered_handles = 0;
+        int preview_edges = 0;
+    } scale_debug;
+    auto capture_scale_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<ScaleDebugCapture *>(userdata);
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HANDLE)
+            capture->handles++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HOVER_HANDLE)
+            capture->hovered_handles++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_PREVIEW_EDGE)
+            capture->preview_edges++;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_scale_debug, &scale_debug));
+    EXPECT_GE(scale_debug.handles, 78);
+    EXPECT_EQ(scale_debug.hovered_handles, 0);
+    EXPECT_EQ(scale_debug.preview_edges, 0);
+
+    ASSERT_TRUE(slayer3d_game_data_scale_selected_editor_brushes(runtime, slayer3d_vec3_make(0.0f, 0.0f, -3.0f),
+                                                                 slayer3d_vec3_make(2.0f, 1.0f, 1.0f)));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.x, 2.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.z, -3.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.z, -2.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.x, 2.0f, 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "scaled 1 selected brush");
+    brush_world_runtime *source_world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(source_world_runtime, nullptr);
+    editor_brush_source_box_runtime scaled_source{};
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(source_world_runtime, brush_name.c_str(), &scaled_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(scaled_source.vertex_count, 8);
+    free_editor_brush_source_box_runtime(&scaled_source);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.x, 1.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.x, 1.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.x, 2.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.x, 2.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "select", nullptr));
+
     ASSERT_TRUE(
         slayer3d_game_data_duplicate_selected_editor_brushes(runtime, slayer3d_vec3_make(1.0f, 0.0f, 0.0f), false));
     ASSERT_EQ(brush_world().brush_count, initial_brush_count + 2);
@@ -28340,6 +28400,42 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordi
         << error;
     EXPECT_EQ(rotated_source.vertex_count, 8);
     free_editor_brush_source_box_runtime(&rotated_source);
+
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", rotate_json,
+                                                                     sizeof(rotate_json) - 1u, "/tmp/source-scale.json",
+                                                                     error, sizeof(error)))
+        << error;
+    world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_scale_source_box(world_runtime, "source.box.rotate",
+                                                    slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                    slayer3d_vec3_make(0.5f, 2.0f, 1.0f), error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 2.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.min.y, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.y, 2.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.min.z, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.z, 8.0f, 0.001f);
+    editor_brush_source_box_runtime scaled_source{};
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(world_runtime, "source.box.rotate", &scaled_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(scaled_source.vertex_count, 8);
+    free_editor_brush_source_box_runtime(&scaled_source);
+
+    SDL_zeroa(error);
+    EXPECT_FALSE(editor_brush_world_scale_source_box(world_runtime, "source.box.rotate",
+                                                     slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                     slayer3d_vec3_make(0.01f, 1.0f, 1.0f), error, sizeof(error)));
+    EXPECT_STRNE(error, "");
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 2.0f, 0.001f) << "invalid scale must be atomic";
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);


### PR DESCRIPTION
## Summary
- add source-backed brush scaling with snap/topology validation and undo/redo snapshots
- add selected-brush scale action, validation, toolbar mode, scene-state publishing, and editor shell scale button
- add scale bounds handles, hover/drag state, live preview debug edges, and focused regression coverage

Closes #448.

## Tests
- `cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8`
- `./build/debug/tests/slayer3d_game_data_test`
- `ctest --test-dir build/debug --output-on-failure` (1384 passed, 1 skipped: OpenGL availability)
