### PR TITLE
Editor: add vertical flip tool with multi-selection support

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       BUILD_DIR: build\windows-msvc
       BUILD_CONFIG: Debug
+      EDITOR_EXE: build\windows-msvc\slayer3d_editor.exe
 
     steps:
       - name: Checkout
@@ -27,8 +28,8 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           cmake -S . -B "$env:BUILD_DIR" `
-            -G "Visual Studio 17 2022" `
-            -A x64 `
+            -G Ninja `
+            -DCMAKE_BUILD_TYPE="$env:BUILD_CONFIG" `
             -DSLAYER3D_BUILD_TESTS=ON `
             -DSLAYER3D_BUILD_DEMOS=ON `
             -DSLAYER3D_BUILD_BENCHMARKS=OFF `
@@ -48,7 +49,7 @@ jobs:
       - name: Verify SDL is statically linked
         shell: pwsh
         run: |
-          dumpbin /DEPENDENTS "$env:BUILD_DIR\$env:BUILD_CONFIG\slayer3d_editor.exe" | Tee-Object logs\editor-dependencies.log
+          dumpbin /DEPENDENTS "$env:EDITOR_EXE" | Tee-Object logs\editor-dependencies.log
           if (Select-String -Path logs\editor-dependencies.log -Pattern 'SDL3\.dll') {
             Write-Error 'slayer3d_editor.exe imports SDL3.dll; expected static SDL linkage.'
             exit 1
@@ -65,7 +66,7 @@ jobs:
       - name: Smoke test editor help
         shell: pwsh
         run: |
-          & "$env:BUILD_DIR\$env:BUILD_CONFIG\slayer3d_editor.exe" -h 2>&1 | Tee-Object logs\editor-help.log
+          & "$env:EDITOR_EXE" -h 2>&1 | Tee-Object logs\editor-help.log
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -74,6 +74,10 @@
             "bindings": [{ "device": "keyboard", "key": "RIGHTBRACKET" }]
           },
           {
+            "name": "action.editor.brush.flip_vertical",
+            "bindings": []
+          },
+          {
             "name": "action.editor.export",
             "bindings": [
               { "device": "keyboard", "key": "S", "modifiers": ["ctrl"] },
@@ -272,6 +276,7 @@
     "signal.editor.delete_selected",
     "signal.editor.brush.lower_y",
     "signal.editor.brush.raise_y",
+    "signal.editor.brush.flip_vertical",
     "signal.editor.command.undo",
     "signal.editor.command.redo",
     "signal.editor.tool.floor",
@@ -359,6 +364,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.brush.raise_y",
         "on_pressed": "signal.editor.brush.raise_y"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.brush.flip_vertical",
+        "on_pressed": "signal.editor.brush.flip_vertical"
       },
       {
         "type": "sensor.input_pressed",
@@ -1407,6 +1417,56 @@
                 "type": "scene_state.set",
                 "key": "editor.tool.last_action",
                 "value": "select brushes before raising"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.brush.flip_vertical",
+        "actions": [
+          {
+            "type": "branch",
+            "if": {
+              "type": "all",
+              "conditions": [
+                {
+                  "type": "any",
+                  "conditions": [
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "select", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "rotate", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "scale", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "shear", "default": "select" }
+                  ]
+                },
+                {
+                  "type": "scene_state.compare",
+                  "key": "editor.selection.count",
+                  "op": ">",
+                  "value": 0,
+                  "default": 0
+                }
+              ]
+            },
+            "then": [
+              {
+                "type": "editor.selection.flip_vertical",
+                "view_mode_key": "editor.view.mode",
+                "outputs": {
+                  "valid_key": "editor.flip_vertical.valid",
+                  "message_key": "editor.flip_vertical.message",
+                  "axis_key": "editor.flip_vertical.axis",
+                  "center_key": "editor.flip_vertical.center"
+                }
+              }
+            ],
+            "else": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "select brushes before vertical flip"
               }
             ]
           }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -36,6 +36,7 @@
       "action.editor.clip.cycle_keep_mode",
       "action.editor.brush.lower_y",
       "action.editor.brush.raise_y",
+      "action.editor.brush.flip_vertical",
       "action.editor.palette.material",
       "action.editor.palette.game_object",
       "action.editor.palette.close",
@@ -551,6 +552,15 @@
             "interactive": true,
             "action": "editor.tool.shear",
             "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "shear" }
+          },
+          {
+            "id": "ui.editor_shell.tool_toolbar.flip_vertical.button",
+            "type": "button",
+            "w": 84,
+            "h": 28,
+            "text": "Flip V",
+            "interactive": true,
+            "action": "editor.brush.flip_vertical"
           },
           {
             "id": "ui.editor_shell.tool_toolbar.grid.button",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -251,8 +251,8 @@
       "grid_key": "editor.grid.size",
       "brush_grid_key": "editor.brush.grid_size",
       "open_key": "editor.grid.menu.open",
-      "button": { "x": 892, "y": 45, "w": 110, "h": 28 },
-      "popup": { "x": 892, "y": 76, "w": 110, "h": 288 },
+      "button": { "x": 982, "y": 45, "w": 110, "h": 28 },
+      "popup": { "x": 982, "y": 76, "w": 110, "h": 288 },
       "row_height": 24,
       "values": [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0]
     },

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -252,21 +252,22 @@ static bool editor_selected_brushes_bounds(const slayer3d_game_data_runtime *run
     SDL_zero(bounds);
     for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
     {
-        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
-        if (!selection->hit || !selection->has_bounds)
+        slayer3d_game_data_editor_selection selection =
+            resolved_editor_selection(runtime, &runtime->editor_selected_brushes[i]);
+        if (!selection.hit || !selection.has_bounds)
             continue;
         if (!has_bounds)
         {
-            bounds = selection->bounds;
+            bounds = selection.bounds;
             has_bounds = true;
             continue;
         }
-        bounds.min.x = SDL_min(bounds.min.x, selection->bounds.min.x);
-        bounds.min.y = SDL_min(bounds.min.y, selection->bounds.min.y);
-        bounds.min.z = SDL_min(bounds.min.z, selection->bounds.min.z);
-        bounds.max.x = SDL_max(bounds.max.x, selection->bounds.max.x);
-        bounds.max.y = SDL_max(bounds.max.y, selection->bounds.max.y);
-        bounds.max.z = SDL_max(bounds.max.z, selection->bounds.max.z);
+        bounds.min.x = SDL_min(bounds.min.x, selection.bounds.min.x);
+        bounds.min.y = SDL_min(bounds.min.y, selection.bounds.min.y);
+        bounds.min.z = SDL_min(bounds.min.z, selection.bounds.min.z);
+        bounds.max.x = SDL_max(bounds.max.x, selection.bounds.max.x);
+        bounds.max.y = SDL_max(bounds.max.y, selection.bounds.max.y);
+        bounds.max.z = SDL_max(bounds.max.z, selection.bounds.max.z);
     }
     if (!has_bounds)
         return false;

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -331,6 +331,126 @@ static bool editor_selection_shear_selected_action(slayer3d_game_data_runtime *r
     return slayer3d_game_data_shear_selected_editor_brushes(runtime, bounds, side_normal, delta);
 }
 
+static const char *editor_flip_axis_label(slayer3d_vec3 normal)
+{
+    const float abs_x = SDL_fabsf(normal.x);
+    const float abs_y = SDL_fabsf(normal.y);
+    const float abs_z = SDL_fabsf(normal.z);
+    if (abs_x >= abs_y && abs_x >= abs_z)
+        return normal.x >= 0.0f ? "+X" : "-X";
+    if (abs_y >= abs_x && abs_y >= abs_z)
+        return normal.y >= 0.0f ? "+Y" : "-Y";
+    return normal.z >= 0.0f ? "+Z" : "-Z";
+}
+
+static bool editor_selection_flip_vertical_normal(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                  slayer3d_vec3 *out_normal, const char **out_axis_label, char *message,
+                                                  size_t message_size)
+{
+    if (out_normal == NULL)
+        return false;
+    if (message != NULL && message_size > 0u)
+        message[0] = '\0';
+
+    slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    if (obj_get(action, "normal") != NULL)
+    {
+        normal = json_vec3(action, "normal", normal);
+    }
+    else
+    {
+        const char *normal_key = json_string(action, "normal_key", NULL);
+        const slayer3d_value *normal_value =
+            runtime != NULL && runtime->scene_state != NULL && normal_key != NULL && normal_key[0] != '\0'
+                ? slayer3d_properties_get_value(runtime->scene_state, normal_key)
+                : NULL;
+        if (normal_value != NULL && normal_value->type == SLAYER3D_VALUE_VEC3)
+        {
+            normal = normal_value->as_vec3;
+        }
+        else
+        {
+            const char *view_mode_key = json_string(action, "view_mode_key", "editor.view.mode");
+            const char *view_mode =
+                runtime != NULL && runtime->scene_state != NULL && view_mode_key != NULL && view_mode_key[0] != '\0'
+                    ? slayer3d_properties_get_string(runtime->scene_state, view_mode_key, "flyby_3d")
+                    : "flyby_3d";
+            const char *top_mode = json_string(action, "top_mode", "orthographic_top");
+            const char *front_mode = json_string(action, "front_mode", "orthographic_front");
+            const char *side_mode = json_string(action, "side_mode", "orthographic_side");
+            const char *flyby_mode = json_string(action, "flyby_mode", "flyby_3d");
+            if (SDL_strcmp(view_mode, top_mode) == 0)
+                normal = slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
+            else if (SDL_strcmp(view_mode, front_mode) == 0 || SDL_strcmp(view_mode, side_mode) == 0 ||
+                     SDL_strcmp(view_mode, flyby_mode) == 0)
+                normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+            else
+            {
+                if (message != NULL && message_size > 0u)
+                    SDL_snprintf(message, message_size, "vertical flip unsupported for view '%s'", view_mode);
+                return false;
+            }
+        }
+    }
+
+    if (SDL_isnan(normal.x) || SDL_isinf(normal.x) || SDL_isnan(normal.y) || SDL_isinf(normal.y) ||
+        SDL_isnan(normal.z) || SDL_isinf(normal.z) || slayer3d_vec3_length_squared(normal) <= 0.000001f)
+    {
+        if (message != NULL && message_size > 0u)
+            SDL_strlcpy(message, "vertical flip requires a finite non-zero normal", message_size);
+        return false;
+    }
+    normal = slayer3d_vec3_normalize(normal);
+    *out_normal = normal;
+    if (out_axis_label != NULL)
+        *out_axis_label = editor_flip_axis_label(normal);
+    return true;
+}
+
+static bool editor_selection_flip_vertical_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    slayer3d_vec3 pivot = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (obj_get(action, "pivot") != NULL)
+        pivot = json_vec3(action, "pivot", pivot);
+    else if (!editor_selected_brushes_bounds_center(runtime, &pivot))
+    {
+        editor_set_bool_output(scene_state, outputs, "valid_key", false);
+        editor_set_string_output(scene_state, outputs, "message_key", "select brushes before vertical flip");
+        if (scene_state != NULL)
+            slayer3d_properties_set_string(scene_state, "editor.tool.last_action",
+                                           "select brushes before vertical flip");
+        return false;
+    }
+
+    slayer3d_vec3 normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    const char *axis_label = "+Y";
+    char message[128];
+    if (!editor_selection_flip_vertical_normal(runtime, action, &normal, &axis_label, message, sizeof(message)))
+    {
+        editor_set_bool_output(scene_state, outputs, "valid_key", false);
+        editor_set_string_output(scene_state, outputs, "message_key",
+                                 message[0] != '\0' ? message : "vertical flip failed");
+        if (scene_state != NULL)
+            slayer3d_properties_set_string(scene_state, "editor.tool.last_action",
+                                           message[0] != '\0' ? message : "vertical flip failed");
+        return false;
+    }
+
+    const bool flipped = slayer3d_game_data_flip_selected_editor_brushes(runtime, pivot, normal);
+    SDL_snprintf(message, sizeof(message),
+                 flipped ? "flipped selected brushes vertically around %s" : "vertical flip failed around %s",
+                 axis_label);
+    editor_set_bool_output(scene_state, outputs, "valid_key", flipped);
+    editor_set_string_output(scene_state, outputs, "message_key", message);
+    editor_set_string_output(scene_state, outputs, "axis_key", axis_label);
+    editor_set_vec3_output(scene_state, outputs, "center_key", pivot);
+    if (scene_state != NULL && !flipped)
+        slayer3d_properties_set_string(scene_state, "editor.tool.last_action", message);
+    return flipped;
+}
+
 bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action, const slayer3d_properties *payload)
 {
     const char *type = json_string(action, "type", "");
@@ -614,6 +734,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 
     if (SDL_strcmp(type, "editor.selection.scale_selected") == 0)
         return editor_selection_scale_selected_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.selection.flip_vertical") == 0)
+        return editor_selection_flip_vertical_action(runtime, action);
 
     if (SDL_strcmp(type, "editor.selection.shear_selected") == 0)
         return editor_selection_shear_selected_action(runtime, action);

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -3799,85 +3799,6 @@ static bool mirror_source_vertex_coord(const int coord[3], const float plane_poi
            source_rotation_coord(mirrored.z, snap_units, &out_coord[2]);
 }
 
-static bool editor_brush_world_apply_transformed_source_vertices(brush_world_runtime *world_runtime, int source_index,
-                                                                 const char *brush_name,
-                                                                 const editor_brush_source_vertex_model *model,
-                                                                 const int *transformed_vertices,
-                                                                 const char *operation_name, char *error_buffer,
-                                                                 int error_buffer_size)
-{
-    if (world_runtime == NULL || source_index < 0 || source_index >= world_runtime->editor_source_box_count ||
-        brush_name == NULL || model == NULL || transformed_vertices == NULL || operation_name == NULL)
-    {
-        set_error(error_buffer, error_buffer_size, "source brush transform requires valid source vertices");
-        return false;
-    }
-
-    slayer3d_game_data_brush rebuilt;
-    if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_name, transformed_vertices,
-                                                                    model->vertex_count, &rebuilt, error_buffer,
-                                                                    error_buffer_size))
-    {
-        return false;
-    }
-    editor_brush_source_free_runtime_brush(&rebuilt);
-
-    editor_brush_source_box_runtime snapshot;
-    SDL_zero(snapshot);
-    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
-    if (!copy_editor_brush_source_box_runtime(box, &snapshot))
-    {
-        set_errorf(error_buffer, error_buffer_size, "failed to snapshot source brush %s", operation_name);
-        return false;
-    }
-
-    char *old_prefab = box->prefab;
-    box->prefab = SDL_strdup("convex");
-    if (box->prefab == NULL)
-    {
-        box->prefab = old_prefab;
-        free_editor_brush_source_box(&snapshot);
-        set_errorf(error_buffer, error_buffer_size, "failed to allocate source brush %s metadata", operation_name);
-        return false;
-    }
-    SDL_free(old_prefab);
-    box->vertex_count = model->vertex_count;
-    for (int vertex = 0; vertex < model->vertex_count; ++vertex)
-    {
-        box->vertices[vertex][0] = transformed_vertices[vertex * 3];
-        box->vertices[vertex][1] = transformed_vertices[vertex * 3 + 1];
-        box->vertices[vertex][2] = transformed_vertices[vertex * 3 + 2];
-    }
-    for (int vertex = model->vertex_count; vertex < SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY; ++vertex)
-    {
-        box->vertices[vertex][0] = 0;
-        box->vertices[vertex][1] = 0;
-        box->vertices[vertex][2] = 0;
-    }
-    source_box_update_bounds_from_vertices(box);
-
-    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
-        !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
-    {
-        free_editor_brush_source_box(box);
-        *box = snapshot;
-        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
-        return false;
-    }
-
-    free_editor_brush_source_box(&snapshot);
-    return true;
-}
-
-typedef struct editor_source_box_transform_batch_item
-{
-    int source_index;
-    int vertex_count;
-    int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
-    bool has_snapshot;
-    editor_brush_source_box_runtime snapshot;
-} editor_source_box_transform_batch_item;
-
 static bool editor_source_box_apply_transformed_vertices(editor_brush_source_box_runtime *box, int vertex_count,
                                                          const int *transformed_vertices, const char *operation_name,
                                                          char *error_buffer, int error_buffer_size)
@@ -3914,6 +3835,67 @@ static bool editor_source_box_apply_transformed_vertices(editor_brush_source_box
     source_box_update_bounds_from_vertices(box);
     return true;
 }
+
+static bool editor_brush_world_apply_transformed_source_vertices(brush_world_runtime *world_runtime, int source_index,
+                                                                 const char *brush_name,
+                                                                 const editor_brush_source_vertex_model *model,
+                                                                 const int *transformed_vertices,
+                                                                 const char *operation_name, char *error_buffer,
+                                                                 int error_buffer_size)
+{
+    if (world_runtime == NULL || source_index < 0 || source_index >= world_runtime->editor_source_box_count ||
+        brush_name == NULL || model == NULL || transformed_vertices == NULL || operation_name == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush transform requires valid source vertices");
+        return false;
+    }
+
+    slayer3d_game_data_brush rebuilt;
+    if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_name, transformed_vertices,
+                                                                    model->vertex_count, &rebuilt, error_buffer,
+                                                                    error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&rebuilt);
+
+    editor_brush_source_box_runtime snapshot;
+    SDL_zero(snapshot);
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    if (!copy_editor_brush_source_box_runtime(box, &snapshot))
+    {
+        set_errorf(error_buffer, error_buffer_size, "failed to snapshot source brush %s", operation_name);
+        return false;
+    }
+
+    if (!editor_source_box_apply_transformed_vertices(box, model->vertex_count, transformed_vertices, operation_name,
+                                                      error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box(&snapshot);
+        return false;
+    }
+
+    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
+        !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box(box);
+        *box = snapshot;
+        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+        return false;
+    }
+
+    free_editor_brush_source_box(&snapshot);
+    return true;
+}
+
+typedef struct editor_source_box_transform_batch_item
+{
+    int source_index;
+    int vertex_count;
+    int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    bool has_snapshot;
+    editor_brush_source_box_runtime snapshot;
+} editor_source_box_transform_batch_item;
 
 static void editor_restore_source_box_transform_batch(brush_world_runtime *world_runtime,
                                                       editor_source_box_transform_batch_item *items, int item_count)

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -3784,6 +3784,91 @@ static bool scale_source_vertex_coord(const int coord[3], const float anchor[3],
            source_rotation_coord(anchor[2] + ((float)coord[2] - anchor[2]) * factors.z, snap_units, &out_coord[2]);
 }
 
+static bool mirror_source_vertex_coord(const int coord[3], const float plane_point[3], slayer3d_vec3 plane_normal,
+                                       int snap_units, int out_coord[3])
+{
+    if (coord == NULL || plane_point == NULL || out_coord == NULL)
+        return false;
+
+    const slayer3d_vec3 point = slayer3d_vec3_make((float)coord[0], (float)coord[1], (float)coord[2]);
+    const slayer3d_vec3 origin = slayer3d_vec3_make(plane_point[0], plane_point[1], plane_point[2]);
+    const float distance = slayer3d_vec3_dot(slayer3d_vec3_sub(point, origin), plane_normal);
+    const slayer3d_vec3 mirrored = slayer3d_vec3_sub(point, slayer3d_vec3_scale(plane_normal, 2.0f * distance));
+    return source_rotation_coord(mirrored.x, snap_units, &out_coord[0]) &&
+           source_rotation_coord(mirrored.y, snap_units, &out_coord[1]) &&
+           source_rotation_coord(mirrored.z, snap_units, &out_coord[2]);
+}
+
+static bool editor_brush_world_apply_transformed_source_vertices(brush_world_runtime *world_runtime, int source_index,
+                                                                 const char *brush_name,
+                                                                 const editor_brush_source_vertex_model *model,
+                                                                 const int *transformed_vertices,
+                                                                 const char *operation_name, char *error_buffer,
+                                                                 int error_buffer_size)
+{
+    if (world_runtime == NULL || source_index < 0 || source_index >= world_runtime->editor_source_box_count ||
+        brush_name == NULL || model == NULL || transformed_vertices == NULL || operation_name == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush transform requires valid source vertices");
+        return false;
+    }
+
+    slayer3d_game_data_brush rebuilt;
+    if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_name, transformed_vertices,
+                                                                    model->vertex_count, &rebuilt, error_buffer,
+                                                                    error_buffer_size))
+    {
+        return false;
+    }
+    editor_brush_source_free_runtime_brush(&rebuilt);
+
+    editor_brush_source_box_runtime snapshot;
+    SDL_zero(snapshot);
+    editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[source_index];
+    if (!copy_editor_brush_source_box_runtime(box, &snapshot))
+    {
+        set_errorf(error_buffer, error_buffer_size, "failed to snapshot source brush %s", operation_name);
+        return false;
+    }
+
+    char *old_prefab = box->prefab;
+    box->prefab = SDL_strdup("convex");
+    if (box->prefab == NULL)
+    {
+        box->prefab = old_prefab;
+        free_editor_brush_source_box(&snapshot);
+        set_errorf(error_buffer, error_buffer_size, "failed to allocate source brush %s metadata", operation_name);
+        return false;
+    }
+    SDL_free(old_prefab);
+    box->vertex_count = model->vertex_count;
+    for (int vertex = 0; vertex < model->vertex_count; ++vertex)
+    {
+        box->vertices[vertex][0] = transformed_vertices[vertex * 3];
+        box->vertices[vertex][1] = transformed_vertices[vertex * 3 + 1];
+        box->vertices[vertex][2] = transformed_vertices[vertex * 3 + 2];
+    }
+    for (int vertex = model->vertex_count; vertex < SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY; ++vertex)
+    {
+        box->vertices[vertex][0] = 0;
+        box->vertices[vertex][1] = 0;
+        box->vertices[vertex][2] = 0;
+    }
+    source_box_update_bounds_from_vertices(box);
+
+    if (!source_box_candidate_valid(world_runtime, box, source_index, error_buffer, error_buffer_size) ||
+        !editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+    {
+        free_editor_brush_source_box(box);
+        *box = snapshot;
+        (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+        return false;
+    }
+
+    free_editor_brush_source_box(&snapshot);
+    return true;
+}
+
 bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                          int error_buffer_size)
@@ -3900,6 +3985,70 @@ bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, con
 
     free_editor_brush_source_box(&snapshot);
     return true;
+}
+
+bool editor_brush_world_mirror_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                          slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal, char *error_buffer,
+                                          int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed brush mirror requires a source model");
+        return false;
+    }
+    if (SDL_isnan(plane_point.x) || SDL_isinf(plane_point.x) || SDL_isnan(plane_point.y) || SDL_isinf(plane_point.y) ||
+        SDL_isnan(plane_point.z) || SDL_isinf(plane_point.z) || SDL_isnan(plane_normal.x) ||
+        SDL_isinf(plane_normal.x) || SDL_isnan(plane_normal.y) || SDL_isinf(plane_normal.y) ||
+        SDL_isnan(plane_normal.z) || SDL_isinf(plane_normal.z))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush mirror requires finite plane point and normal");
+        return false;
+    }
+    if (slayer3d_vec3_length_squared(plane_normal) <= 0.000001f)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush mirror requires a non-zero plane normal");
+        return false;
+    }
+    plane_normal = slayer3d_vec3_normalize(plane_normal);
+
+    const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_name);
+    if (source_index < 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush not found");
+        return false;
+    }
+
+    editor_brush_source_vertex_model model;
+    if (!editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model, error_buffer,
+                                                    error_buffer_size))
+    {
+        return false;
+    }
+
+    const float meters_per_unit =
+        world_runtime->editor_source_meters_per_unit > 0.0f ? world_runtime->editor_source_meters_per_unit : 0.001f;
+    const float plane_point_source[3] = {
+        plane_point.x / meters_per_unit,
+        plane_point.y / meters_per_unit,
+        plane_point.z / meters_per_unit,
+    };
+
+    int mirrored_vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    SDL_zeroa(mirrored_vertices);
+    const int snap_units = source_snap_units(world_runtime);
+    for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+    {
+        if (!mirror_source_vertex_coord(model.vertices[vertex].coord, plane_point_source, plane_normal, snap_units,
+                                        mirrored_vertices[vertex]))
+        {
+            set_error(error_buffer, error_buffer_size, "source brush mirror would overflow the source grid");
+            return false;
+        }
+    }
+
+    return editor_brush_world_apply_transformed_source_vertices(world_runtime, source_index, brush_name, &model,
+                                                                &mirrored_vertices[0][0], "mirror", error_buffer,
+                                                                error_buffer_size);
 }
 
 static bool shear_source_side_axis(slayer3d_vec3 side_normal, int *out_axis, float *out_sign)

--- a/src/game_data_brush_source_model.c
+++ b/src/game_data_brush_source_model.c
@@ -3869,6 +3869,83 @@ static bool editor_brush_world_apply_transformed_source_vertices(brush_world_run
     return true;
 }
 
+typedef struct editor_source_box_transform_batch_item
+{
+    int source_index;
+    int vertex_count;
+    int vertices[SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY][3];
+    bool has_snapshot;
+    editor_brush_source_box_runtime snapshot;
+} editor_source_box_transform_batch_item;
+
+static bool editor_source_box_apply_transformed_vertices(editor_brush_source_box_runtime *box, int vertex_count,
+                                                         const int *transformed_vertices, const char *operation_name,
+                                                         char *error_buffer, int error_buffer_size)
+{
+    if (box == NULL || vertex_count <= 0 || vertex_count > SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY ||
+        transformed_vertices == NULL || operation_name == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush transform requires valid source vertices");
+        return false;
+    }
+
+    char *old_prefab = box->prefab;
+    box->prefab = SDL_strdup("convex");
+    if (box->prefab == NULL)
+    {
+        box->prefab = old_prefab;
+        set_errorf(error_buffer, error_buffer_size, "failed to allocate source brush %s metadata", operation_name);
+        return false;
+    }
+    SDL_free(old_prefab);
+    box->vertex_count = vertex_count;
+    for (int vertex = 0; vertex < vertex_count; ++vertex)
+    {
+        box->vertices[vertex][0] = transformed_vertices[vertex * 3];
+        box->vertices[vertex][1] = transformed_vertices[vertex * 3 + 1];
+        box->vertices[vertex][2] = transformed_vertices[vertex * 3 + 2];
+    }
+    for (int vertex = vertex_count; vertex < SLAYER3D_EDITOR_SOURCE_CONVEX_VERTEX_CAPACITY; ++vertex)
+    {
+        box->vertices[vertex][0] = 0;
+        box->vertices[vertex][1] = 0;
+        box->vertices[vertex][2] = 0;
+    }
+    source_box_update_bounds_from_vertices(box);
+    return true;
+}
+
+static void editor_restore_source_box_transform_batch(brush_world_runtime *world_runtime,
+                                                      editor_source_box_transform_batch_item *items, int item_count)
+{
+    if (world_runtime == NULL || items == NULL)
+        return;
+    for (int i = 0; i < item_count; ++i)
+    {
+        if (!items[i].has_snapshot || items[i].source_index < 0 ||
+            items[i].source_index >= world_runtime->editor_source_box_count)
+        {
+            continue;
+        }
+        free_editor_brush_source_box(&world_runtime->editor_source_boxes[items[i].source_index]);
+        world_runtime->editor_source_boxes[items[i].source_index] = items[i].snapshot;
+        SDL_zero(items[i].snapshot);
+        items[i].has_snapshot = false;
+    }
+}
+
+static void editor_free_source_box_transform_batch(editor_source_box_transform_batch_item *items, int item_count)
+{
+    if (items == NULL)
+        return;
+    for (int i = 0; i < item_count; ++i)
+    {
+        if (items[i].has_snapshot)
+            free_editor_brush_source_box(&items[i].snapshot);
+    }
+    SDL_free(items);
+}
+
 bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                          int error_buffer_size)
@@ -4049,6 +4126,144 @@ bool editor_brush_world_mirror_source_box(brush_world_runtime *world_runtime, co
     return editor_brush_world_apply_transformed_source_vertices(world_runtime, source_index, brush_name, &model,
                                                                 &mirrored_vertices[0][0], "mirror", error_buffer,
                                                                 error_buffer_size);
+}
+
+bool editor_brush_world_mirror_source_boxes(brush_world_runtime *world_runtime, const char *const *brush_identities,
+                                            int brush_count, slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal,
+                                            char *error_buffer, int error_buffer_size)
+{
+    if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+    {
+        set_error(error_buffer, error_buffer_size, "source-backed brush mirror requires a source model");
+        return false;
+    }
+    if (brush_identities == NULL || brush_count <= 0)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush mirror requires selected brushes");
+        return false;
+    }
+    if (SDL_isnan(plane_point.x) || SDL_isinf(plane_point.x) || SDL_isnan(plane_point.y) || SDL_isinf(plane_point.y) ||
+        SDL_isnan(plane_point.z) || SDL_isinf(plane_point.z) || SDL_isnan(plane_normal.x) ||
+        SDL_isinf(plane_normal.x) || SDL_isnan(plane_normal.y) || SDL_isinf(plane_normal.y) ||
+        SDL_isnan(plane_normal.z) || SDL_isinf(plane_normal.z))
+    {
+        set_error(error_buffer, error_buffer_size, "source brush mirror requires finite plane point and normal");
+        return false;
+    }
+    if (slayer3d_vec3_length_squared(plane_normal) <= 0.000001f)
+    {
+        set_error(error_buffer, error_buffer_size, "source brush mirror requires a non-zero plane normal");
+        return false;
+    }
+    plane_normal = slayer3d_vec3_normalize(plane_normal);
+
+    editor_source_box_transform_batch_item *items =
+        (editor_source_box_transform_batch_item *)SDL_calloc((size_t)brush_count, sizeof(*items));
+    if (items == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate source brush mirror batch");
+        return false;
+    }
+    for (int i = 0; i < brush_count; ++i)
+        items[i].source_index = -1;
+
+    const float meters_per_unit =
+        world_runtime->editor_source_meters_per_unit > 0.0f ? world_runtime->editor_source_meters_per_unit : 0.001f;
+    const float plane_point_source[3] = {
+        plane_point.x / meters_per_unit,
+        plane_point.y / meters_per_unit,
+        plane_point.z / meters_per_unit,
+    };
+    const int snap_units = source_snap_units(world_runtime);
+
+    for (int i = 0; i < brush_count; ++i)
+    {
+        const char *brush_identity = brush_identities[i];
+        if (brush_identity == NULL || brush_identity[0] == '\0')
+        {
+            set_error(error_buffer, error_buffer_size, "source brush mirror requires brush identities");
+            goto fail;
+        }
+
+        const int source_index = find_editor_source_box_index_by_identity(world_runtime, brush_identity);
+        if (source_index < 0)
+        {
+            set_error(error_buffer, error_buffer_size, "source brush not found");
+            goto fail;
+        }
+        for (int previous = 0; previous < i; ++previous)
+        {
+            if (items[previous].source_index == source_index)
+            {
+                set_error(error_buffer, error_buffer_size, "source brush mirror batch contains duplicate brushes");
+                goto fail;
+            }
+        }
+
+        editor_brush_source_vertex_model model;
+        if (!editor_brush_source_box_build_vertex_model(world_runtime, source_index, &model, error_buffer,
+                                                        error_buffer_size))
+        {
+            goto fail;
+        }
+
+        items[i].source_index = source_index;
+        items[i].vertex_count = model.vertex_count;
+        for (int vertex = 0; vertex < model.vertex_count; ++vertex)
+        {
+            if (!mirror_source_vertex_coord(model.vertices[vertex].coord, plane_point_source, plane_normal, snap_units,
+                                            items[i].vertices[vertex]))
+            {
+                set_error(error_buffer, error_buffer_size, "source brush mirror would overflow the source grid");
+                goto fail;
+            }
+        }
+
+        slayer3d_game_data_brush rebuilt;
+        if (!editor_brush_world_build_source_convex_brush_from_vertices(world_runtime, brush_identity,
+                                                                        &items[i].vertices[0][0], model.vertex_count,
+                                                                        &rebuilt, error_buffer, error_buffer_size))
+        {
+            goto fail;
+        }
+        editor_brush_source_free_runtime_brush(&rebuilt);
+
+        if (!copy_editor_brush_source_box_runtime(&world_runtime->editor_source_boxes[source_index],
+                                                  &items[i].snapshot))
+        {
+            set_error(error_buffer, error_buffer_size, "failed to snapshot source brush mirror");
+            goto fail;
+        }
+        items[i].has_snapshot = true;
+    }
+
+    for (int i = 0; i < brush_count; ++i)
+    {
+        editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[items[i].source_index];
+        if (!editor_source_box_apply_transformed_vertices(box, items[i].vertex_count, &items[i].vertices[0][0],
+                                                          "mirror", error_buffer, error_buffer_size))
+        {
+            goto fail_restore;
+        }
+    }
+    for (int i = 0; i < brush_count; ++i)
+    {
+        editor_brush_source_box_runtime *box = &world_runtime->editor_source_boxes[items[i].source_index];
+        if (!source_box_candidate_valid(world_runtime, box, items[i].source_index, error_buffer, error_buffer_size))
+            goto fail_restore;
+    }
+    if (!editor_brush_world_rebuild_from_source(world_runtime, error_buffer, error_buffer_size))
+        goto fail_restore;
+
+    editor_free_source_box_transform_batch(items, brush_count);
+    return true;
+
+fail_restore:
+    editor_restore_source_box_transform_batch(world_runtime, items, brush_count);
+    (void)editor_brush_world_rebuild_from_source(world_runtime, NULL, 0);
+fail:
+    editor_free_source_box_transform_batch(items, brush_count);
+    return false;
 }
 
 static bool shear_source_side_axis(slayer3d_vec3 side_normal, int *out_axis, float *out_sign)

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -125,6 +125,9 @@ bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, con
 bool editor_brush_world_mirror_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                           slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal, char *error_buffer,
                                           int error_buffer_size);
+bool editor_brush_world_mirror_source_boxes(brush_world_runtime *world_runtime, const char *const *brush_identities,
+                                            int brush_count, slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal,
+                                            char *error_buffer, int error_buffer_size);
 bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_bounding_box bounds, slayer3d_vec3 side_normal, slayer3d_vec3 delta,
                                          char *error_buffer, int error_buffer_size);

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -122,6 +122,9 @@ bool editor_brush_world_rotate_source_box(brush_world_runtime *world_runtime, co
 bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                          int error_buffer_size);
+bool editor_brush_world_mirror_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                          slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal, char *error_buffer,
+                                          int error_buffer_size);
 bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                          slayer3d_bounding_box bounds, slayer3d_vec3 side_normal, slayer3d_vec3 delta,
                                          char *error_buffer, int error_buffer_size);

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1740,6 +1740,7 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
            (SDL_strcmp(entry->command, "rotate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "scale") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           (SDL_strcmp(entry->command, "flip_vertical") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "shear") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "clip") == 0 && SDL_strcmp(entry->target, "selection") == 0) ||
@@ -1930,7 +1931,8 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         sync_editor_selection_after_transaction(runtime, entry, forward);
         return true;
     }
-    if (SDL_strcmp(entry->command, "scale") == 0 || SDL_strcmp(entry->command, "shear") == 0)
+    if (SDL_strcmp(entry->command, "scale") == 0 || SDL_strcmp(entry->command, "flip_vertical") == 0 ||
+        SDL_strcmp(entry->command, "shear") == 0)
     {
         editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
         editor_selection_identity_snapshot active_snapshot;
@@ -3085,6 +3087,103 @@ bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime
         char message[128];
         SDL_snprintf(message, sizeof(message),
                      applied_count == 1 ? "scaled 1 selected brush" : "scaled %d selected brushes", applied_count);
+        slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
+    }
+    if (last_entry != NULL && runtime->editor_selected_brush_count > 0)
+    {
+        runtime->editor_active_selection = runtime->editor_selected_brushes[runtime->editor_selected_brush_count - 1];
+        runtime->editor_selection_scene = active_scene;
+    }
+    return applied_count > 0;
+
+fail:
+    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
+        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int clear = first_entry; clear < history->count; ++clear)
+        free_editor_command_transaction_entry(&history->entries[clear]);
+    history->count = first_entry;
+    history->cursor = first_entry;
+    return false;
+}
+
+bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
+                                                     slayer3d_vec3 plane_normal)
+{
+    if (runtime == NULL || runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+        return false;
+    if (!editor_float_finite(plane_point.x) || !editor_float_finite(plane_point.y) ||
+        !editor_float_finite(plane_point.z) || !editor_float_finite(plane_normal.x) ||
+        !editor_float_finite(plane_normal.y) || !editor_float_finite(plane_normal.z) ||
+        slayer3d_vec3_length_squared(plane_normal) <= 0.000001f)
+    {
+        return false;
+    }
+    const char *active_scene = slayer3d_game_data_active_scene(runtime);
+    if (active_scene == NULL || SDL_strcmp(runtime->editor_selected_brush_scene, active_scene) != 0)
+        return false;
+
+    plane_normal = slayer3d_vec3_normalize(plane_normal);
+    editor_command_history_state *history = &runtime->editor_command_history;
+    const int first_entry = history->count;
+    int applied_count = 0;
+    editor_command_transaction_entry *last_entry = NULL;
+    for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
+    {
+        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
+        if (!transaction_editor_selection_is_selectable_brush(selection))
+            goto fail;
+
+        editor_command_transaction_entry *entry = editor_command_history_append(runtime);
+        if (entry == NULL)
+            goto fail;
+        if (!editor_prepare_transaction_common(entry, active_scene, "flip_vertical", "element", selection->world_name,
+                                               selection->element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+                                            &entry->element_stable_id))
+        {
+            goto fail;
+        }
+        entry->has_bounds = selection->has_bounds;
+        entry->bounds = selection->bounds;
+        SDL_snprintf(entry->message, sizeof(entry->message), "flipped %s vertically", selection->element_name);
+
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection->world_name);
+        if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+            goto fail;
+        const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                         ? entry->element_stable_id
+                                         : entry->element_name;
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity, &entry->source_box_snapshot,
+                                                            &entry->brush_index, NULL, 0))
+        {
+            goto fail;
+        }
+        entry->has_source_box_snapshot = true;
+
+        if (!editor_brush_world_mirror_source_box(world_runtime, brush_identity, plane_point, plane_normal, NULL, 0))
+            goto fail;
+        editor_brush_world_mark_dirty(world_runtime);
+
+        if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity,
+                                                            &entry->source_box_after_snapshot, NULL, NULL, 0))
+        {
+            (void)apply_editor_source_box_snapshot(runtime, entry, &entry->source_box_snapshot);
+            goto fail;
+        }
+        entry->has_source_box_after_snapshot = true;
+
+        refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
+        last_entry = entry;
+        applied_count++;
+    }
+
+    if (runtime->scene_state != NULL)
+    {
+        char message[128];
+        SDL_snprintf(message, sizeof(message),
+                     applied_count == 1 ? "flipped 1 selected brush vertically"
+                                        : "flipped %d selected brushes vertically",
+                     applied_count);
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
     if (last_entry != NULL && runtime->editor_selected_brush_count > 0)

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -3203,10 +3203,8 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
         if (world_runtime == NULL || !world_runtime->editor_has_source_model)
             goto fail;
 
-        const char *brush_identities[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
-        int group_indices[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
-        SDL_zeroa(brush_identities);
-        SDL_zeroa(group_indices);
+        const char *brush_identities[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY] = {0};
+        int group_indices[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY] = {0};
         int group_count = 0;
         for (int j = i; j < entry_count; ++j)
         {

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -375,6 +375,26 @@ static editor_command_transaction_entry *editor_command_history_append(slayer3d_
     return entry;
 }
 
+static int editor_command_transaction_group_start(const editor_command_history_state *history, int index)
+{
+    if (history == NULL || index < 0 || index >= history->count)
+        return index;
+    const int transaction_id = history->entries[index].id;
+    while (index > 0 && history->entries[index - 1].id == transaction_id)
+        index--;
+    return index;
+}
+
+static int editor_command_transaction_group_end(const editor_command_history_state *history, int index)
+{
+    if (history == NULL || index < 0 || index >= history->count)
+        return index;
+    const int transaction_id = history->entries[index].id;
+    while (index + 1 < history->count && history->entries[index + 1].id == transaction_id)
+        index++;
+    return index;
+}
+
 static const char *editor_metadata_stable_id(const slayer3d_game_data_editor_metadata *metadata)
 {
     return metadata != NULL && metadata->stable_id != NULL ? metadata->stable_id : NULL;
@@ -3125,29 +3145,40 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
     plane_normal = slayer3d_vec3_normalize(plane_normal);
     editor_command_history_state *history = &runtime->editor_command_history;
     const int first_entry = history->count;
+    int entry_count = 0;
     int applied_count = 0;
+    bool mutation_applied[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+    bool group_processed[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+    SDL_zeroa(mutation_applied);
+    SDL_zeroa(group_processed);
     editor_command_transaction_entry *last_entry = NULL;
+    int transaction_group_id = -1;
     for (int i = 0; i < runtime->editor_selected_brush_count; ++i)
     {
-        const slayer3d_game_data_editor_selection *selection = &runtime->editor_selected_brushes[i];
-        if (!transaction_editor_selection_is_selectable_brush(selection))
+        slayer3d_game_data_editor_selection selection =
+            resolved_editor_selection(runtime, &runtime->editor_selected_brushes[i]);
+        if (!transaction_editor_selection_is_selectable_brush(&selection))
             goto fail;
 
         editor_command_transaction_entry *entry = editor_command_history_append(runtime);
         if (entry == NULL)
             goto fail;
-        if (!editor_prepare_transaction_common(entry, active_scene, "flip_vertical", "element", selection->world_name,
-                                               selection->element_name) ||
-            !copy_editor_transaction_string(editor_metadata_stable_id(selection->element_editor),
+        if (transaction_group_id < 0)
+            transaction_group_id = entry->id;
+        else
+            entry->id = transaction_group_id;
+        if (!editor_prepare_transaction_common(entry, active_scene, "flip_vertical", "element", selection.world_name,
+                                               selection.element_name) ||
+            !copy_editor_transaction_string(editor_metadata_stable_id(selection.element_editor),
                                             &entry->element_stable_id))
         {
             goto fail;
         }
-        entry->has_bounds = selection->has_bounds;
-        entry->bounds = selection->bounds;
-        SDL_snprintf(entry->message, sizeof(entry->message), "flipped %s vertically", selection->element_name);
+        entry->has_bounds = selection.has_bounds;
+        entry->bounds = selection.bounds;
+        SDL_snprintf(entry->message, sizeof(entry->message), "flipped %s vertically", selection.element_name);
 
-        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection->world_name);
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection.world_name);
         if (world_runtime == NULL || !world_runtime->editor_has_source_model)
             goto fail;
         const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
@@ -3159,11 +3190,64 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
             goto fail;
         }
         entry->has_source_box_snapshot = true;
+        entry_count++;
+    }
 
-        if (!editor_brush_world_mirror_source_box(world_runtime, brush_identity, plane_point, plane_normal, NULL, 0))
+    for (int i = 0; i < entry_count; ++i)
+    {
+        if (group_processed[i])
+            continue;
+
+        editor_command_transaction_entry *entry = &history->entries[first_entry + i];
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, entry->world_name);
+        if (world_runtime == NULL || !world_runtime->editor_has_source_model)
             goto fail;
-        editor_brush_world_mark_dirty(world_runtime);
 
+        const char *brush_identities[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        int group_indices[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
+        SDL_zeroa(brush_identities);
+        SDL_zeroa(group_indices);
+        int group_count = 0;
+        for (int j = i; j < entry_count; ++j)
+        {
+            editor_command_transaction_entry *candidate = &history->entries[first_entry + j];
+            if (group_processed[j] || candidate->world_name == NULL ||
+                SDL_strcmp(candidate->world_name, entry->world_name) != 0)
+            {
+                continue;
+            }
+            brush_identities[group_count] =
+                candidate->element_stable_id != NULL && candidate->element_stable_id[0] != '\0'
+                    ? candidate->element_stable_id
+                    : candidate->element_name;
+            group_indices[group_count] = j;
+            group_count++;
+        }
+
+        if (group_count <= 0 || !editor_brush_world_mirror_source_boxes(world_runtime, brush_identities, group_count,
+                                                                        plane_point, plane_normal, NULL, 0))
+        {
+            goto fail;
+        }
+        editor_brush_world_mark_dirty(world_runtime);
+        for (int group = 0; group < group_count; ++group)
+        {
+            const int entry_index = group_indices[group];
+            mutation_applied[entry_index] = true;
+            group_processed[entry_index] = true;
+            applied_count++;
+        }
+    }
+
+    for (int i = 0; i < entry_count; ++i)
+    {
+        editor_command_transaction_entry *entry = &history->entries[first_entry + i];
+        brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, entry->world_name);
+        if (world_runtime == NULL || !world_runtime->editor_has_source_model)
+            goto fail;
+        const char *brush_identity = entry->element_stable_id != NULL && entry->element_stable_id[0] != '\0'
+                                         ? entry->element_stable_id
+                                         : entry->element_name;
         if (!editor_brush_world_copy_source_box_by_identity(world_runtime, brush_identity,
                                                             &entry->source_box_after_snapshot, NULL, NULL, 0))
         {
@@ -3174,7 +3258,6 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
 
         refresh_selected_editor_brush_bounds_for_transaction(runtime, entry, i);
         last_entry = entry;
-        applied_count++;
     }
 
     if (runtime->scene_state != NULL)
@@ -3194,8 +3277,14 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
     return applied_count > 0;
 
 fail:
-    for (int rollback = first_entry + applied_count - 1; rollback >= first_entry; --rollback)
-        (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
+    for (int rollback = entry_count - 1; rollback >= 0; --rollback)
+    {
+        if (mutation_applied[rollback])
+        {
+            editor_command_transaction_entry *entry = &history->entries[first_entry + rollback];
+            (void)apply_editor_source_box_snapshot(runtime, entry, &entry->source_box_snapshot);
+        }
+    }
     for (int clear = first_entry; clear < history->count; ++clear)
         free_editor_command_transaction_entry(&history->entries[clear]);
     history->count = first_entry;
@@ -3445,14 +3534,27 @@ bool slayer3d_game_data_undo_editor_command(slayer3d_game_data_runtime *runtime,
         return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "undo", false, NULL, message);
     }
 
-    editor_command_transaction_entry *entry = &history->entries[history->cursor - 1];
-    if (!apply_editor_transaction_mutation(runtime, entry, false))
+    const int group_end = history->cursor - 1;
+    const int group_start = editor_command_transaction_group_start(history, group_end);
+    editor_command_transaction_entry *entry = &history->entries[group_end];
+    int failed_index = -1;
+    for (int i = group_end; i >= group_start; --i)
     {
+        if (!apply_editor_transaction_mutation(runtime, &history->entries[i], false))
+        {
+            failed_index = i;
+            break;
+        }
+    }
+    if (failed_index >= 0)
+    {
+        for (int rollback = failed_index + 1; rollback <= group_end; ++rollback)
+            (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], true);
         const char *message = json_string(action, "invalid_message", "editor command undo failed");
         publish_editor_transaction(runtime, outputs, "undo", false, NULL, message);
         return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "undo", false, NULL, message);
     }
-    history->cursor--;
+    history->cursor = group_start;
     char message[128];
     format_editor_transaction_message(runtime, "undo", true, entry,
                                       json_string(action, "message", "undo {editor_command}"), message,
@@ -3476,14 +3578,27 @@ bool slayer3d_game_data_redo_editor_command(slayer3d_game_data_runtime *runtime,
         return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "redo", false, NULL, message);
     }
 
-    editor_command_transaction_entry *entry = &history->entries[history->cursor];
-    if (!apply_editor_transaction_mutation(runtime, entry, true))
+    const int group_start = history->cursor;
+    const int group_end = editor_command_transaction_group_end(history, group_start);
+    editor_command_transaction_entry *entry = &history->entries[group_start];
+    int failed_index = -1;
+    for (int i = group_start; i <= group_end; ++i)
     {
+        if (!apply_editor_transaction_mutation(runtime, &history->entries[i], true))
+        {
+            failed_index = i;
+            break;
+        }
+    }
+    if (failed_index >= 0)
+    {
+        for (int rollback = failed_index - 1; rollback >= group_start; --rollback)
+            (void)apply_editor_transaction_mutation(runtime, &history->entries[rollback], false);
         const char *message = json_string(action, "invalid_message", "editor command redo failed");
         publish_editor_transaction(runtime, outputs, "redo", false, NULL, message);
         return run_editor_transaction_action_array(runtime, obj_get(action, "else"), "redo", false, NULL, message);
     }
-    history->cursor++;
+    history->cursor = group_end + 1;
     char message[128];
     format_editor_transaction_message(runtime, "redo", true, entry,
                                       json_string(action, "message", "redo {editor_command}"), message,

--- a/src/game_data_editor_grid_widget.c
+++ b/src/game_data_editor_grid_widget.c
@@ -76,8 +76,12 @@ bool editor_handle_grid_widget(slayer3d_game_data_runtime *runtime, yyjson_val *
     const bool over_retained_button =
         retained_hit != NULL && SDL_strcmp(retained_hit->id, EDITOR_GRID_DROPDOWN_ID) == 0;
     const bool over_retained_option = retained_hit != NULL && retained_hit->option_index >= 0;
-    const bool over_button = over_retained_button || editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "button"));
-    const bool over_popup = over_retained_option || editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "popup"));
+    const bool use_legacy_hit_rects = retained_hit == NULL;
+    const bool over_button =
+        over_retained_button ||
+        (use_legacy_hit_rects && editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "button")));
+    const bool over_popup = over_retained_option ||
+                            (use_legacy_hit_rects && editor_mouse_in_rect(mouse_x, mouse_y, obj_get(widget, "popup")));
     if (!left_pressed)
     {
         if (out_consumed != NULL)

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -152,6 +152,8 @@ bool slayer3d_game_data_rotate_selected_editor_brushes(slayer3d_game_data_runtim
                                                        slayer3d_vec3 axis, float angle_radians);
 bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
                                                       slayer3d_vec3 factors);
+bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
+                                                     slayer3d_vec3 plane_normal);
 bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_bounding_box bounds,
                                                       slayer3d_vec3 side_normal, slayer3d_vec3 delta);
 bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -184,7 +184,19 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
 static bool editor_apply_tool_action(slayer3d_game_data_runtime *runtime, const char *action)
 {
     const char *mode = editor_mode_for_tool_action(action);
-    return mode != NULL && slayer3d_game_data_set_editor_tool_mode(runtime, mode, NULL);
+    if (mode != NULL)
+        return slayer3d_game_data_set_editor_tool_mode(runtime, mode, NULL);
+    if (runtime != NULL && SDL_strcmp(action, "editor.brush.flip_vertical") == 0)
+    {
+        slayer3d_signal_bus *bus = runtime_bus(runtime);
+        const int signal_id = slayer3d_game_data_find_signal(runtime, "signal.editor.brush.flip_vertical");
+        if (bus != NULL && signal_id >= 0)
+        {
+            slayer3d_signal_emit(bus, signal_id, NULL);
+            return true;
+        }
+    }
+    return false;
 }
 
 bool editor_handle_tool_mode_buttons(slayer3d_game_data_runtime *runtime, yyjson_val *editor, bool *out_consumed)

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -988,6 +988,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.selection.resize_y", validate_editor_selection_resize_y_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.rotate_selected", validate_editor_selection_rotate_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.scale_selected", validate_editor_selection_scale_selected_action),
+        ACTION_RULE_EXACT_HANDLER("editor.selection.flip_vertical", validate_editor_selection_flip_vertical_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.shear_selected", validate_editor_selection_shear_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.run", validate_editor_selection_run_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.preview", validate_editor_command_preview_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -383,6 +383,44 @@ bool validate_editor_selection_scale_selected_action(validation_context *ctx, yy
     return true;
 }
 
+bool validate_editor_selection_flip_vertical_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                    validation_names *names, const char *type)
+{
+    (void)names;
+    (void)type;
+    yyjson_val *pivot = obj_get(action, "pivot");
+    if (pivot != NULL && !is_vec_array(pivot, 3))
+        return validation_error(ctx, json_path, "editor.selection.flip_vertical pivot must be a numeric vec3");
+    yyjson_val *normal = obj_get(action, "normal");
+    if (normal != NULL)
+    {
+        if (!is_vec_array(normal, 3))
+            return validation_error(ctx, json_path, "editor.selection.flip_vertical normal must be a numeric vec3");
+        const float normal_x = (float)yyjson_get_num(yyjson_arr_get(normal, 0));
+        const float normal_y = (float)yyjson_get_num(yyjson_arr_get(normal, 1));
+        const float normal_z = (float)yyjson_get_num(yyjson_arr_get(normal, 2));
+        if (!validation_float_finite(normal_x) || !validation_float_finite(normal_y) ||
+            !validation_float_finite(normal_z) ||
+            normal_x * normal_x + normal_y * normal_y + normal_z * normal_z <= 0.000001f)
+        {
+            return validation_error(ctx, json_path,
+                                    "editor.selection.flip_vertical normal must be non-zero and finite");
+        }
+    }
+    static const char *const string_fields[] = {"normal_key", "view_mode_key", "top_mode",
+                                                "front_mode", "side_mode",     "flyby_mode"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        yyjson_val *field = obj_get(action, string_fields[i]);
+        if (field != NULL && (!yyjson_is_str(field) || yyjson_get_str(field)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.selection.flip_vertical %s must be a non-empty string",
+                                    string_fields[i]);
+    }
+    static const char *const output_keys[] = {"valid_key", "message_key", "axis_key", "center_key"};
+    return validate_optional_output_keys(ctx, action, json_path, "editor.selection.flip_vertical", output_keys,
+                                         SDL_arraysize(output_keys));
+}
+
 bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type)
 {

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -31,6 +31,8 @@ bool validate_editor_selection_rotate_selected_action(validation_context *ctx, y
                                                       const char *json_path, validation_names *names, const char *type);
 bool validate_editor_selection_scale_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type);
+bool validate_editor_selection_flip_vertical_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                                    validation_names *names, const char *type);
 bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type);
 bool validate_editor_selection_run_action(validation_context *ctx, yyjson_val *action, const char *json_path,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -220,6 +220,9 @@ extern "C"
     bool editor_brush_world_scale_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                              slayer3d_vec3 anchor, slayer3d_vec3 factors, char *error_buffer,
                                              int error_buffer_size);
+    bool editor_brush_world_mirror_source_box(brush_world_runtime *world_runtime, const char *brush_name,
+                                              slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal, char *error_buffer,
+                                              int error_buffer_size);
     bool editor_brush_world_shear_source_box(brush_world_runtime *world_runtime, const char *brush_name,
                                              slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
                                              slayer3d_vec3 delta, char *error_buffer, int error_buffer_size);
@@ -308,6 +311,8 @@ extern "C"
                                                            slayer3d_vec3 axis, float angle_radians);
     bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 anchor,
                                                           slayer3d_vec3 factors);
+    bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
+                                                         slayer3d_vec3 plane_normal);
     bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime,
                                                           slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
                                                           slayer3d_vec3 delta);
@@ -22461,6 +22466,38 @@ TEST(GameDataRuntime, EditorShellDojoBrushHistoryRestoresSourceRuntimeAndSelecti
     ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
     EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.z, -1.0f, 0.001f);
     EXPECT_NEAR(active_selection().bounds.max.z, -1.0f, 0.001f);
+
+    ASSERT_TRUE(slayer3d_game_data_flip_selected_editor_brushes(runtime, slayer3d_vec3_make(0.0f, 2.0f, 0.0f),
+                                                                slayer3d_vec3_make(0.0f, 1.0f, 0.0f)));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.y, 3.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.y, 4.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.min.y, 3.0f, 0.001f);
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "flipped 1 selected brush vertically");
+    ASSERT_TRUE(editor_brush_world_copy_source_box_by_identity(source_world_runtime, brush_name.c_str(), &scaled_source,
+                                                               nullptr, error, sizeof(error)))
+        << error;
+    EXPECT_EQ(scaled_source.vertex_count, 8);
+    free_editor_brush_source_box_runtime(&scaled_source);
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.y, 0.0f, 0.001f);
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).max.y, 1.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.max.y, 1.0f, 0.001f);
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    EXPECT_NEAR(brush_bounds(brush_name.c_str()).min.y, 3.0f, 0.001f);
+    EXPECT_NEAR(active_selection().bounds.min.y, 3.0f, 0.001f);
+
+    slayer3d_properties *mutable_scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    ASSERT_NE(mutable_scene_state, nullptr);
+    slayer3d_properties_set_string(mutable_scene_state, "editor.view.mode", "orthographic_top");
+    slayer3d_signal_bus *flip_bus = slayer3d_game_session_get_signal_bus(session);
+    ASSERT_NE(flip_bus, nullptr);
+    const int flip_signal = slayer3d_game_data_find_signal(runtime, "signal.editor.brush.flip_vertical");
+    ASSERT_GE(flip_signal, 0);
+    slayer3d_signal_emit(flip_bus, flip_signal, nullptr);
+    ASSERT_TRUE(slayer3d_game_data_update(runtime, 0.016f));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_vertical.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.flip_vertical.axis", ""), "-Z");
     ASSERT_TRUE(slayer3d_game_data_set_editor_tool_mode(runtime, "select", nullptr));
 
     ASSERT_TRUE(

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -20144,11 +20144,19 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "shear");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "shear");
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    click_editor(934.0f, 60.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 116);
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_vertical.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.flip_vertical.message", ""),
+                 "flipped selected brushes vertically around +Y");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "flipped 1 selected brush vertically");
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
     slayer3d_signal_emit(bus, escape_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "select");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "select");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 1);
-    move_editor_mouse(660.0f, 360.0f, 116);
+    move_editor_mouse(660.0f, 360.0f, 117);
     slayer3d_signal_emit(bus, mode_clip_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "clip");
     EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.clip.selected_count", 0), 1);
@@ -20201,7 +20209,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
     std::vector<std::string> grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 1"));
-    click_editor(900.0f, 54.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 4);
+    click_editor(990.0f, 54.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 4);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
     grid_toolbar_text = visible_ui_text("ui.editor_shell.tool_toolbar.grid.");
     EXPECT_TRUE(contains_ui_text(grid_toolbar_text, "Grid 16"));
@@ -20259,7 +20267,7 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     ASSERT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_grid_dropdown_rects, &grid_rects));
     EXPECT_TRUE(grid_rects.hovered_option);
     EXPECT_EQ(grid_rects.hovered_option_rect.color.a, 248);
-    click_editor(900.0f, 208.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
+    click_editor(990.0f, 208.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 5);
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", true));
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.grid.size", 0.0f), 4.0f, 0.001f);
     EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.brush.grid_size", 0.0f), 4.0f, 0.001f);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -22087,6 +22087,148 @@ TEST(GameDataRuntime, EditorShellDojoBrushKeyboardNudgeUsesCameraRelativeDirecti
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoVerticalFlipToolbarMirrorsMultiSelection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    editor_brush_source_prefab_result slab_result{};
+    const int slab_min[3] = {-1500, 0, -1500};
+    const int slab_max[3] = {1500, 200, 1500};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, slab_min,
+        slab_max, &slab_result));
+    ASSERT_TRUE(slab_result.valid);
+    ASSERT_STRNE(slab_result.brush_name, "");
+
+    editor_brush_source_prefab_result cube_result{};
+    const int cube_min[3] = {-500, 200, -500};
+    const int cube_max[3] = {500, 1200, 500};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, cube_min,
+        cube_max, &cube_result));
+    ASSERT_TRUE(cube_result.valid);
+    ASSERT_STRNE(cube_result.brush_name, "");
+
+    auto brush_world = [&]() {
+        slayer3d_game_data_brush_world world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+        return world;
+    };
+    auto brush_index = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return i;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return -1;
+    };
+    auto brush_bounds = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return slayer3d_bounding_box{};
+    };
+    auto click_editor = [&](float x, float y, Uint64 frame) {
+        SDL_Event click_motion{};
+        click_motion.type = SDL_EVENT_MOUSE_MOTION;
+        click_motion.motion.x = x;
+        click_motion.motion.y = y;
+        SDL_Event mouse_down{};
+        mouse_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+        mouse_down.button.button = SDL_BUTTON_LEFT;
+        mouse_down.button.x = x;
+        mouse_down.button.y = y;
+        slayer3d_input_process_event(input, &click_motion);
+        slayer3d_input_process_event(input, &mouse_down);
+        slayer3d_input_update(input, frame);
+        EXPECT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+        mouse_down.type = SDL_EVENT_MOUSE_BUTTON_UP;
+        slayer3d_input_process_event(input, &mouse_down);
+        slayer3d_input_update(input, frame + 1U);
+    };
+
+    slayer3d_game_data_editor_selection slab_selection{};
+    slayer3d_game_data_editor_selection cube_selection{};
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(slab_result.brush_name), -1, &slab_selection));
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(cube_result.brush_name), -1, &cube_selection));
+
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &slab_selection));
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &cube_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.multiple", false));
+
+    const slayer3d_bounding_box slab_before = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_before = brush_bounds(cube_result.brush_name);
+    ASSERT_NEAR(slab_before.min.y, 0.0f, 0.001f);
+    ASSERT_NEAR(slab_before.max.y, 0.2f, 0.001f);
+    ASSERT_NEAR(cube_before.min.y, 0.2f, 0.001f);
+    ASSERT_NEAR(cube_before.max.y, 1.2f, 0.001f);
+
+    click_editor(934.0f, 60.0f, 200);
+
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_vertical.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.flip_vertical.message", ""),
+                 "flipped selected brushes vertically around +Y");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "flipped 2 selected brushes vertically");
+
+    const slayer3d_bounding_box slab_after = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_after = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_after.min.y, 1.0f, 0.001f);
+    EXPECT_NEAR(slab_after.max.y, 1.2f, 0.001f);
+    EXPECT_NEAR(cube_after.min.y, 0.0f, 0.001f);
+    EXPECT_NEAR(cube_after.max.y, 1.0f, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    const slayer3d_bounding_box slab_undo = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_undo = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_undo.min.y, slab_before.min.y, 0.001f);
+    EXPECT_NEAR(slab_undo.max.y, slab_before.max.y, 0.001f);
+    EXPECT_NEAR(cube_undo.min.y, cube_before.min.y, 0.001f);
+    EXPECT_NEAR(cube_undo.max.y, cube_before.max.y, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    const slayer3d_bounding_box slab_redo = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_redo = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_redo.min.y, slab_after.min.y, 0.001f);
+    EXPECT_NEAR(slab_redo.max.y, slab_after.max.y, 0.001f);
+    EXPECT_NEAR(cube_redo.min.y, cube_after.min.y, 0.001f);
+    EXPECT_NEAR(cube_redo.max.y, cube_after.max.y, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoBrushDuplicationPreservesSourceAndSelection)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();


### PR DESCRIPTION
## Summary
- Add source-brush mirror support and an editor `Flip V` toolbar action for selected brushes.
- Resolve vertical flip pivots from current selected-brush metadata so stale selection bounds do not drive transforms.
- Apply vertical flips to selected source brushes as an atomic batch, which fixes slab-plus-cube and other multi-selection flips that temporarily overlap during one-at-a-time transforms.
- Preserve per-brush transaction snapshots while grouping same-operation undo/redo, so one flip click undoes/redoes as one editor command.
- Keep the Flip V toolbar hit test separate from the grid dropdown, and update the Windows MSVC static CI job to use Ninja instead of a pinned Visual Studio generator.

Closes #451

## Tests
- `./build/debug/tests/slayer3d_game_data_test --gtest_filter=GameDataRuntime.EditorShellDojoVerticalFlipToolbarMirrorsMultiSelection`
- `./build/debug/tests/slayer3d_game_data_test`
- `cmake --build build/debug --target slayer3d_editor -j 8`
- `git diff --check`