### PR TITLE
Render GL lines as solid screen-space quads

### DIFF
--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -75,7 +75,7 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_HIT_MARKER = 5,
         /** @brief Non-mutating editor command preview bounds edge. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_COMMAND_PREVIEW_BOUNDS_EDGE = 6,
-        /** @brief Authored editor work-plane grid line. */
+        /** @brief Editor grid line clipped to a visible brush surface. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID = 7,
         /** @brief Editor-authored player-start marker line. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_PLAYER_START_EDGE = 8,
@@ -143,6 +143,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_HOVER_HANDLE = 39,
         /** @brief Shear tool non-mutating transformed source preview edge. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_PREVIEW_EDGE = 40,
+        /** @brief Dedicated editor origin axis line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_ORIGIN_AXIS = 41,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -159,7 +161,7 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_HIT_MARKER = 1u << 4,
         /** @brief Emit active non-mutating editor command preview bounds. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_COMMAND_PREVIEW = 1u << 5,
-        /** @brief Emit authored editor work-plane grid lines. */
+        /** @brief Emit editor brush-surface grid lines and origin axes. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID = 1u << 6,
         /** @brief Emit editor-authored player-start marker icons. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_PLAYER_STARTS = 1u << 7,
@@ -236,7 +238,7 @@ extern "C"
         slayer3d_color hit_marker_color;
         /** @brief Color for command preview bounds, or alpha 0 for default. */
         slayer3d_color command_preview_color;
-        /** @brief Color for work-plane grid lines, or alpha 0 for default. */
+        /** @brief Color for brush-surface grid lines, or alpha 0 for default. */
         slayer3d_color work_plane_grid_color;
         /** @brief Color for editor player-start marker lines, or alpha 0 for default. */
         slayer3d_color player_start_color;

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -22,6 +22,13 @@ typedef struct editor_debug_iteration_context
     bool stopped;
 } editor_debug_iteration_context;
 
+typedef struct editor_debug_surface_grid_point
+{
+    float u;
+    float v;
+    float angle;
+} editor_debug_surface_grid_point;
+
 static bool emit_editor_selected_brush_bounds(const slayer3d_game_data_runtime *runtime,
                                               const slayer3d_game_data_editor_debug_desc *desc,
                                               slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata);
@@ -1299,18 +1306,14 @@ static bool emit_editor_overlapping_source_brush_bounds(const slayer3d_game_data
     return true;
 }
 
-static bool editor_selection_face_corners(const slayer3d_game_data_editor_selection *selection,
-                                          slayer3d_vec3 out_corners[4])
+static bool editor_bounds_face_corners(slayer3d_bounding_box bounds, int face_index, slayer3d_vec3 out_corners[4])
 {
-    if (selection == NULL || out_corners == NULL || !selection->hit || !selection->has_bounds ||
-        selection->type != SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD || selection->face_index < 0)
-    {
+    if (out_corners == NULL || face_index < 0)
         return false;
-    }
 
-    const slayer3d_vec3 min = selection->bounds.min;
-    const slayer3d_vec3 max = selection->bounds.max;
-    switch (selection->face_index)
+    const slayer3d_vec3 min = bounds.min;
+    const slayer3d_vec3 max = bounds.max;
+    switch (face_index)
     {
     case 0:
         out_corners[0] = slayer3d_vec3_make(max.x, min.y, min.z);
@@ -1351,6 +1354,17 @@ static bool editor_selection_face_corners(const slayer3d_game_data_editor_select
     default:
         return false;
     }
+}
+
+static bool editor_selection_face_corners(const slayer3d_game_data_editor_selection *selection,
+                                          slayer3d_vec3 out_corners[4])
+{
+    if (selection == NULL || out_corners == NULL || !selection->hit || !selection->has_bounds ||
+        selection->type != SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD || selection->face_index < 0)
+    {
+        return false;
+    }
+    return editor_bounds_face_corners(selection->bounds, selection->face_index, out_corners);
 }
 
 static bool emit_editor_debug_selection_face(const slayer3d_game_data_editor_debug_desc *desc,
@@ -1523,8 +1537,17 @@ static bool emit_editor_debug_overlay_markers(const slayer3d_game_data_runtime *
     return true;
 }
 
-static bool emit_editor_debug_work_plane_grid(const slayer3d_game_data_editor_debug_desc *desc,
-                                              slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+static slayer3d_vec3 editor_debug_axis_vector(int axis)
+{
+    if (axis == 0)
+        return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    if (axis == 2)
+        return slayer3d_vec3_make(0.0f, 0.0f, 1.0f);
+    return slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+}
+
+static bool emit_editor_debug_origin_axes(const slayer3d_game_data_editor_debug_desc *desc,
+                                          slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
 {
     if (desc == NULL || callback == NULL || !desc->has_work_plane_grid ||
         slayer3d_vec3_length_squared(desc->work_plane_normal) <= 0.000001f)
@@ -1532,46 +1555,441 @@ static bool emit_editor_debug_work_plane_grid(const slayer3d_game_data_editor_de
         return true;
     }
 
-    const slayer3d_vec3 normal = slayer3d_vec3_normalize(desc->work_plane_normal);
-    slayer3d_vec3 reference =
-        SDL_fabsf(normal.y) < 0.95f ? slayer3d_vec3_make(0.0f, 1.0f, 0.0f) : slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
-    slayer3d_vec3 tangent = slayer3d_vec3_cross(reference, normal);
-    if (slayer3d_vec3_length_squared(tangent) <= 0.000001f)
-        tangent = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
-    tangent = slayer3d_vec3_normalize(tangent);
-    const slayer3d_vec3 bitangent = slayer3d_vec3_normalize(slayer3d_vec3_cross(normal, tangent));
-    const slayer3d_vec3 center = slayer3d_vec3_scale(normal, desc->work_plane_distance);
     const float half_size = desc->work_plane_grid_size > 0.0f ? desc->work_plane_grid_size : 16.0f;
-    const float spacing = desc->work_plane_grid_spacing > 0.0f ? desc->work_plane_grid_spacing : 1.0f;
-    const int line_count = SDL_min((int)SDL_floorf(half_size / spacing), 512);
+    const slayer3d_color colors[3] = {
+        {230, 70, 50, 230},
+        {70, 220, 100, 230},
+        {80, 140, 255, 230},
+    };
+    const char *names[3] = {"x", "y", "z"};
 
     editor_debug_iteration_context context;
     SDL_zero(context);
     context.callback = callback;
     context.userdata = userdata;
-    context.color = editor_debug_color_or_default(desc->work_plane_grid_color, (slayer3d_color){90, 160, 190, 120});
-    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID;
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_ORIGIN_AXIS;
+    context.world_name = "editor_origin";
     context.face_index = -1;
 
-    for (int i = -line_count; i <= line_count; ++i)
+    for (int axis = 0; axis < 3; ++axis)
     {
-        const float offset = (float)i * spacing;
-        const slayer3d_vec3 tangent_offset = slayer3d_vec3_scale(tangent, offset);
-        const slayer3d_vec3 bitangent_offset = slayer3d_vec3_scale(bitangent, offset);
-        if (!emit_editor_debug_line(&context,
-                                    slayer3d_vec3_add(slayer3d_vec3_add(center, tangent_offset),
-                                                      slayer3d_vec3_scale(bitangent, -half_size)),
-                                    slayer3d_vec3_add(slayer3d_vec3_add(center, tangent_offset),
-                                                      slayer3d_vec3_scale(bitangent, half_size))) ||
-            !emit_editor_debug_line(&context,
-                                    slayer3d_vec3_add(slayer3d_vec3_add(center, bitangent_offset),
-                                                      slayer3d_vec3_scale(tangent, -half_size)),
-                                    slayer3d_vec3_add(slayer3d_vec3_add(center, bitangent_offset),
-                                                      slayer3d_vec3_scale(tangent, half_size))))
+        const slayer3d_vec3 direction = editor_debug_axis_vector(axis);
+        context.color = colors[axis];
+        context.element_name = names[axis];
+        if (!emit_editor_debug_line(&context, slayer3d_vec3_scale(direction, -half_size),
+                                    slayer3d_vec3_scale(direction, half_size)))
         {
             return false;
         }
     }
+    return true;
+}
+
+static slayer3d_vec3 editor_debug_grid_world_point(slayer3d_vec3 normal, slayer3d_vec3 tangent, slayer3d_vec3 bitangent,
+                                                   float plane_distance, float u, float v)
+{
+    return slayer3d_vec3_add(slayer3d_vec3_add(slayer3d_vec3_scale(tangent, u), slayer3d_vec3_scale(bitangent, v)),
+                             slayer3d_vec3_scale(normal, plane_distance));
+}
+
+static void editor_debug_grid_expand_interval(float value, float *out_min, float *out_max, int *out_count)
+{
+    if (out_min == NULL || out_max == NULL || out_count == NULL)
+        return;
+    if (*out_count == 0)
+    {
+        *out_min = value;
+        *out_max = value;
+    }
+    else
+    {
+        *out_min = SDL_min(*out_min, value);
+        *out_max = SDL_max(*out_max, value);
+    }
+    ++(*out_count);
+}
+
+static bool emit_editor_debug_surface_grid_axis(editor_debug_iteration_context *context,
+                                                const editor_debug_surface_grid_point *points, int point_count,
+                                                slayer3d_vec3 normal, slayer3d_vec3 tangent, slayer3d_vec3 bitangent,
+                                                float plane_distance, float spacing, bool fixed_u)
+{
+    if (context == NULL || points == NULL || point_count < 3 || spacing <= 0.0f)
+        return true;
+
+    float min_fixed = fixed_u ? points[0].u : points[0].v;
+    float max_fixed = min_fixed;
+    for (int i = 1; i < point_count; ++i)
+    {
+        const float value = fixed_u ? points[i].u : points[i].v;
+        min_fixed = SDL_min(min_fixed, value);
+        max_fixed = SDL_max(max_fixed, value);
+    }
+
+    const float epsilon = 0.0001f;
+    const int first = (int)SDL_ceilf((min_fixed - epsilon) / spacing);
+    const int last = (int)SDL_floorf((max_fixed + epsilon) / spacing);
+    const int max_lines = 1024;
+    if (last < first)
+        return true;
+
+    const int clamped_last = SDL_min(last, first + max_lines - 1);
+    const slayer3d_vec3 visual_offset = slayer3d_vec3_scale(normal, 0.002f);
+    for (int line = first; line <= clamped_last; ++line)
+    {
+        const float fixed = (float)line * spacing;
+        float min_other = 0.0f;
+        float max_other = 0.0f;
+        int intersection_count = 0;
+
+        for (int edge = 0; edge < point_count; ++edge)
+        {
+            const editor_debug_surface_grid_point *a = &points[edge];
+            const editor_debug_surface_grid_point *b = &points[(edge + 1) % point_count];
+            const float a_fixed = fixed_u ? a->u : a->v;
+            const float b_fixed = fixed_u ? b->u : b->v;
+            const float a_other = fixed_u ? a->v : a->u;
+            const float b_other = fixed_u ? b->v : b->u;
+
+            if (SDL_fabsf(a_fixed - fixed) <= epsilon && SDL_fabsf(b_fixed - fixed) <= epsilon)
+            {
+                editor_debug_grid_expand_interval(a_other, &min_other, &max_other, &intersection_count);
+                editor_debug_grid_expand_interval(b_other, &min_other, &max_other, &intersection_count);
+                continue;
+            }
+
+            const float edge_min = SDL_min(a_fixed, b_fixed);
+            const float edge_max = SDL_max(a_fixed, b_fixed);
+            if (fixed < edge_min - epsilon || fixed > edge_max + epsilon || SDL_fabsf(b_fixed - a_fixed) <= epsilon)
+                continue;
+
+            const float t = SDL_clamp((fixed - a_fixed) / (b_fixed - a_fixed), 0.0f, 1.0f);
+            editor_debug_grid_expand_interval(a_other + (b_other - a_other) * t, &min_other, &max_other,
+                                              &intersection_count);
+        }
+
+        if (intersection_count < 2 || max_other - min_other <= 0.0001f)
+            continue;
+
+        slayer3d_vec3 start;
+        slayer3d_vec3 end;
+        if (fixed_u)
+        {
+            start = editor_debug_grid_world_point(normal, tangent, bitangent, plane_distance, fixed, min_other);
+            end = editor_debug_grid_world_point(normal, tangent, bitangent, plane_distance, fixed, max_other);
+        }
+        else
+        {
+            start = editor_debug_grid_world_point(normal, tangent, bitangent, plane_distance, min_other, fixed);
+            end = editor_debug_grid_world_point(normal, tangent, bitangent, plane_distance, max_other, fixed);
+        }
+        if (!emit_editor_debug_line(context, slayer3d_vec3_add(start, visual_offset),
+                                    slayer3d_vec3_add(end, visual_offset)))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+static slayer3d_vec3 editor_debug_surface_grid_tangent(slayer3d_vec3 normal)
+{
+    slayer3d_vec3 best = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    float best_len_sq = -1.0f;
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        const slayer3d_vec3 candidate = editor_debug_axis_vector(axis);
+        const slayer3d_vec3 projected =
+            slayer3d_vec3_sub(candidate, slayer3d_vec3_scale(normal, slayer3d_vec3_dot(candidate, normal)));
+        const float len_sq = slayer3d_vec3_length_squared(projected);
+        if (len_sq > best_len_sq)
+        {
+            best_len_sq = len_sq;
+            best = projected;
+        }
+    }
+    return best_len_sq > 0.000001f ? slayer3d_vec3_normalize(best) : slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+}
+
+static bool emit_editor_debug_surface_grid(editor_debug_iteration_context *context, const slayer3d_vec3 *corners,
+                                           int corner_count, slayer3d_vec3 normal, float spacing)
+{
+    if (context == NULL || corners == NULL || corner_count < 3 || spacing <= 0.0f ||
+        slayer3d_vec3_length_squared(normal) <= 0.000001f)
+    {
+        return true;
+    }
+
+    normal = slayer3d_vec3_normalize(normal);
+    const slayer3d_vec3 tangent = editor_debug_surface_grid_tangent(normal);
+    const slayer3d_vec3 bitangent = slayer3d_vec3_normalize(slayer3d_vec3_cross(normal, tangent));
+    const float plane_distance = slayer3d_vec3_dot(normal, corners[0]);
+
+    slayer3d_vec3 center = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    for (int i = 0; i < corner_count; ++i)
+        center = slayer3d_vec3_add(center, corners[i]);
+    center = slayer3d_vec3_scale(center, 1.0f / (float)corner_count);
+    const float center_u = slayer3d_vec3_dot(center, tangent);
+    const float center_v = slayer3d_vec3_dot(center, bitangent);
+
+    editor_debug_surface_grid_point points[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
+    SDL_zeroa(points);
+    int point_count = 0;
+    for (int i = 0; i < corner_count && i < (int)SDL_arraysize(points); ++i)
+    {
+        editor_debug_surface_grid_point point;
+        SDL_zero(point);
+        point.u = slayer3d_vec3_dot(corners[i], tangent);
+        point.v = slayer3d_vec3_dot(corners[i], bitangent);
+        point.angle = SDL_atan2f(point.v - center_v, point.u - center_u);
+
+        int insert = point_count;
+        while (insert > 0 && points[insert - 1].angle > point.angle)
+        {
+            points[insert] = points[insert - 1];
+            --insert;
+        }
+        points[insert] = point;
+        ++point_count;
+    }
+
+    return emit_editor_debug_surface_grid_axis(context, points, point_count, normal, tangent, bitangent, plane_distance,
+                                               spacing, true) &&
+           emit_editor_debug_surface_grid_axis(context, points, point_count, normal, tangent, bitangent, plane_distance,
+                                               spacing, false);
+}
+
+static bool emit_editor_debug_source_model_face_grid(editor_debug_iteration_context *context,
+                                                     const brush_world_runtime *world,
+                                                     const slayer3d_game_data_brush *brush,
+                                                     const slayer3d_game_data_brush_compiled_face *compiled_face,
+                                                     slayer3d_vec3 world_position, float spacing, bool *out_handled)
+{
+    if (out_handled != NULL)
+        *out_handled = false;
+    if (context == NULL || world == NULL || brush == NULL || compiled_face == NULL || spacing <= 0.0f ||
+        compiled_face->face_index < 0 || compiled_face->face_index >= brush->face_count)
+    {
+        return true;
+    }
+
+    const char *brush_identity =
+        compiled_face->source_brush_stable_id != NULL && compiled_face->source_brush_stable_id[0] != '\0'
+            ? compiled_face->source_brush_stable_id
+        : brush->editor.stable_id != NULL && brush->editor.stable_id[0] != '\0' ? brush->editor.stable_id
+                                                                                : brush->name;
+    const int source_index = editor_brush_world_find_source_box_index(world, brush_identity);
+    editor_brush_source_vertex_model model;
+    if (source_index < 0 || !editor_brush_source_box_build_vertex_model(world, source_index, &model, NULL, 0) ||
+        compiled_face->face_index >= model.face_count)
+    {
+        return true;
+    }
+
+    const editor_brush_source_face_ref *face = &model.faces[compiled_face->face_index];
+    if (face->vertex_count < 3)
+        return true;
+
+    slayer3d_vec3 corners[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY];
+    SDL_zeroa(corners);
+    int corner_count = 0;
+    for (int i = 0; i < face->vertex_count && corner_count < (int)SDL_arraysize(corners); ++i)
+    {
+        const int vertex_index = face->vertex_indices[i];
+        if (vertex_index < 0 || vertex_index >= model.vertex_count)
+            continue;
+        corners[corner_count++] =
+            slayer3d_vec3_add(world_position, editor_source_vertex_coord_meters(world, &model.vertices[vertex_index]));
+    }
+    if (corner_count < 3)
+        return true;
+
+    if (out_handled != NULL)
+        *out_handled = true;
+    const slayer3d_vec3 normal = brush->faces[compiled_face->face_index].normal;
+    return emit_editor_debug_surface_grid(context, corners, corner_count, normal, spacing);
+}
+
+static slayer3d_vec3 editor_debug_bounds_face_normal(int face_index)
+{
+    switch (face_index)
+    {
+    case 0:
+        return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    case 1:
+        return slayer3d_vec3_make(-1.0f, 0.0f, 0.0f);
+    case 2:
+        return slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    case 3:
+        return slayer3d_vec3_make(0.0f, -1.0f, 0.0f);
+    case 4:
+        return slayer3d_vec3_make(0.0f, 0.0f, 1.0f);
+    case 5:
+        return slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
+    default:
+        return slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    }
+}
+
+static bool emit_editor_debug_bounds_face_grid(editor_debug_iteration_context *context,
+                                               const slayer3d_game_data_brush *brush, int face_index,
+                                               slayer3d_vec3 world_position, float spacing)
+{
+    if (context == NULL || brush == NULL || !brush->has_bounds || spacing <= 0.0f)
+        return true;
+
+    slayer3d_vec3 corners[4];
+    if (!editor_bounds_face_corners(brush->bounds, face_index, corners))
+        return true;
+    for (int i = 0; i < 4; ++i)
+        corners[i] = slayer3d_vec3_add(corners[i], world_position);
+
+    slayer3d_vec3 normal = face_index >= 0 && face_index < brush->face_count
+                               ? brush->faces[face_index].normal
+                               : editor_debug_bounds_face_normal(face_index);
+    if (slayer3d_vec3_length_squared(normal) <= 0.000001f)
+        normal = editor_debug_bounds_face_normal(face_index);
+    return emit_editor_debug_surface_grid(context, corners, 4, normal, spacing);
+}
+
+static bool editor_debug_compiled_face_seen(const slayer3d_game_data_brush_world *world, int face_index)
+{
+    if (world == NULL || world->compile_rendered_faces == NULL || face_index < 0 ||
+        face_index >= world->compile_rendered_face_metadata_count)
+    {
+        return false;
+    }
+
+    const slayer3d_game_data_brush_compiled_face *face = &world->compile_rendered_faces[face_index];
+    for (int i = 0; i < face_index; ++i)
+    {
+        const slayer3d_game_data_brush_compiled_face *previous = &world->compile_rendered_faces[i];
+        if (previous->brush_index == face->brush_index && previous->face_index == face->face_index)
+            return true;
+    }
+    return false;
+}
+
+typedef struct editor_surface_grid_context
+{
+    const slayer3d_game_data_runtime *runtime;
+    const slayer3d_game_data_editor_debug_desc *desc;
+    slayer3d_game_data_editor_debug_primitive_fn callback;
+    void *userdata;
+    bool stopped;
+} editor_surface_grid_context;
+
+static bool emit_editor_debug_brush_face_grid(editor_debug_iteration_context *context, const brush_world_runtime *world,
+                                              const slayer3d_game_data_brush *brush,
+                                              const slayer3d_game_data_brush_compiled_face *compiled_face,
+                                              int fallback_face_index, slayer3d_vec3 world_position, float spacing)
+{
+    if (context == NULL || world == NULL || brush == NULL || spacing <= 0.0f)
+        return true;
+
+    bool handled = false;
+    if (compiled_face != NULL && !emit_editor_debug_source_model_face_grid(context, world, brush, compiled_face,
+                                                                           world_position, spacing, &handled))
+    {
+        return false;
+    }
+    if (handled)
+        return true;
+
+    const int face_index = compiled_face != NULL ? compiled_face->face_index : fallback_face_index;
+    return emit_editor_debug_bounds_face_grid(context, brush, face_index, world_position, spacing);
+}
+
+static bool emit_editor_debug_brush_world_surface_grid(void *userdata,
+                                                       const slayer3d_game_data_brush_world_instance *instance)
+{
+    editor_surface_grid_context *grid_context = (editor_surface_grid_context *)userdata;
+    if (grid_context == NULL || grid_context->runtime == NULL || grid_context->desc == NULL || instance == NULL)
+        return true;
+
+    const brush_world_runtime *world = find_brush_world_runtime(grid_context->runtime, instance->world_name);
+    if (world == NULL)
+        return false;
+
+    const float spacing =
+        grid_context->desc->work_plane_grid_spacing > 0.0f ? grid_context->desc->work_plane_grid_spacing : 1.0f;
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = grid_context->callback;
+    context.userdata = grid_context->userdata;
+    context.color =
+        editor_debug_color_or_default(grid_context->desc->work_plane_grid_color, (slayer3d_color){90, 160, 190, 120});
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID;
+    context.world_name = instance->world_name;
+
+    const slayer3d_game_data_brush_world *brush_world = &world->desc;
+    if (brush_world->compile_rendered_faces != NULL && brush_world->compile_rendered_face_metadata_count > 0)
+    {
+        for (int i = 0; i < brush_world->compile_rendered_face_metadata_count; ++i)
+        {
+            if (editor_debug_compiled_face_seen(brush_world, i))
+                continue;
+            const slayer3d_game_data_brush_compiled_face *face = &brush_world->compile_rendered_faces[i];
+            if (face->brush_index < 0 || face->brush_index >= brush_world->brush_count)
+                continue;
+            const slayer3d_game_data_brush *brush = &brush_world->brushes[face->brush_index];
+            if (face->face_index < 0 || face->face_index >= brush->face_count)
+                continue;
+            context.element_name = face->brush_name != NULL ? face->brush_name : brush->name;
+            context.face_index = face->face_index;
+            if (!emit_editor_debug_brush_face_grid(&context, world, brush, face, -1, instance->position, spacing))
+            {
+                grid_context->stopped = context.stopped;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    for (int brush_index = 0; brush_index < brush_world->brush_count; ++brush_index)
+    {
+        const slayer3d_game_data_brush *brush = &brush_world->brushes[brush_index];
+        context.element_name = brush->name;
+        for (int face_index = 0; face_index < brush->face_count; ++face_index)
+        {
+            context.face_index = face_index;
+            if (!emit_editor_debug_brush_face_grid(&context, world, brush, NULL, face_index, instance->position,
+                                                   spacing))
+            {
+                grid_context->stopped = context.stopped;
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+static bool emit_editor_debug_work_plane_grid(const slayer3d_game_data_runtime *runtime,
+                                              const slayer3d_game_data_editor_debug_desc *desc,
+                                              slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL || !desc->has_work_plane_grid ||
+        slayer3d_vec3_length_squared(desc->work_plane_normal) <= 0.000001f)
+    {
+        return true;
+    }
+
+    if (!emit_editor_debug_origin_axes(desc, callback, userdata))
+        return false;
+
+    editor_surface_grid_context context;
+    SDL_zero(context);
+    context.runtime = runtime;
+    context.desc = desc;
+    context.callback = callback;
+    context.userdata = userdata;
+    if (!slayer3d_game_data_for_each_brush_world_instance(runtime, emit_editor_debug_brush_world_surface_grid,
+                                                          &context))
+    {
+        return false;
+    }
+    if (context.stopped)
+        return false;
     return true;
 }
 
@@ -2239,7 +2657,7 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
 
     const unsigned int flags = desc->flags != 0u ? desc->flags : SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL;
     if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORK_PLANE_GRID) != 0u &&
-        !emit_editor_debug_work_plane_grid(desc, callback, userdata))
+        !emit_editor_debug_work_plane_grid(runtime, desc, callback, userdata))
     {
         return true;
     }

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -56,9 +56,81 @@ static const float *ensure_white_colors(slayer3d_gl_context *ctx, int vertex_cou
 
 static float *copy_floats(const float *src, size_t count);
 
+static slayer3d_vec4 transform_vec4_columns(const float *m, float x, float y, float z, float w)
+{
+    return slayer3d_vec4_make(
+        (m[0] * x) + (m[4] * y) + (m[8] * z) + (m[12] * w), (m[1] * x) + (m[5] * y) + (m[9] * z) + (m[13] * w),
+        (m[2] * x) + (m[6] * y) + (m[10] * z) + (m[14] * w), (m[3] * x) + (m[7] * y) + (m[11] * z) + (m[15] * w));
+}
+
+static float clip_line_distance(slayer3d_vec4 v, int plane)
+{
+    switch (plane)
+    {
+    case 0:
+        return v.x + v.w;
+    case 1:
+        return v.w - v.x;
+    case 2:
+        return v.y + v.w;
+    case 3:
+        return v.w - v.y;
+    case 4:
+        return v.z + v.w;
+    default:
+        return v.w - v.z;
+    }
+}
+
+static bool clip_line_to_view(slayer3d_vec4 *a, slayer3d_vec4 *b)
+{
+    if (a == NULL || b == NULL)
+        return false;
+
+    for (int plane = 0; plane < 6; ++plane)
+    {
+        const float da = clip_line_distance(*a, plane);
+        const float db = clip_line_distance(*b, plane);
+        if (da < 0.0f && db < 0.0f)
+            return false;
+        if (da >= 0.0f && db >= 0.0f)
+            continue;
+
+        const float denom = da - db;
+        if (SDL_fabsf(denom) <= 0.000001f)
+            return false;
+        const float t = da / denom;
+        const slayer3d_vec4 p = slayer3d_vec4_lerp(*a, *b, t);
+        if (da < 0.0f)
+            *a = p;
+        else
+            *b = p;
+    }
+
+    return a->w > 0.0f && b->w > 0.0f;
+}
+
+static bool append_line_quad_vertex(float *positions, float *uvs, float *quad_colors, int *index, slayer3d_vec4 p,
+                                    const float *color)
+{
+    if (positions == NULL || uvs == NULL || quad_colors == NULL || index == NULL || color == NULL)
+        return false;
+    const int i = *index;
+    positions[(i * 3) + 0] = p.x;
+    positions[(i * 3) + 1] = p.y;
+    positions[(i * 3) + 2] = p.z;
+    uvs[(i * 2) + 0] = 0.0f;
+    uvs[(i * 2) + 1] = 0.0f;
+    quad_colors[(i * 4) + 0] = color[0];
+    quad_colors[(i * 4) + 1] = color[1];
+    quad_colors[(i * 4) + 2] = color[2];
+    quad_colors[(i * 4) + 3] = color[3];
+    *index = i + 1;
+    return true;
+}
+
 bool slayer3d_gl_append_line(slayer3d_gl_context *ctx, const float *positions, const float *colors, const float *mvp)
 {
-    static const float k_zero_uvs[4] = {0.0f, 0.0f, 0.0f, 0.0f};
     static const float k_white_tint[4] = {1.0f, 1.0f, 1.0f, 1.0f};
 
     if (!ctx || !positions || !colors || !mvp)
@@ -66,18 +138,68 @@ bool slayer3d_gl_append_line(slayer3d_gl_context *ctx, const float *positions, c
         return false;
     }
 
+    slayer3d_vec4 clip_start = transform_vec4_columns(mvp, positions[0], positions[1], positions[2], 1.0f);
+    slayer3d_vec4 clip_end = transform_vec4_columns(mvp, positions[3], positions[4], positions[5], 1.0f);
+    if (!clip_line_to_view(&clip_start, &clip_end))
+        return true;
+
+    slayer3d_vec4 start =
+        slayer3d_vec4_make(clip_start.x / clip_start.w, clip_start.y / clip_start.w, clip_start.z / clip_start.w, 1.0f);
+    slayer3d_vec4 end =
+        slayer3d_vec4_make(clip_end.x / clip_end.w, clip_end.y / clip_end.w, clip_end.z / clip_end.w, 1.0f);
+
+    const int logical_w = ctx->logical_w > 0 ? ctx->logical_w : SDL_max(ctx->world_w, 1);
+    const int logical_h = ctx->logical_h > 0 ? ctx->logical_h : SDL_max(ctx->world_h, 1);
+    float viewport_w = (float)logical_w;
+    float viewport_h = (float)logical_h;
+    if (ctx->current_ctx != NULL && ctx->current_ctx->viewport_enabled && ctx->current_ctx->viewport_rect.w > 0 &&
+        ctx->current_ctx->viewport_rect.h > 0)
+    {
+        viewport_w = (float)ctx->current_ctx->viewport_rect.w;
+        viewport_h = (float)ctx->current_ctx->viewport_rect.h;
+    }
+    viewport_w *= (float)SDL_max(ctx->world_w, 1) / (float)logical_w;
+    viewport_h *= (float)SDL_max(ctx->world_h, 1) / (float)logical_h;
+
+    const float dx = (end.x - start.x) * viewport_w * 0.5f;
+    const float dy = (end.y - start.y) * viewport_h * 0.5f;
+    const float len = SDL_sqrtf((dx * dx) + (dy * dy));
+    if (len <= 0.0001f)
+        return true;
+
+    const float half_width_px = 0.75f;
+    const float off_x = (-dy / len) * half_width_px * 2.0f / viewport_w;
+    const float off_y = (dx / len) * half_width_px * 2.0f / viewport_h;
+    const slayer3d_vec4 start_a = slayer3d_vec4_make(start.x + off_x, start.y + off_y, start.z, 1.0f);
+    const slayer3d_vec4 start_b = slayer3d_vec4_make(start.x - off_x, start.y - off_y, start.z, 1.0f);
+    const slayer3d_vec4 end_a = slayer3d_vec4_make(end.x + off_x, end.y + off_y, end.z, 1.0f);
+    const slayer3d_vec4 end_b = slayer3d_vec4_make(end.x - off_x, end.y - off_y, end.z, 1.0f);
+
+    float quad_positions[18];
+    float quad_uvs[12];
+    float quad_colors[24];
+    int vertex_index = 0;
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, start_a, colors);
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, start_b, colors);
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, end_b, colors + 4);
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, start_a, colors);
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, end_b, colors + 4);
+    (void)append_line_quad_vertex(quad_positions, quad_uvs, quad_colors, &vertex_index, end_a, colors + 4);
+
     slayer3d_draw_entry *e = slayer3d_gl_append_draw_entry(ctx);
     if (!e)
         return false;
 
     e->lit = false;
-    e->primitive_mode = GL_LINES;
-    e->vertex_count = 2;
-    e->positions = copy_floats(positions, 6);
-    e->uvs = copy_floats(k_zero_uvs, 4);
-    e->colors = copy_floats(colors, 8);
-    SDL_memcpy(e->mvp, mvp, 16 * sizeof(float));
+    e->primitive_mode = GL_TRIANGLES;
+    e->vertex_count = vertex_index;
+    e->positions = copy_floats(quad_positions, (size_t)vertex_index * 3u);
+    e->uvs = copy_floats(quad_uvs, (size_t)vertex_index * 2u);
+    e->colors = copy_floats(quad_colors, (size_t)vertex_index * 4u);
+    const slayer3d_mat4 identity = slayer3d_mat4_identity();
+    SDL_memcpy(e->mvp, identity.m, 16 * sizeof(float));
     SDL_memcpy(e->tint, k_white_tint, sizeof(k_white_tint));
+    e->disable_culling = true;
     e->owns_arrays = true;
     if (ctx->current_ctx != NULL)
         draw_entry_capture_viewport(e, ctx->current_ctx);
@@ -1318,7 +1440,7 @@ static bool draw_entries_can_instance(const slayer3d_gl_context *ctx, const slay
            draw_entry_float3_equal(a->emissive, b->emissive) &&
            draw_entry_matrix_equal(a->view_projection, b->view_projection, 16) &&
            draw_entry_float3_equal(a->camera_pos, b->camera_pos) && a->viewport_enabled == b->viewport_enabled &&
-           a->scissor_enabled == b->scissor_enabled &&
+           a->scissor_enabled == b->scissor_enabled && a->disable_culling == b->disable_culling &&
            (!a->viewport_enabled || SDL_memcmp(&a->viewport_rect, &b->viewport_rect, sizeof(a->viewport_rect)) == 0) &&
            (!a->scissor_enabled || SDL_memcmp(&a->scissor_rect, &b->scissor_rect, sizeof(a->scissor_rect)) == 0) &&
            draw_entry_skinning_equal(a, b);
@@ -1393,6 +1515,25 @@ static bool upload_instance_attributes(slayer3d_gl_context *ctx, const slayer3d_
     return true;
 }
 
+static void apply_draw_entry_cull_state(slayer3d_gl_context *ctx, const slayer3d_draw_entry *entry)
+{
+    if (ctx == NULL || entry == NULL)
+        return;
+    slayer3d_gl_funcs *gl = &ctx->gl;
+    if (entry->disable_culling)
+    {
+        gl->Disable(GL_CULL_FACE);
+    }
+    else if (ctx->current_ctx != NULL && ctx->current_ctx->backface_culling_enabled)
+    {
+        gl->Enable(GL_CULL_FACE);
+    }
+    else
+    {
+        gl->Disable(GL_CULL_FACE);
+    }
+}
+
 static bool draw_static_mesh_instance_batch(slayer3d_gl_context *ctx, int start, int count)
 {
     if (ctx == NULL || count <= 1)
@@ -1432,6 +1573,7 @@ static void replay_draw_list_geometry(slayer3d_gl_context *ctx)
         slayer3d_draw_entry *e = &ctx->draw_list[i];
         GLuint tex = slayer3d_gl_resolve_texture(ctx, e->texture);
         apply_draw_entry_viewport(ctx, e);
+        apply_draw_entry_cull_state(ctx, e);
 
         if (e->lit)
         {

--- a/src/gl_renderer_internal.h
+++ b/src/gl_renderer_internal.h
@@ -134,6 +134,7 @@ typedef struct slayer3d_draw_entry
     int joint_palette_offset;
     bool use_joint_palette_buffer;
     bool gpu_skinned;
+    bool disable_culling;
     bool viewport_enabled;
     SDL_Rect viewport_rect;
     bool scissor_enabled;

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -16758,6 +16758,7 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
     struct DebugCapture
     {
         int grid_lines = 0;
+        int origin_axes = 0;
         int world_edges = 0;
         int selection_edges = 0;
         int selection_face_edges = 0;
@@ -16765,14 +16766,29 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
         int rays = 0;
         int normals = 0;
         int markers = 0;
+        float max_grid_abs = 0.0f;
     } debug;
     auto capture_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) -> bool {
         auto *capture = static_cast<DebugCapture *>(userdata);
         if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORK_PLANE_GRID)
         {
             capture->grid_lines++;
-            EXPECT_NEAR(primitive->start.y, 0.0f, 0.001f);
-            EXPECT_NEAR(primitive->end.y, 0.0f, 0.001f);
+            EXPECT_NE(primitive->world_name, nullptr);
+            EXPECT_NE(primitive->element_name, nullptr);
+            EXPECT_GE(primitive->face_index, 0);
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->start.x));
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->start.y));
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->start.z));
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->end.x));
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->end.y));
+            capture->max_grid_abs = std::max(capture->max_grid_abs, std::fabs(primitive->end.z));
+        }
+        else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_ORIGIN_AXIS)
+        {
+            capture->origin_axes++;
+            EXPECT_STREQ(primitive->world_name, "editor_origin");
+            EXPECT_NE(primitive->element_name, nullptr);
+            EXPECT_EQ(primitive->face_index, -1);
         }
         else if (primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_WORLD_BOUNDS_EDGE)
             capture->world_edges++;
@@ -16794,7 +16810,10 @@ TEST(GameDataRuntime, EditorShellDojoPublishesSelectionAndDebugOverlay)
         return true;
     };
     ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, capture_debug, &debug));
-    EXPECT_EQ(debug.grid_lines, 1026);
+    EXPECT_GT(debug.grid_lines, 0);
+    EXPECT_LT(debug.grid_lines, 1026);
+    EXPECT_LT(debug.max_grid_abs, 64.0f);
+    EXPECT_EQ(debug.origin_axes, 3);
     EXPECT_EQ(debug.world_edges, 12);
     EXPECT_EQ(debug.selection_edges, 12);
     EXPECT_EQ(debug.selection_face_edges, 52);

--- a/tests/test_gl_renderer.cpp
+++ b/tests/test_gl_renderer.cpp
@@ -1852,6 +1852,40 @@ TEST_F(GLRendererTest, Line3DVisibleOnGLBackend)
     EXPECT_TRUE(found_red);
 }
 
+TEST_F(GLRendererTest, Line3DVisibleWithBackfaceCullingOnGLBackend)
+{
+    slayer3d_camera3d cam;
+    cam.position = slayer3d_vec3_make(0, 0, 5);
+    cam.target = slayer3d_vec3_make(0, 0, 0);
+    cam.up = slayer3d_vec3_make(0, 1, 0);
+    cam.fovy = 60.0f;
+    cam.projection = SLAYER3D_CAMERA_PERSPECTIVE;
+
+    ASSERT_TRUE(slayer3d_set_backface_culling_enabled(ctx, true));
+    slayer3d_clear_render_context(ctx, slayer3d_color{0, 0, 0, 255});
+    slayer3d_begin_mode_3d(ctx, cam);
+    slayer3d_draw_line_3d(ctx, slayer3d_vec3_make(1.5f, 0.0f, 0.0f), slayer3d_vec3_make(-1.5f, 0.0f, 0.0f),
+                          slayer3d_color{255, 32, 32, 255});
+    slayer3d_end_mode_3d(ctx);
+
+    bool found_red = false;
+    for (int y = 0; y < 240 && !found_red; ++y)
+    {
+        for (int x = 0; x < 320; ++x)
+        {
+            unsigned char px[4];
+            readPixel(x, y, px);
+            if (px[0] > 100 && px[1] < 80 && px[2] < 80)
+            {
+                found_red = true;
+                break;
+            }
+        }
+    }
+
+    EXPECT_TRUE(found_red);
+}
+
 TEST_F(GLRendererTest, BackfaceCullingShowsFrontFaces)
 {
     /* A cube viewed from the front should show the front face, not the back. */


### PR DESCRIPTION
## Summary
- render OpenGL-backed slayer3d_draw_line_3d primitives as clipped screen-space quads instead of raw GL_LINES
- preserve fixed pixel thickness across active viewports and keep normal 3D depth testing
- make line quads ignore face culling, matching line primitive semantics

## Verification
- cmake --build build/debug --target slayer3d_gl_renderer_test slayer3d_editor -j 8
- ./build/debug/tests/slayer3d_gl_renderer_test --gtest_filter='GLRendererTest.Line3DVisibleOnGLBackend:GLRendererTest.Line3DVisibleWithBackfaceCullingOnGLBackend'
- ./build/debug/tests/slayer3d_gl_renderer_test
- ctest --test-dir build/debug --output-on-failure
