### PR TITLE
Editor: implement shear tool

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -278,7 +278,6 @@
     "signal.editor.tool.wall",
     "signal.editor.tool.ceiling",
     "signal.editor.tool.sky",
-    "signal.editor.tool.player_start",
     "signal.editor.grid.decrease",
     "signal.editor.grid.increase",
     "signal.editor.wall_axis.toggle",
@@ -287,7 +286,6 @@
     "signal.editor.mode.edge",
     "signal.editor.mode.face",
     "signal.editor.mode.select",
-    "signal.editor.mode.texture",
     "signal.editor.mode.vertex",
     "signal.editor.mode.rotate",
     "signal.editor.palette.material",
@@ -514,7 +512,7 @@
             "type": "scene_state.cycle",
             "key": "editor.tool.mode",
             "default": "select",
-            "values": ["select", "move", "paint", "floor", "wall", "ceiling", "sky", "player_start"]
+            "values": ["select", "move", "floor", "wall", "ceiling", "sky"]
           }
         ]
       },
@@ -559,13 +557,6 @@
         ]
       },
       {
-        "signal": "signal.editor.tool.player_start",
-        "actions": [
-          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "player_start" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player start tool selected" }
-        ]
-      },
-      {
         "signal": "signal.editor.mode.brush",
         "actions": [
           { "type": "editor.tool.set_mode", "mode": "brush" }
@@ -605,12 +596,6 @@
         "signal": "signal.editor.mode.select",
         "actions": [
           { "type": "editor.tool.set_mode", "mode": "select" }
-        ]
-      },
-      {
-        "signal": "signal.editor.mode.texture",
-        "actions": [
-          { "type": "editor.tool.set_mode", "mode": "texture", "message": "texture mode" }
         ]
       },
       {
@@ -706,73 +691,7 @@
       {
         "signal": "signal.editor.escape",
         "actions": [
-          {
-            "type": "branch",
-            "if": { "type": "scene_state.compare", "key": "editor.palette.active", "op": "!=", "value": "", "default": "" },
-            "then": [
-              { "type": "scene_state.set", "key": "editor.palette.active", "value": "" },
-              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "palette closed" }
-            ],
-            "else": [
-              {
-                "type": "branch",
-                "if": { "type": "scene_state.compare", "key": "editor.vertex.selection.count", "op": ">", "value": 0, "default": 0 },
-                "then": [
-                  { "type": "editor.vertex.selection.clear" },
-                  { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "vertex selection cleared" }
-                ],
-                "else": [
-                  {
-                    "type": "branch",
-                    "if": { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "vertex", "default": "select" },
-	                    "then": [
-	                      { "type": "editor.tool.set_mode", "mode": "select" }
-	                    ],
-	                    "else": [
-	                      {
-	                        "type": "branch",
-	                        "if": { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "clip", "default": "select" },
-	                        "then": [
-	                          { "type": "editor.clip.escape" }
-	                        ],
-	                        "else": [
-	                          {
-	                            "type": "branch",
-	                            "if": { "type": "scene_state.compare", "key": "editor.selection.count", "op": ">", "value": 0, "default": 0 },
-	                            "then": [
-	                              { "type": "editor.selection.clear" },
-	                              { "type": "editor.command.clear_preview", "message": "selection cleared" },
-	                              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "selection cleared" }
-	                            ],
-	                            "else": [
-	                              {
-	                                "type": "branch",
-	                                "if": {
-	                                  "type": "any",
-	                                  "conditions": [
-	                                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
-	                                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "edge", "default": "select" },
-	                                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
-	                                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "rotate", "default": "select" }
-	                                  ]
-	                                },
-	                                "then": [
-	                                  { "type": "editor.tool.set_mode", "mode": "select" }
-	                                ],
-	                                "else": [
-	                                  { "type": "editor.command.clear_preview", "message": "escape" }
-	                                ]
-	                              }
-	                            ]
-	                          }
-	                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
+          { "type": "editor.escape" }
         ]
       },
       {

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -303,6 +303,12 @@
         "tool_mode": "scale",
         "message": "scale tool",
         "button": { "x": 704, "y": 45, "w": 88, "h": 28 }
+      },
+      {
+        "mode": "shear",
+        "tool_mode": "shear",
+        "message": "shear tool",
+        "button": { "x": 798, "y": 45, "w": 88, "h": 28 }
       }
     ],
     "palette": {
@@ -368,6 +374,7 @@
         "edge_handles",
         "rotate_handles",
         "scale_handles",
+        "shear_handles",
         "command_preview",
         "clip_preview",
         "markers"
@@ -534,6 +541,16 @@
             "interactive": true,
             "action": "editor.tool.scale",
             "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "scale" }
+          },
+          {
+            "id": "ui.editor_shell.tool_toolbar.shear.button",
+            "type": "button",
+            "w": 88,
+            "h": 28,
+            "text": "Shear",
+            "interactive": true,
+            "action": "editor.tool.shear",
+            "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "shear" }
           },
           {
             "id": "ui.editor_shell.tool_toolbar.entity.button",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -250,8 +250,8 @@
       "grid_key": "editor.grid.size",
       "brush_grid_key": "editor.brush.grid_size",
       "open_key": "editor.grid.menu.open",
-      "button": { "x": 835, "y": 45, "w": 110, "h": 28 },
-      "popup": { "x": 835, "y": 76, "w": 110, "h": 288 },
+      "button": { "x": 892, "y": 45, "w": 110, "h": 28 },
+      "popup": { "x": 892, "y": 76, "w": 110, "h": 288 },
       "row_height": 24,
       "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
     },
@@ -551,25 +551,6 @@
             "interactive": true,
             "action": "editor.tool.shear",
             "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "shear" }
-          },
-          {
-            "id": "ui.editor_shell.tool_toolbar.entity.button",
-            "type": "button",
-            "w": 104,
-            "h": 28,
-            "text": "Entity Tool",
-            "interactive": true,
-            "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "player_start" }
-          },
-          {
-            "id": "ui.editor_shell.tool_toolbar.texture.button",
-            "type": "button",
-            "w": 110,
-            "h": 28,
-            "text": "Texture Tool",
-            "interactive": true,
-            "action": "editor.tool.texture",
-            "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "paint" }
           },
           {
             "id": "ui.editor_shell.tool_toolbar.grid.button",
@@ -1527,7 +1508,7 @@
         "h": 26,
         "layer": 141,
         "font": "font.editor_shell.ui",
-        "text": "3D editor: WASD move, RMB drag look, MMB drag pan, wheel zoom, Q/E down/up. Modes: Space select, B brush tool, C clip, V vertex, M texture, G objects. Edge Tool exposes selected-brush edges. Esc clears selection/back to select.",
+        "text": "3D editor: WASD move, RMB drag look, MMB drag pan, wheel zoom, Q/E down/up. Modes: Space select, B brush tool, C clip, V vertex. Edge Tool exposes selected-brush edges. Esc clears selection/back to select.",
         "text_color": [
                 190,
                 205,

--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -137,6 +137,12 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_HOVER_HANDLE = 36,
         /** @brief Scale tool non-mutating transformed source preview edge. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SCALE_PREVIEW_EDGE = 37,
+        /** @brief Shear tool bounds-side handle line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HANDLE = 38,
+        /** @brief Shear tool hovered or active bounds-side handle line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HOVER_HANDLE = 39,
+        /** @brief Shear tool non-mutating transformed source preview edge. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_PREVIEW_EDGE = 40,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -171,6 +177,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES = 1u << 13,
         /** @brief Emit scale tool bounds handles. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES = 1u << 14,
+        /** @brief Emit shear tool bounds side handles. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES = 1u << 15,
         /** @brief Emit every supported editor debug primitive. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
@@ -180,7 +188,8 @@ extern "C"
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_DIAGNOSTIC_MARKERS |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_FACE | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_VERTEX_HANDLES |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_CLIP_PREVIEW | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_EDGE_HANDLES |
-            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES,
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES |
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES,
     };
 
     /** @brief One renderer-agnostic editor debug line segment. */

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -242,9 +242,9 @@ static bool console_write_action(slayer3d_game_data_runtime *runtime, yyjson_val
     return true;
 }
 
-static bool editor_selected_brushes_bounds_center(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_center)
+static bool editor_selected_brushes_bounds(const slayer3d_game_data_runtime *runtime, slayer3d_bounding_box *out_bounds)
 {
-    if (runtime == NULL || out_center == NULL || runtime->editor_selected_brush_count <= 0)
+    if (runtime == NULL || out_bounds == NULL || runtime->editor_selected_brush_count <= 0)
         return false;
 
     bool has_bounds = false;
@@ -271,6 +271,17 @@ static bool editor_selected_brushes_bounds_center(const slayer3d_game_data_runti
     if (!has_bounds)
         return false;
 
+    *out_bounds = bounds;
+    return true;
+}
+
+static bool editor_selected_brushes_bounds_center(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_center)
+{
+    if (out_center == NULL)
+        return false;
+    slayer3d_bounding_box bounds;
+    if (!editor_selected_brushes_bounds(runtime, &bounds))
+        return false;
     *out_center = slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
     return true;
 }
@@ -300,6 +311,24 @@ static bool editor_selection_scale_selected_action(slayer3d_game_data_runtime *r
 
     const slayer3d_vec3 factors = json_vec3(action, "factors", slayer3d_vec3_make(1.0f, 1.0f, 1.0f));
     return slayer3d_game_data_scale_selected_editor_brushes(runtime, anchor, factors);
+}
+
+static bool editor_selection_shear_selected_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    slayer3d_bounding_box bounds;
+    if (obj_get(action, "bounds_min") != NULL && obj_get(action, "bounds_max") != NULL)
+    {
+        bounds.min = json_vec3(action, "bounds_min", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        bounds.max = json_vec3(action, "bounds_max", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    }
+    else if (!editor_selected_brushes_bounds(runtime, &bounds))
+    {
+        return false;
+    }
+
+    const slayer3d_vec3 side_normal = json_vec3(action, "side_normal", slayer3d_vec3_make(1.0f, 0.0f, 0.0f));
+    const slayer3d_vec3 delta = json_vec3(action, "delta", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    return slayer3d_game_data_shear_selected_editor_brushes(runtime, bounds, side_normal, delta);
 }
 
 bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
@@ -551,6 +580,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 
     if (SDL_strcmp(type, "editor.selection.scale_selected") == 0)
         return editor_selection_scale_selected_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.selection.shear_selected") == 0)
+        return editor_selection_shear_selected_action(runtime, action);
 
     if (SDL_strcmp(type, "editor.selection.run") == 0)
     {

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -536,6 +536,40 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         return slayer3d_game_data_set_editor_tool_mode(runtime, json_string(action, "mode", NULL),
                                                        json_string(action, "message", NULL));
 
+    if (SDL_strcmp(type, "editor.escape") == 0)
+    {
+        if (runtime == NULL || runtime->scene_state == NULL)
+            return false;
+        if (SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.palette.active", ""), "") != 0)
+        {
+            slayer3d_properties_set_string(runtime->scene_state, "editor.palette.active", "");
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "palette closed");
+            return true;
+        }
+        if (slayer3d_properties_get_int(runtime->scene_state, "editor.vertex.selection.count", 0) > 0)
+        {
+            if (!slayer3d_game_data_clear_editor_vertex_selection(runtime))
+                return false;
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "vertex selection cleared");
+            return true;
+        }
+
+        const char *mode = slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select");
+        if (SDL_strcmp(mode, "clip") == 0)
+            return slayer3d_game_data_escape_editor_clip_tool(runtime);
+        if (SDL_strcmp(mode, "select") != 0)
+            return slayer3d_game_data_set_editor_tool_mode(runtime, "select", NULL);
+        if (slayer3d_properties_get_int(runtime->scene_state, "editor.selection.count", 0) > 0)
+        {
+            if (!slayer3d_game_data_clear_active_editor_selection(runtime))
+                return false;
+            (void)slayer3d_game_data_clear_editor_command_preview(runtime, action);
+            slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "selection cleared");
+            return true;
+        }
+        return slayer3d_game_data_clear_editor_command_preview(runtime, action);
+    }
+
     if (SDL_strcmp(type, "editor.clip.cancel") == 0)
         return slayer3d_game_data_cancel_editor_clip_tool(runtime, json_string(action, "message", NULL));
 

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -3902,6 +3902,207 @@ bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, con
     return true;
 }
 
+static bool shear_source_side_axis(slayer3d_vec3 side_normal, int *out_axis, float *out_sign)
+{
+    if (out_axis != NULL)
+        *out_axis = -1;
+    if (out_sign != NULL)
+        *out_sign = 0.0f;
+    const float ax = SDL_fabsf(side_normal.x);
+    const float ay = SDL_fabsf(side_normal.y);
+    const float az = SDL_fabsf(side_normal.z);
+    if (ax > 0.5f && ay <= 0.0001f && az <= 0.0001f)
+    {
+        if (out_axis != NULL)
+            *out_axis = 0;
+        if (out_sign != NULL)
+            *out_sign = side_normal.x < 0.0f ? -1.0f : 1.0f;
+        return true;
+    }
+    if (ay > 0.5f && ax <= 0.0001f && az <= 0.0001f)
+    {
+        if (out_axis != NULL)
+            *out_axis = 1;
+        if (out_sign != NULL)
+            *out_sign = side_normal.y < 0.0f ? -1.0f : 1.0f;
+        return true;
+    }
+    if (az > 0.5f && ax <= 0.0001f && ay <= 0.0001f)
+    {
+        if (out_axis != NULL)
+            *out_axis = 2;
+        if (out_sign != NULL)
+            *out_sign = side_normal.z < 0.0f ? -1.0f : 1.0f;
+        return true;
+    }
+    return false;
+}
+
+static bool shear_source_vertex_coord(const int coord[3], const float bounds_min[3], const float bounds_max[3],
+                                      int axis, float sign, slayer3d_vec3 delta_source, int snap_units,
+                                      int out_coord[3])
+{
+    if (coord == NULL || bounds_min == NULL || bounds_max == NULL || out_coord == NULL || axis < 0 || axis > 2)
+        return false;
+    const float axis_min = bounds_min[axis];
+    const float axis_max = bounds_max[axis];
+    const float axis_size = axis_max - axis_min;
+    if (axis_size <= 0.000001f)
+        return false;
+    const float coord_axis = (float)coord[axis];
+    float t = sign > 0.0f ? (coord_axis - axis_min) / axis_size : (axis_max - coord_axis) / axis_size;
+    if (t < 0.0f)
+        t = 0.0f;
+    if (t > 1.0f)
+        t = 1.0f;
+
+    return source_rotation_coord((float)coord[0] + delta_source.x * t, snap_units, &out_coord[0]) &&
+           source_rotation_coord((float)coord[1] + delta_source.y * t, snap_units, &out_coord[1]) &&
+           source_rotation_coord((float)coord[2] + delta_source.z * t, snap_units, &out_coord[2]);
+}
+
+bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                         slayer3d_bounding_box bounds, slayer3d_vec3 side_normal, slayer3d_vec3 delta,
+                                         char *error_buffer, int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed brush shear requires a source model");
+        return false;
+    }
+    if (SDL_isnan(bounds.min.x) || SDL_isinf(bounds.min.x) || SDL_isnan(bounds.min.y) || SDL_isinf(bounds.min.y) ||
+        SDL_isnan(bounds.min.z) || SDL_isinf(bounds.min.z) || SDL_isnan(bounds.max.x) || SDL_isinf(bounds.max.x) ||
+        SDL_isnan(bounds.max.y) || SDL_isinf(bounds.max.y) || SDL_isnan(bounds.max.z) || SDL_isinf(bounds.max.z) ||
+        SDL_isnan(side_normal.x) || SDL_isinf(side_normal.x) || SDL_isnan(side_normal.y) || SDL_isinf(side_normal.y) ||
+        SDL_isnan(side_normal.z) || SDL_isinf(side_normal.z) || SDL_isnan(delta.x) || SDL_isinf(delta.x) ||
+        SDL_isnan(delta.y) || SDL_isinf(delta.y) || SDL_isnan(delta.z) || SDL_isinf(delta.z))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush shear requires finite bounds, side, and delta");
+        return false;
+    }
+
+    int axis = -1;
+    float sign = 0.0f;
+    if (!shear_source_side_axis(side_normal, &axis, &sign))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush shear requires an axis-aligned side normal");
+        return false;
+    }
+    if ((axis == 0 && bounds.max.x - bounds.min.x <= 0.000001f) ||
+        (axis == 1 && bounds.max.y - bounds.min.y <= 0.000001f) ||
+        (axis == 2 && bounds.max.z - bounds.min.z <= 0.000001f))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush shear requires non-empty bounds");
+        return false;
+    }
+
+    if (axis == 0)
+        delta.x = 0.0f;
+    else if (axis == 1)
+        delta.y = 0.0f;
+    else
+        delta.z = 0.0f;
+    if (slayer3d_vec3_length_squared(delta) <= 0.0000001f)
+        return true;
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_name);
+    if (source_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        return false;
+    }
+
+    editor_brush_source_vertex_model model;
+    if (!editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model, error_buffer,
+                                                    error_buffer_size))
+    {
+        return false;
+    }
+
+    const float meters_per_unit =
+        world_runtime->editor_source_meters_per_unit > 0.0f ? world_runtime->editor_source_meters_per_unit : 0.001f;
+    const float bounds_min[3] = {
+        bounds.min.x / meters_per_unit,
+        bounds.min.y / meters_per_unit,
+        bounds.min.z / meters_per_unit,
+    };
+    const float bounds_max[3] = {
+        bounds.max.x / meters_per_unit,
+        bounds.max.y / meters_per_unit,
+        bounds.max.z / meters_per_unit,
+    };
+    const slayer3d_vec3 delta_source =
+        slayer3d_vec3_make(delta.x / meters_per_unit, delta.y / meters_per_unit, delta.z / meters_per_unit);
+
+    int sheared_vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    SDL_zeroa(sheared_vertices);
+    const int snap_units = source_snap_units(world_runtime);
+    for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+    {
+        if (!shear_source_vertex_coord(model.vertices[vertex].coord, bounds_min, bounds_max, axis, sign, delta_source,
+                                       snap_units, sheared_vertices[vertex]))
+        {
+            set_error(error_buffer, error_buffer_size, "source brush shear would overflow the source grid");
+            return false;
+        }
+    }
+
+    slayer3d_game_data_brush rebuilt;
+    if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_name, &sheared_vertices[0][0],
+                                                                    model.vertex_count, &rebuilt, error_buffer,
+                                                                    error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&rebuilt);
+
+    editor_brush_source_box_runtime snapshot;
+    SDL_zero(snapshot);
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    if (!copy_editor_brush_source_box_runtime(box, &snapshot))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to snapshot source brush shear");
+        return false;
+    }
+
+    char *old_prefab = box->prefab;
+    box->prefab = SDL_strdup("convex");
+    if (box->prefab == NULL)
+    {
+        box->prefab = old_prefab;
+        free_editor_brush_source_box(&snapshot);
+        set_error(error_buffer, error_buffer_size, "failed to allocate source brush shear metadata");
+        return false;
+    }
+    SDL_free(old_prefab);
+    box->vertex_count = model.vertex_count;
+    for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+    {
+        box->vertices[vertex][0] = sheared_vertices[vertex][0];
+        box->vertices[vertex][1] = sheared_vertices[vertex][1];
+        box->vertices[vertex][2] = sheared_vertices[vertex][2];
+    }
+    for (int vertex = model.vertex_count; vertex < SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY; ++vertex)
+    {
+        box->vertices[vertex][0] = 0;
+        box->vertices[vertex][1] = 0;
+        box->vertices[vertex][2] = 0;
+    }
+    source_box_update_bounds_from_vertices(box);
+
+    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
+        !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box(box);
+        *box = snapshot;
+        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+        return false;
+    }
+
+    free_editor_brush_source_box(&snapshot);
+    return true;
+}
+
 bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                int error_buffer_size)

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -122,6 +122,9 @@ bool editor_brush_world_rotate_source_box(brush_world_runtime *world_runtime, co
 bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                          int error_buffer_size);
+bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                         slayer3d_bounding_box bounds, slayer3d_vec3 side_normal, slayer3d_vec3 delta,
+                                         char *error_buffer, int error_buffer_size);
 int editor_brush_world_source_box_face_index_for_identity(const brush_world_runtime *world_runtime,
                                                           const char *brush_identity, int fallback_face_index,
                                                           const char *face_identity);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -590,6 +590,35 @@ static const char *editor_shear_side_name(slayer3d_vec3 normal)
     return "";
 }
 
+static bool editor_shear_axis_side_normal(slayer3d_vec3 normal, slayer3d_vec3 *out_normal)
+{
+    if (out_normal == NULL || slayer3d_vec3_length_squared(normal) <= 0.000001f)
+        return false;
+
+    const float ax = SDL_fabsf(normal.x);
+    const float ay = SDL_fabsf(normal.y);
+    const float az = SDL_fabsf(normal.z);
+    if (ax >= ay && ax >= az)
+        *out_normal = slayer3d_vec3_make(normal.x < 0.0f ? -1.0f : 1.0f, 0.0f, 0.0f);
+    else if (ay >= az)
+        *out_normal = slayer3d_vec3_make(0.0f, normal.y < 0.0f ? -1.0f : 1.0f, 0.0f);
+    else
+        *out_normal = slayer3d_vec3_make(0.0f, 0.0f, normal.z < 0.0f ? -1.0f : 1.0f);
+    return true;
+}
+
+static bool editor_pick_shear_side_from_hover(slayer3d_game_data_runtime *runtime,
+                                              const slayer3d_game_data_editor_selection *hover_selection,
+                                              slayer3d_vec3 *out_normal)
+{
+    if (runtime == NULL || out_normal == NULL || editor_selected_brush_index(runtime, hover_selection) < 0 ||
+        hover_selection->face_index < 0)
+    {
+        return false;
+    }
+    return editor_shear_axis_side_normal(hover_selection->normal, out_normal);
+}
+
 static bool editor_pick_shear_side_at(slayer3d_game_data_runtime *runtime, float mouse_x, float mouse_y,
                                       slayer3d_bounding_box bounds, slayer3d_vec3 *out_normal)
 {
@@ -1338,7 +1367,8 @@ static bool editor_handle_scale_drag(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
-static bool editor_update_shear_hover_state(slayer3d_game_data_runtime *runtime)
+static bool editor_update_shear_hover_state(slayer3d_game_data_runtime *runtime,
+                                            const slayer3d_game_data_editor_selection *hover_selection)
 {
     if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_shear(runtime) ||
         runtime->editor_drag_move.shear_drag)
@@ -1346,10 +1376,10 @@ static bool editor_update_shear_hover_state(slayer3d_game_data_runtime *runtime)
         return false;
     }
     slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-    bool hovered = false;
+    bool hovered = editor_pick_shear_side_from_hover(runtime, hover_selection, &normal);
     slayer3d_bounding_box bounds;
     slayer3d_input_manager *input = runtime_input(runtime);
-    if (input != NULL && editor_selected_bounds(runtime, &bounds))
+    if (!hovered && input != NULL && editor_selected_bounds(runtime, &bounds))
     {
         float mouse_x = 0.0f;
         float mouse_y = 0.0f;
@@ -1379,7 +1409,7 @@ static bool editor_handle_shear_drag(slayer3d_game_data_runtime *runtime,
     slayer3d_input_manager *input = runtime_input(runtime);
     if (input == NULL)
         return true;
-    (void)editor_update_shear_hover_state(runtime);
+    (void)editor_update_shear_hover_state(runtime, hover_selection);
 
     editor_drag_move_state *drag = &runtime->editor_drag_move;
     const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
@@ -1396,8 +1426,11 @@ static bool editor_handle_shear_drag(slayer3d_game_data_runtime *runtime,
         float mouse_y = 0.0f;
         (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
         slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
-        if (!editor_pick_shear_side_at(runtime, mouse_x, mouse_y, bounds, &normal))
+        if (!editor_pick_shear_side_from_hover(runtime, hover_selection, &normal) &&
+            !editor_pick_shear_side_at(runtime, mouse_x, mouse_y, bounds, &normal))
+        {
             return true;
+        }
 
         SDL_zero(*drag);
         drag->active = true;

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -14,6 +14,9 @@
 #include "slayer3d/camera.h"
 #include "slayer3d/math.h"
 
+static bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
+                                slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic);
+
 static bool editor_selection_button_requested(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
                                               const char *key, const char *fallback)
 {
@@ -451,6 +454,28 @@ void reset_editor_scale_tool_state(slayer3d_game_data_runtime *runtime, const ch
                                                    : (has_bounds ? "scale tool" : "select a brush before scale tool"));
 }
 
+void reset_editor_shear_tool_state(slayer3d_game_data_runtime *runtime, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    slayer3d_bounding_box bounds;
+    const bool has_bounds = editor_selected_bounds(runtime, &bounds);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.ready", has_bounds);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.dragging", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.hovered", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.live_preview", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.valid", has_bounds);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.vertical", false);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.side_normal",
+                                 slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.delta", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.axis", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_string(runtime->scene_state, "editor.shear.side", "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.shear.message",
+                                   message != NULL ? message
+                                                   : (has_bounds ? "shear tool" : "select a brush before shear tool"));
+}
+
 static slayer3d_vec3 editor_scale_bounds_point(slayer3d_bounding_box bounds, slayer3d_vec3 signs)
 {
     const slayer3d_vec3 center = slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
@@ -536,6 +561,151 @@ static slayer3d_vec3 editor_scale_anchor_for_handle(slayer3d_bounding_box bounds
     if (center_anchor)
         return slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
     return editor_scale_bounds_point(bounds, slayer3d_vec3_scale(signs, -1.0f));
+}
+
+static slayer3d_vec3 editor_shear_side_center(slayer3d_bounding_box bounds, slayer3d_vec3 normal)
+{
+    const slayer3d_vec3 center = slayer3d_vec3_scale(slayer3d_vec3_add(bounds.min, bounds.max), 0.5f);
+    if (SDL_fabsf(normal.x) > 0.5f)
+        return slayer3d_vec3_make(normal.x > 0.0f ? bounds.max.x : bounds.min.x, center.y, center.z);
+    if (SDL_fabsf(normal.y) > 0.5f)
+        return slayer3d_vec3_make(center.x, normal.y > 0.0f ? bounds.max.y : bounds.min.y, center.z);
+    return slayer3d_vec3_make(center.x, center.y, normal.z > 0.0f ? bounds.max.z : bounds.min.z);
+}
+
+static const char *editor_shear_side_name(slayer3d_vec3 normal)
+{
+    if (normal.x > 0.5f)
+        return "right";
+    if (normal.x < -0.5f)
+        return "left";
+    if (normal.y > 0.5f)
+        return "top";
+    if (normal.y < -0.5f)
+        return "bottom";
+    if (normal.z > 0.5f)
+        return "front";
+    if (normal.z < -0.5f)
+        return "back";
+    return "";
+}
+
+static bool editor_pick_shear_side_at(slayer3d_game_data_runtime *runtime, float mouse_x, float mouse_y,
+                                      slayer3d_bounding_box bounds, slayer3d_vec3 *out_normal)
+{
+    if (runtime == NULL || out_normal == NULL)
+        return false;
+    yyjson_val *editor = active_editor_tooling_root(runtime);
+    yyjson_val *selection = obj_get(editor, "selection");
+    yyjson_val *trace = obj_get(selection, "trace");
+    editor_trace_viewport_config viewport;
+    if (!editor_trace_select_viewport_at(runtime, trace, mouse_x, mouse_y, &viewport))
+        return false;
+    slayer3d_camera3d camera;
+    if (!slayer3d_game_data_get_camera(runtime, viewport.camera, &camera))
+        return false;
+
+    const slayer3d_vec3 normals[] = {
+        slayer3d_vec3_make(1.0f, 0.0f, 0.0f), slayer3d_vec3_make(-1.0f, 0.0f, 0.0f),
+        slayer3d_vec3_make(0.0f, 1.0f, 0.0f), slayer3d_vec3_make(0.0f, -1.0f, 0.0f),
+        slayer3d_vec3_make(0.0f, 0.0f, 1.0f), slayer3d_vec3_make(0.0f, 0.0f, -1.0f),
+    };
+    slayer3d_vec3 best_normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    float best_distance = FLT_MAX;
+    for (int i = 0; i < (int)SDL_arraysize(normals); ++i)
+    {
+        float screen_x = 0.0f;
+        float screen_y = 0.0f;
+        if (!editor_project_world_to_viewport(&camera, &viewport, editor_shear_side_center(bounds, normals[i]),
+                                              &screen_x, &screen_y))
+            continue;
+        const float dx = mouse_x - (viewport.x + screen_x);
+        const float dy = mouse_y - (viewport.y + screen_y);
+        const float distance = dx * dx + dy * dy;
+        if (distance < best_distance)
+        {
+            best_distance = distance;
+            best_normal = normals[i];
+        }
+    }
+    const float side_pick_radius_pixels = 28.0f;
+    if (best_distance > side_pick_radius_pixels * side_pick_radius_pixels)
+        return false;
+    *out_normal = best_normal;
+    return true;
+}
+
+static slayer3d_vec3 editor_shear_axis_for_side(slayer3d_vec3 side_normal, bool vertical, slayer3d_vec3 camera_right)
+{
+    const slayer3d_vec3 world_up = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    if (vertical && SDL_fabsf(side_normal.y) <= 0.5f)
+        return world_up;
+    if (SDL_fabsf(side_normal.y) > 0.5f)
+    {
+        slayer3d_vec3 horizontal_right = slayer3d_vec3_make(camera_right.x, 0.0f, camera_right.z);
+        if (slayer3d_vec3_length_squared(horizontal_right) > 0.000001f)
+            return slayer3d_vec3_normalize(horizontal_right);
+        return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    }
+    slayer3d_vec3 sideways = slayer3d_vec3_cross(side_normal, world_up);
+    if (slayer3d_vec3_length_squared(sideways) <= 0.000001f)
+        sideways = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    return slayer3d_vec3_normalize(sideways);
+}
+
+static slayer3d_vec3 editor_shear_drag_delta(const slayer3d_game_data_runtime *runtime,
+                                             const editor_drag_move_state *drag, float mouse_x, float mouse_y)
+{
+    if (drag == NULL)
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    slayer3d_vec3 camera_forward;
+    slayer3d_vec3 camera_right;
+    slayer3d_vec3 camera_up;
+    bool orthographic = false;
+    if (!editor_camera_basis(runtime, &camera_forward, &camera_right, &camera_up, &orthographic))
+    {
+        camera_right = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+        camera_up = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    }
+    (void)camera_forward;
+    (void)orthographic;
+    const slayer3d_vec3 axis = editor_shear_axis_for_side(drag->shear_side_normal, drag->shear_vertical, camera_right);
+    const float projected_x = slayer3d_vec3_dot(axis, camera_right);
+    const float projected_y = -slayer3d_vec3_dot(axis, camera_up);
+    const float projected_length_squared = projected_x * projected_x + projected_y * projected_y;
+    if (projected_length_squared <= 0.000001f)
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const float inverse_projected_length = 1.0f / SDL_sqrtf(projected_length_squared);
+    const float mouse_dx = mouse_x - drag->start_mouse_x;
+    const float mouse_dy = mouse_y - drag->start_mouse_y;
+    const float pixel_distance = (mouse_dx * projected_x + mouse_dy * projected_y) * inverse_projected_length;
+    const float units_per_pixel = SDL_max(drag->grid_size, 0.001f) / 48.0f;
+    const float distance = editor_snap_delta(pixel_distance * units_per_pixel, drag->grid_size);
+    return slayer3d_vec3_scale(axis, distance);
+}
+
+static void publish_editor_shear_drag_state(slayer3d_game_data_runtime *runtime, const editor_drag_move_state *drag,
+                                            bool valid, const char *message)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return;
+    const bool active = drag != NULL && drag->active && drag->shear_drag;
+    const slayer3d_vec3 side_normal = drag != NULL ? drag->shear_side_normal : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    const slayer3d_vec3 delta = active ? drag->shear_delta : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.ready", runtime->editor_selected_brush_count > 0);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.dragging", active);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.hovered", drag != NULL && drag->shear_hovered);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.live_preview",
+                                 active && slayer3d_vec3_length_squared(delta) > 0.0000001f);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.valid", valid);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.vertical", active && drag->shear_vertical);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.side_normal", side_normal);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.delta", delta);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.axis",
+                                 active ? drag->shear_axis : slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    slayer3d_properties_set_string(runtime->scene_state, "editor.shear.side",
+                                   drag != NULL && drag->shear_hovered ? editor_shear_side_name(side_normal) : "");
+    slayer3d_properties_set_string(runtime->scene_state, "editor.shear.message", message != NULL ? message : "");
 }
 
 static slayer3d_vec3 editor_scale_drag_factors(const editor_drag_move_state *drag, float mouse_x, float mouse_y)
@@ -1168,6 +1338,152 @@ static bool editor_handle_scale_drag(slayer3d_game_data_runtime *runtime,
     return true;
 }
 
+static bool editor_update_shear_hover_state(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_shear(runtime) ||
+        runtime->editor_drag_move.shear_drag)
+    {
+        return false;
+    }
+    slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    bool hovered = false;
+    slayer3d_bounding_box bounds;
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input != NULL && editor_selected_bounds(runtime, &bounds))
+    {
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        if (slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y))
+            hovered = editor_pick_shear_side_at(runtime, mouse_x, mouse_y, bounds, &normal);
+    }
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.hovered", hovered);
+    slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.side_normal", normal);
+    slayer3d_properties_set_string(runtime->scene_state, "editor.shear.side",
+                                   hovered ? editor_shear_side_name(normal) : "");
+    return hovered;
+}
+
+static bool editor_handle_shear_drag(slayer3d_game_data_runtime *runtime,
+                                     const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
+{
+    (void)hover_selection;
+    if (out_consumed != NULL)
+        *out_consumed = false;
+    if (runtime == NULL || runtime->scene_state == NULL || !editor_mode_is_shear(runtime))
+    {
+        if (runtime != NULL && runtime->editor_drag_move.active && runtime->editor_drag_move.shear_drag)
+            clear_editor_drag_move(runtime);
+        return true;
+    }
+
+    slayer3d_input_manager *input = runtime_input(runtime);
+    if (input == NULL)
+        return true;
+    (void)editor_update_shear_hover_state(runtime);
+
+    editor_drag_move_state *drag = &runtime->editor_drag_move;
+    const bool left_pressed = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
+    const bool left_released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
+
+    if (!drag->active && left_pressed && editor_selected_brushes_active_for_scene(runtime) &&
+        runtime->editor_selected_brush_count > 0)
+    {
+        slayer3d_bounding_box bounds;
+        if (!editor_selected_bounds(runtime, &bounds))
+            return true;
+        float mouse_x = 0.0f;
+        float mouse_y = 0.0f;
+        (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
+        slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        if (!editor_pick_shear_side_at(runtime, mouse_x, mouse_y, bounds, &normal))
+            return true;
+
+        SDL_zero(*drag);
+        drag->active = true;
+        drag->shear_drag = true;
+        drag->scene = slayer3d_game_data_active_scene(runtime);
+        drag->grid_size = slayer3d_properties_get_float(runtime->scene_state, "editor.grid.size", 1.0f);
+        drag->shear_start_bounds = bounds;
+        drag->shear_side_normal = normal;
+        drag->shear_vertical = (SDL_GetModState() & SDL_KMOD_ALT) != 0 && SDL_fabsf(normal.y) <= 0.5f;
+        slayer3d_vec3 camera_forward;
+        slayer3d_vec3 camera_right;
+        slayer3d_vec3 camera_up;
+        bool orthographic = false;
+        if (!editor_camera_basis(runtime, &camera_forward, &camera_right, &camera_up, &orthographic))
+            camera_right = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+        (void)camera_forward;
+        (void)camera_up;
+        (void)orthographic;
+        drag->shear_axis = editor_shear_axis_for_side(normal, drag->shear_vertical, camera_right);
+        drag->shear_delta = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        drag->shear_hovered = true;
+        drag->shear_preview_valid = true;
+        drag->start_mouse_x = mouse_x;
+        drag->start_mouse_y = mouse_y;
+        publish_editor_shear_drag_state(runtime, drag, true, "shear drag");
+        if (out_consumed != NULL)
+            *out_consumed = true;
+        return true;
+    }
+
+    if (!drag->active || !drag->shear_drag)
+        return true;
+    if (out_consumed != NULL)
+        *out_consumed = true;
+
+    drag->shear_vertical = (SDL_GetModState() & SDL_KMOD_ALT) != 0 && SDL_fabsf(drag->shear_side_normal.y) <= 0.5f;
+    slayer3d_vec3 camera_forward;
+    slayer3d_vec3 camera_right;
+    slayer3d_vec3 camera_up;
+    bool orthographic = false;
+    if (!editor_camera_basis(runtime, &camera_forward, &camera_right, &camera_up, &orthographic))
+        camera_right = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    (void)camera_forward;
+    (void)camera_up;
+    (void)orthographic;
+    drag->shear_axis = editor_shear_axis_for_side(drag->shear_side_normal, drag->shear_vertical, camera_right);
+
+    float mouse_x = drag->start_mouse_x;
+    float mouse_y = drag->start_mouse_y;
+    (void)slayer3d_input_get_mouse_position(input, &mouse_x, &mouse_y);
+    drag->shear_delta = editor_shear_drag_delta(runtime, drag, mouse_x, mouse_y);
+    drag->moved = slayer3d_vec3_length_squared(drag->shear_delta) > 0.0000001f;
+    publish_editor_shear_drag_state(runtime, drag, true, drag->moved ? "shear preview" : "shear drag");
+
+    if (left_released || !left_down)
+    {
+        const slayer3d_bounding_box bounds = drag->shear_start_bounds;
+        const slayer3d_vec3 side_normal = drag->shear_side_normal;
+        const slayer3d_vec3 delta = drag->shear_delta;
+        const bool moved = drag->moved;
+        if (moved)
+        {
+            if (slayer3d_game_data_shear_selected_editor_brushes(runtime, bounds, side_normal, delta))
+            {
+                update_active_editor_selection_from_selected_brushes(runtime);
+                slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.valid", true);
+                slayer3d_properties_set_string(runtime->scene_state, "editor.shear.message", "sheared selection");
+                editor_publish_console_message(runtime, "sheared selection");
+            }
+            else
+            {
+                slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.valid", false);
+                slayer3d_properties_set_string(runtime->scene_state, "editor.shear.message", "shear rejected");
+                slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "shear rejected");
+            }
+        }
+        clear_editor_drag_move(runtime);
+        slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.dragging", false);
+        slayer3d_properties_set_bool(runtime->scene_state, "editor.shear.live_preview", false);
+        slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.side_normal", side_normal);
+        slayer3d_properties_set_vec3(runtime->scene_state, "editor.shear.delta", delta);
+    }
+
+    return true;
+}
+
 static bool editor_handle_drag_move(slayer3d_game_data_runtime *runtime,
                                     const slayer3d_game_data_editor_selection *hover_selection, bool *out_consumed)
 {
@@ -1293,7 +1609,8 @@ static bool editor_handle_grid_nudge(slayer3d_game_data_runtime *runtime, bool *
     const bool edge_mode = editor_mode_is_edge(runtime);
     const bool source_handle_mode = vertex_mode || edge_mode;
     const bool brush_transform_mode = editor_mode_is_select(runtime) || editor_mode_is_brush(runtime) ||
-                                      editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime);
+                                      editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime) ||
+                                      editor_mode_is_shear(runtime);
     if (!brush_transform_mode && !source_handle_mode)
         return true;
 
@@ -1789,6 +2106,15 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
         publish_editor_selected_brush_count(runtime);
         return true;
     }
+    bool shear_drag_consumed = false;
+    if (!editor_handle_shear_drag(runtime, &hover_selection, &shear_drag_consumed))
+        return false;
+    if (shear_drag_consumed)
+    {
+        publish_editor_selection(runtime, outputs, &runtime->editor_active_selection);
+        publish_editor_selected_brush_count(runtime);
+        return true;
+    }
     bool face_drag_consumed = false;
     if (!editor_handle_face_drag(runtime, &hover_selection, &face_drag_consumed))
         return false;
@@ -1872,7 +2198,8 @@ bool slayer3d_game_data_update_active_editor_tooling(slayer3d_game_data_runtime 
     }
 
     if ((editor_mode_is_brush(runtime) || editor_mode_is_face(runtime) || editor_mode_is_edge(runtime) ||
-         editor_mode_is_vertex(runtime) || editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime)) &&
+         editor_mode_is_vertex(runtime) || editor_mode_is_rotate(runtime) || editor_mode_is_scale(runtime) ||
+         editor_mode_is_shear(runtime)) &&
         hover_selection.hit)
     {
         runtime->editor_active_selection = hover_selection;

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1740,6 +1740,7 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
            (SDL_strcmp(entry->command, "rotate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "scale") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           (SDL_strcmp(entry->command, "shear") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "clip") == 0 && SDL_strcmp(entry->target, "selection") == 0) ||
            ((SDL_strcmp(entry->command, "create") == 0 || SDL_strcmp(entry->command, "duplicate") == 0) &&
@@ -1929,7 +1930,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
-    if (SDL_strcmp(entry->command, "scale") == 0)
+    if (SDL_strcmp(entry->command, "scale") == 0 || SDL_strcmp(entry->command, "shear") == 0)
     {
         editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
         editor_selection_identity_snapshot active_snapshot;
@@ -3021,7 +3022,6 @@ bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime
     {
         return false;
     }
-
     const char *active_scene = slayer3d_game_data_active_scene(runtime);
     if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
         return false;
@@ -3085,6 +3085,117 @@ bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime
         char message[128];
         SDL_snprintf(message, sizeof(message),
                      applied_count == 1 ? "scaled 1 selected brush" : "scaled %d selected brushes", applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
+    if (last_entry != NULL && runtime->editor_selected_brush_count > 0)
+    {
+        runtime->editor_active_selection = runtime->editor_selected_brushes[runtime->editor_selected_brush_count - 1];
+        runtime->editor_selection_scene = active_scene;
+    }
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
+}
+
+bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_bounding_box bounds,
+                                                      slayer3d_vec3 side_normal, slayer3d_vec3 delta)
+{
+    if (runtime == NULL || runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+        return false;
+    if (!editor_float_finite(bounds.min.x) || !editor_float_finite(bounds.min.y) ||
+        !editor_float_finite(bounds.min.z) || !editor_float_finite(bounds.max.x) ||
+        !editor_float_finite(bounds.max.y) || !editor_float_finite(bounds.max.z) ||
+        !editor_float_finite(side_normal.x) || !editor_float_finite(side_normal.y) ||
+        !editor_float_finite(side_normal.z) || !editor_float_finite(delta.x) || !editor_float_finite(delta.y) ||
+        !editor_float_finite(delta.z) || slayer3d_vec3_length_squared(side_normal) <= 0.000001f ||
+        slayer3d_vec3_length_squared(delta) <= 0.0000001f)
+    {
+        return false;
+    }
+    const float normal_abs_x = SDL_fabsf(side_normal.x);
+    const float normal_abs_y = SDL_fabsf(side_normal.y);
+    const float normal_abs_z = SDL_fabsf(side_normal.z);
+    if (normal_abs_x > 0.5f && normal_abs_y <= 0.0001f && normal_abs_z <= 0.0001f)
+        delta.x = 0.0f;
+    else if (normal_abs_y > 0.5f && normal_abs_x <= 0.0001f && normal_abs_z <= 0.0001f)
+        delta.y = 0.0f;
+    else if (normal_abs_z > 0.5f && normal_abs_x <= 0.0001f && normal_abs_y <= 0.0001f)
+        delta.z = 0.0f;
+    else
+        return false;
+    if (slayer3d_vec3_length_squared(delta) <= 0.0000001f)
+        return false;
+
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+        return false;
+
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int applied_count = 0;
+    editor_command_transaction_entry *last_entry = NULL;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+        if (!transaction_editor_selection_is_selectable_brush(selection))
+            goto fail;
+
+        editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+        if (entry == NULL)
+            goto fail;
+        if (!editor_prepare_transaction_common(entry, active_scene, "shear", "element", selection->world_name,
+                                               selection->element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+                                            &entry->element_stable_id))
+        {
+            goto fail;
+        }
+        entry->has_bounds = selection->has_bounds;
+        entry->bounds = selection->bounds;
+        SDL_snprintf(entry->message, sizeof(entry->message), "sheared %s", selection->element_name);
+
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection->world_name);
+        if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+            goto fail;
+        const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                         ? entry->element_stable_id
+                                         : entry->element_name;
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity, &entry->source_box_snapshot,
+                                                            &entry->brush_index, NULL, 0))
+        {
+            goto fail;
+        }
+        entry->has_source_box_snapshot = true;
+
+        if (!editor_brush_world_shear_source_box(world_runtime, brush_identity, bounds, side_normal, delta, NULL, 0))
+            goto fail;
+        editor_brush_world_mark_dirty(world_runtime);
+
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity,
+                                                            &entry->source_box_after_snapshot, NULL, NULL, 0))
+        {
+            (void)apply_editor_source_box_snapshot(runtime, entry, &entry->source_box_snapshot);
+            goto fail;
+        }
+        entry->has_source_box_after_snapshot = true;
+
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
+        last_entry = entry;
+        applied_count++;
+    }
+
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "sheared 1 selected brush" : "sheared %d selected brushes", applied_count);
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
     if (last_entry != NULL && runtime->editor_selected_brush_count > 0)

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -128,6 +128,8 @@ static unsigned int editor_debug_flag_from_string(const char *value)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES;
     if (SDL_strcmp(value != NULL ? value : "", "scale_handles") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES;
+    if (SDL_strcmp(value != NULL ? value : "", "shear_handles") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES;
     if (SDL_strcmp(value != NULL ? value : "", "clip_preview") == 0)
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_CLIP_PREVIEW;
     return 0u;
@@ -1966,6 +1968,190 @@ static bool emit_editor_debug_scale_tool(const slayer3d_game_data_runtime *runti
     return true;
 }
 
+static slayer3d_vec3 editor_debug_shear_point(slayer3d_vec3 point, slayer3d_bounding_box bounds,
+                                              slayer3d_vec3 side_normal, slayer3d_vec3 delta)
+{
+    if (SDL_fabsf(side_normal.x) > 0.5f)
+    {
+        const float size = bounds.max.x - bounds.min.x;
+        if (size <= 0.000001f)
+            return point;
+        float t = side_normal.x > 0.0f ? (point.x - bounds.min.x) / size : (bounds.max.x - point.x) / size;
+        t = SDL_clamp(t, 0.0f, 1.0f);
+        return slayer3d_vec3_add(point, slayer3d_vec3_scale(delta, t));
+    }
+    if (SDL_fabsf(side_normal.y) > 0.5f)
+    {
+        const float size = bounds.max.y - bounds.min.y;
+        if (size <= 0.000001f)
+            return point;
+        float t = side_normal.y > 0.0f ? (point.y - bounds.min.y) / size : (bounds.max.y - point.y) / size;
+        t = SDL_clamp(t, 0.0f, 1.0f);
+        return slayer3d_vec3_add(point, slayer3d_vec3_scale(delta, t));
+    }
+    const float size = bounds.max.z - bounds.min.z;
+    if (size <= 0.000001f)
+        return point;
+    float t = side_normal.z > 0.0f ? (point.z - bounds.min.z) / size : (bounds.max.z - point.z) / size;
+    t = SDL_clamp(t, 0.0f, 1.0f);
+    return slayer3d_vec3_add(point, slayer3d_vec3_scale(delta, t));
+}
+
+static bool editor_debug_shear_normals_match(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return SDL_fabsf(a.x - b.x) <= 0.001f && SDL_fabsf(a.y - b.y) <= 0.001f && SDL_fabsf(a.z - b.z) <= 0.001f;
+}
+
+static void editor_debug_shear_side_corners(slayer3d_bounding_box bounds, slayer3d_vec3 normal,
+                                            slayer3d_vec3 out_points[4])
+{
+    if (out_points == NULL)
+        return;
+    if (SDL_fabsf(normal.x) > 0.5f)
+    {
+        const float x = normal.x > 0.0f ? bounds.max.x : bounds.min.x;
+        out_points[0] = slayer3d_vec3_make(x, bounds.min.y, bounds.min.z);
+        out_points[1] = slayer3d_vec3_make(x, bounds.max.y, bounds.min.z);
+        out_points[2] = slayer3d_vec3_make(x, bounds.max.y, bounds.max.z);
+        out_points[3] = slayer3d_vec3_make(x, bounds.min.y, bounds.max.z);
+        return;
+    }
+    if (SDL_fabsf(normal.y) > 0.5f)
+    {
+        const float y = normal.y > 0.0f ? bounds.max.y : bounds.min.y;
+        out_points[0] = slayer3d_vec3_make(bounds.min.x, y, bounds.min.z);
+        out_points[1] = slayer3d_vec3_make(bounds.max.x, y, bounds.min.z);
+        out_points[2] = slayer3d_vec3_make(bounds.max.x, y, bounds.max.z);
+        out_points[3] = slayer3d_vec3_make(bounds.min.x, y, bounds.max.z);
+        return;
+    }
+    const float z = normal.z > 0.0f ? bounds.max.z : bounds.min.z;
+    out_points[0] = slayer3d_vec3_make(bounds.min.x, bounds.min.y, z);
+    out_points[1] = slayer3d_vec3_make(bounds.max.x, bounds.min.y, z);
+    out_points[2] = slayer3d_vec3_make(bounds.max.x, bounds.max.y, z);
+    out_points[3] = slayer3d_vec3_make(bounds.min.x, bounds.max.y, z);
+}
+
+static bool emit_editor_debug_shear_side_outline(editor_debug_iteration_context *context, slayer3d_bounding_box bounds,
+                                                 slayer3d_vec3 normal, slayer3d_vec3 delta)
+{
+    slayer3d_vec3 corners[4];
+    editor_debug_shear_side_corners(bounds, normal, corners);
+    for (int edge = 0; edge < 4; ++edge)
+    {
+        const slayer3d_vec3 start = editor_debug_shear_point(corners[edge], bounds, normal, delta);
+        const slayer3d_vec3 end = editor_debug_shear_point(corners[(edge + 1) % 4], bounds, normal, delta);
+        if (!emit_editor_debug_line(context, start, end))
+            return false;
+    }
+    return true;
+}
+
+static bool emit_editor_debug_shear_preview_edges(editor_debug_iteration_context *context,
+                                                  const slayer3d_game_data_runtime *runtime,
+                                                  slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
+                                                  slayer3d_vec3 delta)
+{
+    if (context == NULL || runtime == NULL || slayer3d_vec3_length_squared(delta) <= 0.0000001f)
+        return true;
+
+    const slayer3d_game_data_editor_debug_primitive_type old_type = context->type;
+    const slayer3d_color old_color = context->color;
+    context->type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_PREVIEW_EDGE;
+    context->color = (slayer3d_color){255, 210, 80, 245};
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        slayer3d_game_data_editor_selection selection =
+            resolved_editor_selection(runtime, &runtime->editor_selected_brushes[i]);
+        const brush_world_runtime *world = find_brush_world_runtime(runtime, selection.world_name);
+        const int source_index = editor_debug_source_index_for_selection(world, &selection);
+        editor_brush_source_vertex_model model;
+        if (source_index < 0 || !editor_brush_source_box_build_vertex_model(world, source_index, &model, NULL, 0))
+            continue;
+
+        context->world_name = selection.world_name;
+        context->element_name = selection.element_name;
+        context->face_index = -1;
+        for (int edge = 0; edge < model.edge_count; ++edge)
+        {
+            const editor_brush_source_edge *source_edge = &model.edges[edge];
+            const int a = source_edge->vertex_indices[0];
+            const int b = source_edge->vertex_indices[1];
+            if (a < 0 || a >= model.vertex_count || b < 0 || b >= model.vertex_count)
+                continue;
+            const slayer3d_vec3 start = slayer3d_vec3_add(selection.world_position,
+                                                          editor_source_vertex_coord_meters(world, &model.vertices[a]));
+            const slayer3d_vec3 end = slayer3d_vec3_add(selection.world_position,
+                                                        editor_source_vertex_coord_meters(world, &model.vertices[b]));
+            if (!emit_editor_debug_line(context, editor_debug_shear_point(start, bounds, side_normal, delta),
+                                        editor_debug_shear_point(end, bounds, side_normal, delta)))
+            {
+                context->type = old_type;
+                context->color = old_color;
+                return false;
+            }
+        }
+    }
+    context->type = old_type;
+    context->color = old_color;
+    return true;
+}
+
+static bool emit_editor_debug_shear_tool(const slayer3d_game_data_runtime *runtime,
+                                         const slayer3d_game_data_editor_debug_desc *desc,
+                                         slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    const unsigned int flags =
+        desc != NULL && desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
+    if (runtime == NULL || runtime->scene_state == NULL || callback == NULL ||
+        (flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES) == 0u || !editor_mode_is_shear(runtime))
+    {
+        return true;
+    }
+
+    slayer3d_bounding_box bounds;
+    if (!editor_rotate_tool_selection_bounds(runtime, &bounds))
+        return true;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.face_index = -1;
+
+    const bool dragging = runtime->editor_drag_move.active && runtime->editor_drag_move.shear_drag;
+    const bool hovered = scene_state_bool(runtime, "editor.shear.hovered", false);
+    const slayer3d_vec3 active_normal =
+        dragging ? runtime->editor_drag_move.shear_side_normal
+                 : slayer3d_properties_get_vec3(runtime->scene_state, "editor.shear.side_normal",
+                                                slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    const slayer3d_vec3 normals[] = {
+        slayer3d_vec3_make(1.0f, 0.0f, 0.0f), slayer3d_vec3_make(-1.0f, 0.0f, 0.0f),
+        slayer3d_vec3_make(0.0f, 1.0f, 0.0f), slayer3d_vec3_make(0.0f, -1.0f, 0.0f),
+        slayer3d_vec3_make(0.0f, 0.0f, 1.0f), slayer3d_vec3_make(0.0f, 0.0f, -1.0f),
+    };
+    for (int i = 0; i < (int)SDL_arraysize(normals); ++i)
+    {
+        const bool highlighted = (dragging || hovered) && editor_debug_shear_normals_match(normals[i], active_normal);
+        context.type = highlighted ? SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HOVER_HANDLE
+                                   : SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HANDLE;
+        context.color = highlighted ? (slayer3d_color){255, 255, 255, 255} : (slayer3d_color){245, 180, 80, 220};
+        const slayer3d_vec3 delta =
+            dragging && highlighted ? runtime->editor_drag_move.shear_delta : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        if (!emit_editor_debug_shear_side_outline(&context, bounds, normals[i], delta))
+            return false;
+    }
+
+    if (dragging)
+    {
+        if (!emit_editor_debug_shear_preview_edges(&context, runtime, runtime->editor_drag_move.shear_start_bounds,
+                                                   runtime->editor_drag_move.shear_side_normal,
+                                                   runtime->editor_drag_move.shear_delta))
+            return false;
+    }
+    return true;
+}
+
 static bool emit_editor_debug_rotate_tool(const slayer3d_game_data_runtime *runtime,
                                           const slayer3d_game_data_editor_debug_desc *desc,
                                           slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
@@ -2085,6 +2271,11 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
     }
     if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES) != 0u &&
         !emit_editor_debug_scale_tool(runtime, desc, callback, userdata))
+    {
+        return true;
+    }
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES) != 0u &&
+        !emit_editor_debug_shear_tool(runtime, desc, callback, userdata))
     {
         return true;
     }

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -68,6 +68,7 @@ bool editor_mode_is_edge(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_vertex(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_rotate(const slayer3d_game_data_runtime *runtime);
 bool editor_mode_is_scale(const slayer3d_game_data_runtime *runtime);
+bool editor_mode_is_shear(const slayer3d_game_data_runtime *runtime);
 bool editor_selection_matches_brush(const slayer3d_game_data_editor_selection *selection, const char *world_name,
                                     const char *element_name);
 bool editor_hover_is_selected_brush(const slayer3d_game_data_runtime *runtime,
@@ -98,6 +99,7 @@ bool editor_handle_vertex_add_to_source(slayer3d_game_data_runtime *runtime,
                                         bool select_requested, bool *out_consumed);
 void reset_editor_rotate_tool_state(slayer3d_game_data_runtime *runtime, const char *message);
 void reset_editor_scale_tool_state(slayer3d_game_data_runtime *runtime, const char *message);
+void reset_editor_shear_tool_state(slayer3d_game_data_runtime *runtime, const char *message);
 bool editor_handle_vertex_selection(slayer3d_game_data_runtime *runtime,
                                     const slayer3d_game_data_editor_selection *hover_selection, bool select_requested,
                                     bool *out_consumed);
@@ -150,6 +152,8 @@ bool slayer3d_game_data_rotate_selected_editor_brushes(slayer3d_game_data_runtim
                                                        slayer3d_vec3 axis, float angle_radians);
 bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
                                                       slayer3d_vec3 factors);
+bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_bounding_box bounds,
+                                                      slayer3d_vec3 side_normal, slayer3d_vec3 delta);
 bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);
 bool slayer3d_game_data_duplicate_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 offset,
                                                           bool use_last_offset);

--- a/src/game_data_editor_selection_helpers.c
+++ b/src/game_data_editor_selection_helpers.c
@@ -212,6 +212,12 @@ bool editor_mode_is_scale(const slayer3d_game_data_runtime *runtime)
            SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "scale") == 0;
 }
 
+bool editor_mode_is_shear(const slayer3d_game_data_runtime *runtime)
+{
+    return runtime != NULL && runtime->scene_state != NULL &&
+           SDL_strcmp(slayer3d_properties_get_string(runtime->scene_state, "editor.mode", "select"), "shear") == 0;
+}
+
 bool editor_selection_matches_brush(const slayer3d_game_data_editor_selection *selection, const char *world_name,
                                     const char *element_name)
 {

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -66,6 +66,8 @@ static const char *editor_mode_for_tool_action(const char *action)
         return "rotate";
     if (SDL_strcmp(action, "editor.tool.scale") == 0)
         return "scale";
+    if (SDL_strcmp(action, "editor.tool.shear") == 0)
+        return "shear";
     if (SDL_strcmp(action, "editor.tool.texture") == 0)
         return "texture";
     return NULL;
@@ -139,6 +141,15 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
             message = selected_count > 0 ? "scale tool" : "select a brush before scale tool";
         }
     }
+    else if (SDL_strcmp(mode, "shear") == 0)
+    {
+        tool_mode = "shear";
+        if (message == NULL || message[0] == '\0')
+        {
+            const int selected_count = slayer3d_properties_get_int(runtime->scene_state, "editor.selection.count", 0);
+            message = selected_count > 0 ? "shear tool" : "select a brush before shear tool";
+        }
+    }
     else if (SDL_strcmp(mode, "texture") == 0)
     {
         tool_mode = "paint";
@@ -172,6 +183,8 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
         reset_editor_rotate_tool_state(runtime, message);
     if (SDL_strcmp(mode, "scale") == 0)
         reset_editor_scale_tool_state(runtime, message);
+    if (SDL_strcmp(mode, "shear") == 0)
+        reset_editor_shear_tool_state(runtime, message);
     return true;
 }
 

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -68,8 +68,6 @@ static const char *editor_mode_for_tool_action(const char *action)
         return "scale";
     if (SDL_strcmp(action, "editor.tool.shear") == 0)
         return "shear";
-    if (SDL_strcmp(action, "editor.tool.texture") == 0)
-        return "texture";
     return NULL;
 }
 
@@ -150,12 +148,6 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
             message = selected_count > 0 ? "shear tool" : "select a brush before shear tool";
         }
     }
-    else if (SDL_strcmp(mode, "texture") == 0)
-    {
-        tool_mode = "paint";
-        if (message == NULL || message[0] == '\0')
-            message = "texture tool";
-    }
     else
     {
         return false;
@@ -176,6 +168,7 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
     slayer3d_properties_set_string(runtime->scene_state, "editor.mode", mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.mode", tool_mode);
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.grid.menu.open", false);
     clear_editor_command_preview(runtime);
     if (entering_clip)
         return slayer3d_game_data_enter_editor_clip_tool(runtime, message);

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -102,6 +102,7 @@ typedef struct editor_drag_move_state
     bool edge_lasso;
     bool rotate_drag;
     bool scale_drag;
+    bool shear_drag;
     bool vertex_toggle_on_click;
     bool lasso_additive;
     const char *scene;
@@ -132,6 +133,13 @@ typedef struct editor_drag_move_state
     bool scale_proportional;
     bool scale_hovered;
     bool scale_preview_valid;
+    slayer3d_bounding_box shear_start_bounds;
+    slayer3d_vec3 shear_side_normal;
+    slayer3d_vec3 shear_delta;
+    slayer3d_vec3 shear_axis;
+    bool shear_vertical;
+    bool shear_hovered;
+    bool shear_preview_valid;
     int vertex_origin_count;
     editor_drag_vertex_origin vertex_toggle_origin;
     editor_drag_vertex_origin vertex_origins[SLAYER3D_EDITOR_DRAG_VERTEX_ORIGIN_CAPACITY];

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -987,6 +987,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.selection.resize_y", validate_editor_selection_resize_y_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.rotate_selected", validate_editor_selection_rotate_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.scale_selected", validate_editor_selection_scale_selected_action),
+        ACTION_RULE_EXACT_HANDLER("editor.selection.shear_selected", validate_editor_selection_shear_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.run", validate_editor_selection_run_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.preview", validate_editor_command_preview_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.clear_preview", validate_editor_command_clear_preview_action),

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -971,6 +971,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.vertex.selection.clear", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.edge.selection.clear", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.tool.set_mode", validate_editor_tool_set_mode_action),
+        ACTION_RULE_EXACT_HANDLER("editor.escape", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.clip.cancel", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.clip.escape", validate_noop_action),
         ACTION_RULE_EXACT_HANDLER("editor.clip.cycle_keep_mode", validate_noop_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -158,7 +158,8 @@ static bool editor_tool_mode_valid(const char *mode)
     return mode != NULL &&
            (SDL_strcmp(mode, "select") == 0 || SDL_strcmp(mode, "brush") == 0 || SDL_strcmp(mode, "face") == 0 ||
             SDL_strcmp(mode, "edge") == 0 || SDL_strcmp(mode, "clip") == 0 || SDL_strcmp(mode, "vertex") == 0 ||
-            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "scale") == 0 || SDL_strcmp(mode, "texture") == 0);
+            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "scale") == 0 || SDL_strcmp(mode, "shear") == 0 ||
+            SDL_strcmp(mode, "texture") == 0);
 }
 
 bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *action, const char *json_path,
@@ -170,7 +171,7 @@ bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *a
     if (!editor_tool_mode_valid(mode))
         return validation_error(ctx, json_path,
                                 "editor.tool.set_mode mode must be one of select, brush, face, edge, clip, vertex, "
-                                "rotate, scale, texture");
+                                "rotate, scale, shear, texture");
     yyjson_val *message = obj_get(action, "message");
     if (message != NULL && (!yyjson_is_str(message) || yyjson_get_str(message)[0] == '\0'))
         return validation_error(ctx, json_path, "editor.tool.set_mode message must be non-empty");
@@ -379,6 +380,47 @@ bool validate_editor_selection_scale_selected_action(validation_context *ctx, yy
         !validation_float_finite(factor_z) || factor_x <= 0.0f || factor_y <= 0.0f || factor_z <= 0.0f)
     {
         return validation_error(ctx, json_path, "editor.selection.scale_selected factors must be positive and finite");
+    }
+    return true;
+}
+
+bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                     validation_names *names, const char *type)
+{
+    (void)names;
+    (void)type;
+    yyjson_val *bounds_min = obj_get(action, "bounds_min");
+    yyjson_val *bounds_max = obj_get(action, "bounds_max");
+    if ((bounds_min == NULL) != (bounds_max == NULL))
+        return validation_error(ctx, json_path,
+                                "editor.selection.shear_selected requires both bounds_min and bounds_max");
+    if (bounds_min != NULL && !is_vec_array(bounds_min, 3))
+        return validation_error(ctx, json_path, "editor.selection.shear_selected bounds_min must be a numeric vec3");
+    if (bounds_max != NULL && !is_vec_array(bounds_max, 3))
+        return validation_error(ctx, json_path, "editor.selection.shear_selected bounds_max must be a numeric vec3");
+    yyjson_val *side_normal = obj_get(action, "side_normal");
+    if (!is_vec_array(side_normal, 3))
+        return validation_error(ctx, json_path, "editor.selection.shear_selected side_normal must be a numeric vec3");
+    const float normal_x = (float)yyjson_get_num(yyjson_arr_get(side_normal, 0));
+    const float normal_y = (float)yyjson_get_num(yyjson_arr_get(side_normal, 1));
+    const float normal_z = (float)yyjson_get_num(yyjson_arr_get(side_normal, 2));
+    if (!validation_float_finite(normal_x) || !validation_float_finite(normal_y) ||
+        !validation_float_finite(normal_z) ||
+        normal_x * normal_x + normal_y * normal_y + normal_z * normal_z <= 0.000001f)
+    {
+        return validation_error(ctx, json_path,
+                                "editor.selection.shear_selected side_normal must be non-zero and finite");
+    }
+    yyjson_val *delta = obj_get(action, "delta");
+    if (!is_vec_array(delta, 3))
+        return validation_error(ctx, json_path, "editor.selection.shear_selected delta must be a numeric vec3");
+    const float delta_x = (float)yyjson_get_num(yyjson_arr_get(delta, 0));
+    const float delta_y = (float)yyjson_get_num(yyjson_arr_get(delta, 1));
+    const float delta_z = (float)yyjson_get_num(yyjson_arr_get(delta, 2));
+    if (!validation_float_finite(delta_x) || !validation_float_finite(delta_y) || !validation_float_finite(delta_z) ||
+        delta_x * delta_x + delta_y * delta_y + delta_z * delta_z <= 0.000001f)
+    {
+        return validation_error(ctx, json_path, "editor.selection.shear_selected delta must be non-zero and finite");
     }
     return true;
 }

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -158,8 +158,7 @@ static bool editor_tool_mode_valid(const char *mode)
     return mode != NULL &&
            (SDL_strcmp(mode, "select") == 0 || SDL_strcmp(mode, "brush") == 0 || SDL_strcmp(mode, "face") == 0 ||
             SDL_strcmp(mode, "edge") == 0 || SDL_strcmp(mode, "clip") == 0 || SDL_strcmp(mode, "vertex") == 0 ||
-            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "scale") == 0 || SDL_strcmp(mode, "shear") == 0 ||
-            SDL_strcmp(mode, "texture") == 0);
+            SDL_strcmp(mode, "rotate") == 0 || SDL_strcmp(mode, "scale") == 0 || SDL_strcmp(mode, "shear") == 0);
 }
 
 bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *action, const char *json_path,
@@ -171,7 +170,7 @@ bool validate_editor_tool_set_mode_action(validation_context *ctx, yyjson_val *a
     if (!editor_tool_mode_valid(mode))
         return validation_error(ctx, json_path,
                                 "editor.tool.set_mode mode must be one of select, brush, face, edge, clip, vertex, "
-                                "rotate, scale, shear, texture");
+                                "rotate, scale, shear");
     yyjson_val *message = obj_get(action, "message");
     if (message != NULL && (!yyjson_is_str(message) || yyjson_get_str(message)[0] == '\0'))
         return validation_error(ctx, json_path, "editor.tool.set_mode message must be non-empty");

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -31,6 +31,8 @@ bool validate_editor_selection_rotate_selected_action(validation_context *ctx, y
                                                       const char *json_path, validation_names *names, const char *type);
 bool validate_editor_selection_scale_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type);
+bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                     validation_names *names, const char *type);
 bool validate_editor_selection_run_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                           validation_names *names, const char *type);
 bool validate_editor_command_preview_action(validation_context *ctx, yyjson_val *action, const char *json_path,

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -49,7 +49,7 @@ static bool editor_debug_flag_name_valid(const char *value)
                              SDL_strcmp(value, "diagnostic_markers") == 0 || SDL_strcmp(value, "selection_face") == 0 ||
                              SDL_strcmp(value, "vertex_handles") == 0 || SDL_strcmp(value, "edge_handles") == 0 ||
                              SDL_strcmp(value, "rotate_handles") == 0 || SDL_strcmp(value, "scale_handles") == 0 ||
-                             SDL_strcmp(value, "clip_preview") == 0);
+                             SDL_strcmp(value, "shear_handles") == 0 || SDL_strcmp(value, "clip_preview") == 0);
 }
 
 static bool validate_string_or_string_array_names(validation_context *ctx, yyjson_val *value, const char *path,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -28232,6 +28232,90 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxCreateCommandPreviewsAndAppl
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoShearToolDragsHoveredSelectedFace)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+
+    const int source_min[3] = {0, 0, 0};
+    const int source_max[3] = {2000, 2000, 2000};
+    editor_brush_source_prefab_result source_result{};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, source_min,
+        source_max, &source_result));
+    ASSERT_TRUE(source_result.valid);
+    ASSERT_NE(source_result.brush_name, nullptr);
+    select_editor_shell_test_brush(runtime, source_result.brush_name);
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "shear", nullptr));
+
+    slayer3d_game_data_brush_world world{};
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    const slayer3d_bounding_box before = world.brushes[0].bounds;
+
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+    SDL_Event motion{};
+    motion.type = SDL_EVENT_MOUSE_MOTION;
+    motion.motion.x = 640.0f;
+    motion.motion.y = 340.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 1);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.shear.hovered", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.hover.element", ""), source_result.brush_name);
+
+    SDL_Event down{};
+    down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    down.button.button = SDL_BUTTON_LEFT;
+    down.button.x = motion.motion.x;
+    down.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &down);
+    slayer3d_input_update(input, 2);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.shear.dragging", false));
+
+    motion.motion.x = 760.0f;
+    motion.motion.y = 340.0f;
+    motion.motion.xrel = 120.0f;
+    motion.motion.yrel = 0.0f;
+    slayer3d_input_process_event(input, &motion);
+    slayer3d_input_update(input, 3);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.shear.live_preview", false));
+
+    SDL_Event up{};
+    up.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    up.button.button = SDL_BUTTON_LEFT;
+    up.button.x = motion.motion.x;
+    up.button.y = motion.motion.y;
+    slayer3d_input_process_event(input, &up);
+    slayer3d_input_update(input, 4);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    const slayer3d_bounding_box after = world.brushes[0].bounds;
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.shear.dragging", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "sheared 1 selected brush");
+    EXPECT_TRUE(SDL_fabsf(after.min.x - before.min.x) > 0.001f || SDL_fabsf(after.max.x - before.max.x) > 0.001f ||
+                SDL_fabsf(after.min.y - before.min.y) > 0.001f || SDL_fabsf(after.max.y - before.max.y) > 0.001f ||
+                SDL_fabsf(after.min.z - before.min.z) > 0.001f || SDL_fabsf(after.max.z - before.max.z) > 0.001f);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordinates)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -220,6 +220,9 @@ extern "C"
     bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                              slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                              int error_buffer_size);
+    bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                             slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
+                                             slayer3d_vec3 delta, char *error_buffer, int error_buffer_size);
     bool editor_brush_world_resize_source_box_face(brush_world_runtime *world_runtime, const char *brush_name,
                                                    slayer3d_vec3 face_normal, float distance, char *error_buffer,
                                                    int error_buffer_size);
@@ -305,6 +308,9 @@ extern "C"
                                                            slayer3d_vec3 axis, float angle_radians);
     bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
                                                           slayer3d_vec3 factors);
+    bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime,
+                                                          slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
+                                                          slayer3d_vec3 delta);
     bool slayer3d_game_data_delete_selected_editor_brushes(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                                            const slayer3d_properties *payload);
     bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime, yyjson_val *action,
@@ -22373,6 +22379,53 @@ TEST(GameDataRuntime, EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelecti
     ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
     EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.x, 2.0f, 0.001f);
     EXPECT_NEAR(active_selection().bounds.max.x, 2.0f, 0.001f);
+
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "shear", nullptr));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "shear");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "shear");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.shear.ready", false));
+    struct ShearDebugCapture
+    {
+        int handles = 0;
+        int hovered_handles = 0;
+        int preview_edges = 0;
+    } shear_debug;
+    auto capture_shear_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
+        auto *capture = static_cast<ShearDebugCapture *>(userdata);
+        if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HANDLE)
+            capture->handles++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HOVER_HANDLE)
+            capture->hovered_handles++;
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_PREVIEW_EDGE)
+            capture->preview_edges++;
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_shear_debug, &shear_debug));
+    EXPECT_GE(shear_debug.handles, 24);
+    EXPECT_EQ(shear_debug.hovered_handles, 0);
+    EXPECT_EQ(shear_debug.preview_edges, 0);
+
+    const slayer3d_bounding_box shear_bounds = brush_bounds(brush_name.c_str());
+    ASSERT_TRUE(slayer3d_game_data_shear_selected_editor_brushes(
+        runtime, shear_bounds, slayer3d_vec3_make(1.0f, 0.0f, 0.0f), slayer3d_vec3_make(0.0f, 0.0f, 1.0f)));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.x, 2.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.z, -3.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.z, -1.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.z, -1.0f, 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "sheared 1 selected brush");
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(source_world_runtime, brush_name.c_str(), &scaled_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(scaled_source.vertex_count, 8);
+    free_editor_brush_source_box_runtime(&scaled_source);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.z, -2.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.z, -2.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.z, -1.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.z, -1.0f, 0.001f);
     ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "select", nullptr));
 
     ASSERT_TRUE(
@@ -28436,6 +28489,42 @@ TEST(GameDataRuntime, EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordi
     ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
     ASSERT_TRUE(world.brushes[0].has_bounds);
     EXPECT_NEAR(world.brushes[0].bounds.max.x, 2.0f, 0.001f) << "invalid scale must be atomic";
+
+    ASSERT_TRUE(slayer3d_game_data_load_editable_level_fragment_json(runtime, "brush.editor_shell.target", rotate_json,
+                                                                     sizeof(rotate_json) - 1u, "/tmp/source-shear.json",
+                                                                     error, sizeof(error)))
+        << error;
+    world_runtime = find_brush_world_runtime_mutable(runtime, "brush.editor_shell.target");
+    ASSERT_NE(world_runtime, nullptr);
+    const slayer3d_bounding_box shear_source_bounds = {slayer3d_vec3_make(0.0f, 0.0f, 0.0f),
+                                                       slayer3d_vec3_make(4.0f, 1.0f, 8.0f)};
+    SDL_zeroa(error);
+    ASSERT_TRUE(editor_brush_world_shear_source_box(world_runtime, "source.box.rotate", shear_source_bounds,
+                                                    slayer3d_vec3_make(1.0f, 0.0f, 0.0f),
+                                                    slayer3d_vec3_make(0.0f, 0.0f, 1.0f), error, sizeof(error)))
+        << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_EQ(world.brush_count, 1);
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.min.x, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.x, 4.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.min.z, 0.0f, 0.001f);
+    EXPECT_NEAR(world.brushes[0].bounds.max.z, 9.0f, 0.001f);
+    editor_brush_source_box_runtime sheared_source{};
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(world_runtime, "source.box.rotate", &sheared_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(sheared_source.vertex_count, 8);
+    free_editor_brush_source_box_runtime(&sheared_source);
+
+    SDL_zeroa(error);
+    EXPECT_FALSE(editor_brush_world_shear_source_box(world_runtime, "source.box.rotate", shear_source_bounds,
+                                                     slayer3d_vec3_make(1.0f, 1.0f, 0.0f),
+                                                     slayer3d_vec3_make(0.0f, 0.0f, 1.0f), error, sizeof(error)));
+    EXPECT_NE(std::string(error).find("axis-aligned side normal"), std::string::npos) << error;
+    ASSERT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+    ASSERT_TRUE(world.brushes[0].has_bounds);
+    EXPECT_NEAR(world.brushes[0].bounds.max.z, 9.0f, 0.001f) << "invalid shear must be atomic";
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16866,7 +16866,8 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.transaction.redo_count", -1), 0);
     EXPECT_NEAR(target_cube_min_y(), 0.35f, 0.001f);
 
-    slayer3d_signal_emit(bus, tool_cycle_signal, nullptr);
+    slayer3d_signal_emit(bus, slayer3d_game_data_find_signal(runtime, "signal.editor.palette.material"), nullptr);
+    slayer3d_properties_set_string(slayer3d_game_data_mutable_scene_state(runtime), "editor.palette.active", "");
     ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "paint");
 
@@ -19727,7 +19728,6 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     const int mode_edge_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.edge");
     const int mode_face_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.face");
     const int mode_select_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.select");
-    const int mode_texture_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.texture");
     const int mode_vertex_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.mode.vertex");
     const int commit_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.command.commit");
     const int clip_cycle_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.clip.cycle_keep_mode");
@@ -19755,8 +19755,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_GE(mode_edge_signal, 0);
     ASSERT_GE(mode_face_signal, 0);
     ASSERT_GE(mode_select_signal, 0);
-    ASSERT_GE(mode_texture_signal, 0);
     ASSERT_GE(mode_vertex_signal, 0);
+    EXPECT_LT(slayer3d_game_data_find_signal(runtime, "signal.editor.mode.texture"), 0);
+    EXPECT_LT(slayer3d_game_data_find_signal(runtime, "signal.editor.tool.player_start"), 0);
     ASSERT_GE(commit_signal, 0);
     ASSERT_GE(clip_cycle_signal, 0);
     ASSERT_GE(undo_signal, 0);
@@ -20097,18 +20098,33 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_signal_emit(bus, escape_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_TRUE(visible_ui_rect("ui.editor_shell.tool_toolbar.select.selected"));
-    slayer3d_signal_emit(bus, mode_texture_signal, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "texture");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "paint");
     EXPECT_TRUE(press_key(SDL_SCANCODE_SPACE, 113));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""), "select mode");
+    EXPECT_FALSE(visible_ui_rect("ui.editor_shell.tool_toolbar.entity.button"));
+    EXPECT_FALSE(visible_ui_rect("ui.editor_shell.tool_toolbar.texture.button"));
 
     seed_editor_shell_test_cube(runtime);
     select_editor_shell_test_cube(runtime);
     EXPECT_EQ(world().brush_count, 1);
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "scale", nullptr));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "scale");
+    slayer3d_signal_emit(bus, escape_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "scale", nullptr));
+    click_editor(840.0f, 60.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 115);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "shear");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "shear");
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    slayer3d_signal_emit(bus, escape_signal, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
+    move_editor_mouse(660.0f, 360.0f, 116);
     slayer3d_signal_emit(bus, mode_clip_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "clip");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.clip.selected_count", 0), 1);
@@ -20161,7 +20177,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
     std::vector<std::string> grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 1"));
-    click_editor(890.0f, 54.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 4);
+    click_editor(900.0f, 54.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
     grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 16"));
@@ -20219,7 +20235,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_grid_dropdown_rects, &grid_rects));
     EXPECT_TRUE(grid_rects.hovered_option);
     EXPECT_EQ(grid_rects.hovered_option_rect.color.a, 248);
-    click_editor(890.0f, 208.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
+    click_editor(900.0f, 208.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", true));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 4.0f, 0.001f);
@@ -29185,8 +29201,8 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
         bool buttons[9]{};
         bool labels[9]{};
         bool tool_background = false;
-        bool tool_buttons[8]{};
-        bool tool_labels[8]{};
+        bool tool_buttons[9]{};
+        bool tool_labels[9]{};
         bool grid_widget = false;
         bool grid_label = false;
         bool inspector_panel = false;
@@ -29308,18 +29324,20 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
                 index = 0;
             else if (key == "brush")
                 index = 1;
-            else if (key == "clip")
+            else if (key == "edge")
                 index = 2;
-            else if (key == "face")
+            else if (key == "clip")
                 index = 3;
-            else if (key == "vertex")
+            else if (key == "face")
                 index = 4;
-            else if (key == "rotate")
+            else if (key == "vertex")
                 index = 5;
-            else if (key == "entity")
+            else if (key == "rotate")
                 index = 6;
-            else if (key == "texture")
+            else if (key == "scale")
                 index = 7;
+            else if (key == "shear")
+                index = 8;
             if (index >= 0)
                 capture->tool_buttons[index] = true;
         }
@@ -29393,18 +29411,20 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
                 index = 0;
             else if (key == "brush")
                 index = 1;
-            else if (key == "clip")
+            else if (key == "edge")
                 index = 2;
-            else if (key == "face")
+            else if (key == "clip")
                 index = 3;
-            else if (key == "vertex")
+            else if (key == "face")
                 index = 4;
-            else if (key == "rotate")
+            else if (key == "vertex")
                 index = 5;
-            else if (key == "entity")
+            else if (key == "rotate")
                 index = 6;
-            else if (key == "texture")
+            else if (key == "scale")
                 index = 7;
+            else if (key == "shear")
+                index = 8;
             if (index >= 0)
                 capture->tool_labels[index] = true;
         }
@@ -29420,7 +29440,7 @@ TEST(GameDataRuntime, EditorShellDojoCameraNavigation)
         EXPECT_TRUE(toolbar_capture.labels[i]) << i;
     }
     EXPECT_TRUE(toolbar_capture.tool_background);
-    for (int i = 0; i < 8; ++i)
+    for (int i = 0; i < 9; ++i)
     {
         EXPECT_TRUE(toolbar_capture.tool_buttons[i]) << i;
         EXPECT_TRUE(toolbar_capture.tool_labels[i]) << i;


### PR DESCRIPTION
## Summary
- adds a source-backed editor shear operation with source vertex persistence, validation, undo/redo, and selection refresh
- adds shear tool mode handling with side handles, hover/drag state, grid-snapped live preview, and Alt vertical shearing for side faces
- wires shear UI/debug flags into the editor shell and validates the new exact action

Closes #447

## Tests
- cmake --build build/debug --target slayer3d_game_data_test slayer3d_editor -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelection:GameDataRuntime.EditableLevelFragmentSourceBoxMutationsRejectOffSnapCoordinates'
- ./build/debug/tests/slayer3d_game_data_test
- ctest --test-dir build/debug --output-on-failure (1384 passed, 1 skipped: SDLVideoFixture.OpenGLBackendClearAndPresentSucceedWhenAvailable)