### PR TITLE
Editor: add horizontal flip tool

### DIFF
--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -74,6 +74,10 @@
             "bindings": [{ "device": "keyboard", "key": "RIGHTBRACKET" }]
           },
           {
+            "name": "action.editor.brush.flip_horizontal",
+            "bindings": []
+          },
+          {
             "name": "action.editor.brush.flip_vertical",
             "bindings": []
           },
@@ -276,6 +280,7 @@
     "signal.editor.delete_selected",
     "signal.editor.brush.lower_y",
     "signal.editor.brush.raise_y",
+    "signal.editor.brush.flip_horizontal",
     "signal.editor.brush.flip_vertical",
     "signal.editor.command.undo",
     "signal.editor.command.redo",
@@ -364,6 +369,11 @@
         "type": "sensor.input_pressed",
         "action": "action.editor.brush.raise_y",
         "on_pressed": "signal.editor.brush.raise_y"
+      },
+      {
+        "type": "sensor.input_pressed",
+        "action": "action.editor.brush.flip_horizontal",
+        "on_pressed": "signal.editor.brush.flip_horizontal"
       },
       {
         "type": "sensor.input_pressed",
@@ -1417,6 +1427,56 @@
                 "type": "scene_state.set",
                 "key": "editor.tool.last_action",
                 "value": "select brushes before raising"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "signal": "signal.editor.brush.flip_horizontal",
+        "actions": [
+          {
+            "type": "branch",
+            "if": {
+              "type": "all",
+              "conditions": [
+                {
+                  "type": "any",
+                  "conditions": [
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "select", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "brush", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "face", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "rotate", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "scale", "default": "select" },
+                    { "type": "scene_state.compare", "key": "editor.mode", "op": "==", "value": "shear", "default": "select" }
+                  ]
+                },
+                {
+                  "type": "scene_state.compare",
+                  "key": "editor.selection.count",
+                  "op": ">",
+                  "value": 0,
+                  "default": 0
+                }
+              ]
+            },
+            "then": [
+              {
+                "type": "editor.selection.flip_horizontal",
+                "view_mode_key": "editor.view.mode",
+                "outputs": {
+                  "valid_key": "editor.flip_horizontal.valid",
+                  "message_key": "editor.flip_horizontal.message",
+                  "axis_key": "editor.flip_horizontal.axis",
+                  "center_key": "editor.flip_horizontal.center"
+                }
+              }
+            ],
+            "else": [
+              {
+                "type": "scene_state.set",
+                "key": "editor.tool.last_action",
+                "value": "select brushes before horizontal flip"
               }
             ]
           }

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -36,6 +36,7 @@
       "action.editor.clip.cycle_keep_mode",
       "action.editor.brush.lower_y",
       "action.editor.brush.raise_y",
+      "action.editor.brush.flip_horizontal",
       "action.editor.brush.flip_vertical",
       "action.editor.palette.material",
       "action.editor.palette.game_object",
@@ -554,9 +555,18 @@
             "selected_if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "shear" }
           },
           {
+            "id": "ui.editor_shell.tool_toolbar.flip_horizontal.button",
+            "type": "button",
+            "w": 60,
+            "h": 28,
+            "text": "Flip H",
+            "interactive": true,
+            "action": "editor.brush.flip_horizontal"
+          },
+          {
             "id": "ui.editor_shell.tool_toolbar.flip_vertical.button",
             "type": "button",
-            "w": 84,
+            "w": 60,
             "h": 28,
             "text": "Flip V",
             "interactive": true,

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -344,6 +344,61 @@ static const char *editor_flip_axis_label(slayer3d_vec3 normal)
     return normal.z >= 0.0f ? "+Z" : "-Z";
 }
 
+static slayer3d_vec3 editor_flip_dominant_axis_vector(slayer3d_vec3 v)
+{
+    const float abs_x = SDL_fabsf(v.x);
+    const float abs_y = SDL_fabsf(v.y);
+    const float abs_z = SDL_fabsf(v.z);
+    if (abs_x >= abs_y && abs_x >= abs_z)
+        return slayer3d_vec3_make(v.x < 0.0f ? -1.0f : 1.0f, 0.0f, 0.0f);
+    if (abs_y >= abs_x && abs_y >= abs_z)
+        return slayer3d_vec3_make(0.0f, v.y < 0.0f ? -1.0f : 1.0f, 0.0f);
+    return slayer3d_vec3_make(0.0f, 0.0f, v.z < 0.0f ? -1.0f : 1.0f);
+}
+
+static bool editor_flip_vec3_same_direction(slayer3d_vec3 a, slayer3d_vec3 b)
+{
+    return SDL_fabsf(a.x - b.x) <= 0.0001f && SDL_fabsf(a.y - b.y) <= 0.0001f && SDL_fabsf(a.z - b.z) <= 0.0001f;
+}
+
+static slayer3d_vec3 editor_flip_perspective_forward_axis(slayer3d_vec3 forward, slayer3d_vec3 up)
+{
+    slayer3d_vec3 projected = slayer3d_vec3_make(forward.x, 0.0f, forward.z);
+    if (slayer3d_vec3_length_squared(projected) <= 0.000001f)
+    {
+        projected = slayer3d_vec3_make(up.x, 0.0f, up.z);
+        if (forward.y > 0.0f)
+            projected = slayer3d_vec3_negate(projected);
+    }
+    if (slayer3d_vec3_length_squared(projected) <= 0.000001f)
+        return slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    return editor_flip_dominant_axis_vector(projected);
+}
+
+static slayer3d_vec3 editor_flip_perspective_right_axis(slayer3d_vec3 right, slayer3d_vec3 forward_axis)
+{
+    slayer3d_vec3 axis = editor_flip_dominant_axis_vector(right);
+    if (editor_flip_vec3_same_direction(axis, forward_axis))
+    {
+        axis = slayer3d_vec3_cross(axis, slayer3d_vec3_make(0.0f, 1.0f, 0.0f));
+        if (slayer3d_vec3_length_squared(axis) <= 0.000001f)
+            axis = slayer3d_vec3_make(0.0f, 0.0f, 1.0f);
+    }
+    return editor_flip_dominant_axis_vector(axis);
+}
+
+static bool editor_flip_normal_valid(slayer3d_vec3 normal, const char *adjective, char *message, size_t message_size)
+{
+    if (SDL_isnan(normal.x) || SDL_isinf(normal.x) || SDL_isnan(normal.y) || SDL_isinf(normal.y) ||
+        SDL_isnan(normal.z) || SDL_isinf(normal.z) || slayer3d_vec3_length_squared(normal) <= 0.000001f)
+    {
+        if (message != NULL && message_size > 0u)
+            SDL_snprintf(message, message_size, "%s flip requires a finite non-zero normal", adjective);
+        return false;
+    }
+    return true;
+}
+
 static bool editor_selection_flip_vertical_normal(slayer3d_game_data_runtime *runtime, yyjson_val *action,
                                                   slayer3d_vec3 *out_normal, const char **out_axis_label, char *message,
                                                   size_t message_size)
@@ -394,13 +449,88 @@ static bool editor_selection_flip_vertical_normal(slayer3d_game_data_runtime *ru
         }
     }
 
-    if (SDL_isnan(normal.x) || SDL_isinf(normal.x) || SDL_isnan(normal.y) || SDL_isinf(normal.y) ||
-        SDL_isnan(normal.z) || SDL_isinf(normal.z) || slayer3d_vec3_length_squared(normal) <= 0.000001f)
-    {
-        if (message != NULL && message_size > 0u)
-            SDL_strlcpy(message, "vertical flip requires a finite non-zero normal", message_size);
+    if (!editor_flip_normal_valid(normal, "vertical", message, message_size))
         return false;
+    normal = slayer3d_vec3_normalize(normal);
+    *out_normal = normal;
+    if (out_axis_label != NULL)
+        *out_axis_label = editor_flip_axis_label(normal);
+    return true;
+}
+
+static bool editor_selection_flip_horizontal_normal(slayer3d_game_data_runtime *runtime, yyjson_val *action,
+                                                    slayer3d_vec3 *out_normal, const char **out_axis_label,
+                                                    char *message, size_t message_size)
+{
+    if (out_normal == NULL)
+        return false;
+    if (message != NULL && message_size > 0u)
+        message[0] = '\0';
+
+    slayer3d_vec3 normal = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    if (obj_get(action, "normal") != NULL)
+    {
+        normal = json_vec3(action, "normal", normal);
     }
+    else
+    {
+        const char *normal_key = json_string(action, "normal_key", NULL);
+        const slayer3d_value *normal_value =
+            runtime != NULL && runtime->scene_state != NULL && normal_key != NULL && normal_key[0] != '\0'
+                ? slayer3d_properties_get_value(runtime->scene_state, normal_key)
+                : NULL;
+        if (normal_value != NULL && normal_value->type == SLAYER3D_VALUE_VEC3)
+        {
+            normal = normal_value->as_vec3;
+        }
+        else
+        {
+            slayer3d_vec3 forward;
+            slayer3d_vec3 right;
+            slayer3d_vec3 up;
+            bool orthographic = false;
+            if (editor_camera_basis(runtime, &forward, &right, &up, &orthographic))
+            {
+                if (orthographic)
+                    normal = editor_flip_dominant_axis_vector(right);
+                else
+                {
+                    const slayer3d_vec3 forward_axis = editor_flip_perspective_forward_axis(forward, up);
+                    normal = editor_flip_perspective_right_axis(right, forward_axis);
+                }
+            }
+            else
+            {
+                const char *view_mode_key = json_string(action, "view_mode_key", "editor.view.mode");
+                const char *view_mode =
+                    runtime != NULL && runtime->scene_state != NULL && view_mode_key != NULL && view_mode_key[0] != '\0'
+                        ? slayer3d_properties_get_string(runtime->scene_state, view_mode_key, "flyby_3d")
+                        : "flyby_3d";
+                const char *top_mode = json_string(action, "top_mode", "orthographic_top");
+                const char *front_mode = json_string(action, "front_mode", "orthographic_front");
+                const char *side_mode = json_string(action, "side_mode", "orthographic_side");
+                const char *flyby_mode = json_string(action, "flyby_mode", "flyby_3d");
+                if (SDL_strcmp(view_mode, top_mode) == 0 || SDL_strcmp(view_mode, front_mode) == 0 ||
+                    SDL_strcmp(view_mode, flyby_mode) == 0)
+                {
+                    normal = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+                }
+                else if (SDL_strcmp(view_mode, side_mode) == 0)
+                {
+                    normal = slayer3d_vec3_make(0.0f, 0.0f, -1.0f);
+                }
+                else
+                {
+                    if (message != NULL && message_size > 0u)
+                        SDL_snprintf(message, message_size, "horizontal flip unsupported for view '%s'", view_mode);
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (!editor_flip_normal_valid(normal, "horizontal", message, message_size))
+        return false;
     normal = slayer3d_vec3_normalize(normal);
     *out_normal = normal;
     if (out_axis_label != NULL)
@@ -442,6 +572,50 @@ static bool editor_selection_flip_vertical_action(slayer3d_game_data_runtime *ru
     const bool flipped = slayer3d_game_data_flip_selected_editor_brushes(runtime, pivot, normal);
     SDL_snprintf(message, sizeof(message),
                  flipped ? "flipped selected brushes vertically around %s" : "vertical flip failed around %s",
+                 axis_label);
+    editor_set_bool_output(scene_state, outputs, "valid_key", flipped);
+    editor_set_string_output(scene_state, outputs, "message_key", message);
+    editor_set_string_output(scene_state, outputs, "axis_key", axis_label);
+    editor_set_vec3_output(scene_state, outputs, "center_key", pivot);
+    if (scene_state != NULL && !flipped)
+        slayer3d_properties_set_string(scene_state, "editor.tool.last_action", message);
+    return flipped;
+}
+
+static bool editor_selection_flip_horizontal_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    slayer3d_vec3 pivot = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    if (obj_get(action, "pivot") != NULL)
+        pivot = json_vec3(action, "pivot", pivot);
+    else if (!editor_selected_brushes_bounds_center(runtime, &pivot))
+    {
+        editor_set_bool_output(scene_state, outputs, "valid_key", false);
+        editor_set_string_output(scene_state, outputs, "message_key", "select brushes before horizontal flip");
+        if (scene_state != NULL)
+            slayer3d_properties_set_string(scene_state, "editor.tool.last_action",
+                                           "select brushes before horizontal flip");
+        return false;
+    }
+
+    slayer3d_vec3 normal = slayer3d_vec3_make(1.0f, 0.0f, 0.0f);
+    const char *axis_label = "+X";
+    char message[128];
+    if (!editor_selection_flip_horizontal_normal(runtime, action, &normal, &axis_label, message, sizeof(message)))
+    {
+        editor_set_bool_output(scene_state, outputs, "valid_key", false);
+        editor_set_string_output(scene_state, outputs, "message_key",
+                                 message[0] != '\0' ? message : "horizontal flip failed");
+        if (scene_state != NULL)
+            slayer3d_properties_set_string(scene_state, "editor.tool.last_action",
+                                           message[0] != '\0' ? message : "horizontal flip failed");
+        return false;
+    }
+
+    const bool flipped = slayer3d_game_data_flip_selected_editor_brushes_horizontal(runtime, pivot, normal);
+    SDL_snprintf(message, sizeof(message),
+                 flipped ? "flipped selected brushes horizontally around %s" : "horizontal flip failed around %s",
                  axis_label);
     editor_set_bool_output(scene_state, outputs, "valid_key", flipped);
     editor_set_string_output(scene_state, outputs, "message_key", message);
@@ -738,6 +912,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 
     if (SDL_strcmp(type, "editor.selection.flip_vertical") == 0)
         return editor_selection_flip_vertical_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.selection.flip_horizontal") == 0)
+        return editor_selection_flip_horizontal_action(runtime, action);
 
     if (SDL_strcmp(type, "editor.selection.shear_selected") == 0)
         return editor_selection_shear_selected_action(runtime, action);

--- a/src/game_data_editor_active_selection.c
+++ b/src/game_data_editor_active_selection.c
@@ -14,9 +14,6 @@
 #include "slayer3d/camera.h"
 #include "slayer3d/math.h"
 
-static bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
-                                slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic);
-
 static bool editor_selection_button_requested(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
                                               const char *key, const char *fallback)
 {
@@ -860,8 +857,8 @@ static bool editor_vec3_same_direction(slayer3d_vec3 a, slayer3d_vec3 b)
     return SDL_fabsf(a.x - b.x) <= 0.0001f && SDL_fabsf(a.y - b.y) <= 0.0001f && SDL_fabsf(a.z - b.z) <= 0.0001f;
 }
 
-static bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
-                                slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic)
+bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
+                         slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic)
 {
     if (out_forward != NULL)
         *out_forward = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);

--- a/src/game_data_editor_command_transactions.c
+++ b/src/game_data_editor_command_transactions.c
@@ -1760,7 +1760,8 @@ static bool editor_transaction_has_brush_mutation(const editor_command_transacti
            (SDL_strcmp(entry->command, "rotate") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "rotate_y") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "scale") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
-           (SDL_strcmp(entry->command, "flip_vertical") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
+           ((SDL_strcmp(entry->command, "flip_vertical") == 0 || SDL_strcmp(entry->command, "flip_horizontal") == 0) &&
+            SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "shear") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "sector_floor") == 0 && SDL_strcmp(entry->target, "element") == 0) ||
            (SDL_strcmp(entry->command, "clip") == 0 && SDL_strcmp(entry->target, "selection") == 0) ||
@@ -1952,7 +1953,7 @@ static bool apply_editor_transaction_mutation(slayer3d_game_data_runtime *runtim
         return true;
     }
     if (SDL_strcmp(entry->command, "scale") == 0 || SDL_strcmp(entry->command, "flip_vertical") == 0 ||
-        SDL_strcmp(entry->command, "shear") == 0)
+        SDL_strcmp(entry->command, "flip_horizontal") == 0 || SDL_strcmp(entry->command, "shear") == 0)
     {
         editor_selection_identity_snapshot selected_snapshots[SLAYER3D_EDITOR_SELECTED_BRUSH_CAPACITY];
         editor_selection_identity_snapshot active_snapshot;
@@ -3126,11 +3127,15 @@ fail:
     return false;
 }
 
-bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
-                                                     slayer3d_vec3 plane_normal)
+static bool slayer3d_game_data_mirror_selected_editor_brushes(slayer3d_game_data_runtime *runtime,
+                                                              slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal,
+                                                              const char *command_name, const char *adverb)
 {
-    if (runtime == NULL || runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+    if (runtime == NULL || command_name == NULL || command_name[0] == '\0' || adverb == NULL || adverb[0] == '\0' ||
+        runtime->editor_selected_brush_count <= 0 || runtime->editor_selected_brush_scene == NULL)
+    {
         return false;
+    }
     if (!editor_float_finite(plane_point.x) || !editor_float_finite(plane_point.y) ||
         !editor_float_finite(plane_point.z) || !editor_float_finite(plane_normal.x) ||
         !editor_float_finite(plane_normal.y) || !editor_float_finite(plane_normal.z) ||
@@ -3167,7 +3172,7 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
             transaction_group_id = entry->id;
         else
             entry->id = transaction_group_id;
-        if (!editor_prepare_transaction_common(entry, active_scene, "flip_vertical", "element", selection.world_name,
+        if (!editor_prepare_transaction_common(entry, active_scene, command_name, "element", selection.world_name,
                                                selection.element_name) ||
             !copy_editor_transaction_string(editor_metadata_stable_id(selection.element_editor),
                                             &entry->element_stable_id))
@@ -3176,7 +3181,7 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
         }
         entry->has_bounds = selection.has_bounds;
         entry->bounds = selection.bounds;
-        SDL_snprintf(entry->message, sizeof(entry->message), "flipped %s vertically", selection.element_name);
+        SDL_snprintf(entry->message, sizeof(entry->message), "flipped %s %s", selection.element_name, adverb);
 
         brush_world_runtime *world_runtime = find_brush_world_runtime_mutable(runtime, selection.world_name);
         if (world_runtime == NULL || !world_runtime->editor_has_source_model)
@@ -3261,10 +3266,10 @@ bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime 
     if (runtime->scene_state != NULL)
     {
         char message[128];
-        SDL_snprintf(message, sizeof(message),
-                     applied_count == 1 ? "flipped 1 selected brush vertically"
-                                        : "flipped %d selected brushes vertically",
-                     applied_count);
+        if (applied_count == 1)
+            SDL_snprintf(message, sizeof(message), "flipped 1 selected brush %s", adverb);
+        else
+            SDL_snprintf(message, sizeof(message), "flipped %d selected brushes %s", applied_count, adverb);
         slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     }
     if (last_entry != NULL && runtime->editor_selected_brush_count > 0)
@@ -3288,6 +3293,20 @@ fail:
     history->count = first_entry;
     history->cursor = first_entry;
     return false;
+}
+
+bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
+                                                     slayer3d_vec3 plane_normal)
+{
+    return slayer3d_game_data_mirror_selected_editor_brushes(runtime, plane_point, plane_normal, "flip_vertical",
+                                                             "vertically");
+}
+
+bool slayer3d_game_data_flip_selected_editor_brushes_horizontal(slayer3d_game_data_runtime *runtime,
+                                                                slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal)
+{
+    return slayer3d_game_data_mirror_selected_editor_brushes(runtime, plane_point, plane_normal, "flip_horizontal",
+                                                             "horizontally");
 }
 
 bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_bounding_box bounds,

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -140,6 +140,8 @@ bool update_editor_drag_create(slayer3d_game_data_runtime *runtime, yyjson_val *
 const char *editor_selection_type_name(slayer3d_game_data_world_model_type type);
 slayer3d_game_data_editor_selection resolved_editor_selection(const slayer3d_game_data_runtime *runtime,
                                                               const slayer3d_game_data_editor_selection *selection);
+bool editor_camera_basis(const slayer3d_game_data_runtime *runtime, slayer3d_vec3 *out_forward,
+                         slayer3d_vec3 *out_right, slayer3d_vec3 *out_up, bool *out_orthographic);
 void publish_editor_selection(slayer3d_game_data_runtime *runtime, yyjson_val *outputs,
                               const slayer3d_game_data_editor_selection *selection);
 bool slayer3d_game_data_select_editor_brush_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
@@ -154,6 +156,8 @@ bool slayer3d_game_data_scale_selected_editor_brushes(slayer3d_game_data_runtime
                                                       slayer3d_vec3 factors);
 bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
                                                      slayer3d_vec3 plane_normal);
+bool slayer3d_game_data_flip_selected_editor_brushes_horizontal(slayer3d_game_data_runtime *runtime,
+                                                                slayer3d_vec3 plane_point, slayer3d_vec3 plane_normal);
 bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_bounding_box bounds,
                                                       slayer3d_vec3 side_normal, slayer3d_vec3 delta);
 bool slayer3d_game_data_rotate_selected_editor_brushes_y(slayer3d_game_data_runtime *runtime, int quarter_turns);

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -186,10 +186,14 @@ static bool editor_apply_tool_action(slayer3d_game_data_runtime *runtime, const 
     const char *mode = editor_mode_for_tool_action(action);
     if (mode != NULL)
         return slayer3d_game_data_set_editor_tool_mode(runtime, mode, NULL);
-    if (runtime != NULL && SDL_strcmp(action, "editor.brush.flip_vertical") == 0)
+    if (runtime != NULL && (SDL_strcmp(action, "editor.brush.flip_vertical") == 0 ||
+                            SDL_strcmp(action, "editor.brush.flip_horizontal") == 0))
     {
         slayer3d_signal_bus *bus = runtime_bus(runtime);
-        const int signal_id = slayer3d_game_data_find_signal(runtime, "signal.editor.brush.flip_vertical");
+        const char *signal = SDL_strcmp(action, "editor.brush.flip_horizontal") == 0
+                                 ? "signal.editor.brush.flip_horizontal"
+                                 : "signal.editor.brush.flip_vertical";
+        const int signal_id = slayer3d_game_data_find_signal(runtime, signal);
         if (bus != NULL && signal_id >= 0)
         {
             slayer3d_signal_emit(bus, signal_id, NULL);

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -989,6 +989,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.selection.rotate_selected", validate_editor_selection_rotate_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.scale_selected", validate_editor_selection_scale_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.flip_vertical", validate_editor_selection_flip_vertical_action),
+        ACTION_RULE_EXACT_HANDLER("editor.selection.flip_horizontal", validate_editor_selection_flip_horizontal_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.shear_selected", validate_editor_selection_shear_selected_action),
         ACTION_RULE_EXACT_HANDLER("editor.selection.run", validate_editor_selection_run_action),
         ACTION_RULE_EXACT_HANDLER("editor.command.preview", validate_editor_command_preview_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -421,6 +421,44 @@ bool validate_editor_selection_flip_vertical_action(validation_context *ctx, yyj
                                          SDL_arraysize(output_keys));
 }
 
+bool validate_editor_selection_flip_horizontal_action(validation_context *ctx, yyjson_val *action,
+                                                      const char *json_path, validation_names *names, const char *type)
+{
+    (void)names;
+    (void)type;
+    yyjson_val *pivot = obj_get(action, "pivot");
+    if (pivot != NULL && !is_vec_array(pivot, 3))
+        return validation_error(ctx, json_path, "editor.selection.flip_horizontal pivot must be a numeric vec3");
+    yyjson_val *normal = obj_get(action, "normal");
+    if (normal != NULL)
+    {
+        if (!is_vec_array(normal, 3))
+            return validation_error(ctx, json_path, "editor.selection.flip_horizontal normal must be a numeric vec3");
+        const float normal_x = (float)yyjson_get_num(yyjson_arr_get(normal, 0));
+        const float normal_y = (float)yyjson_get_num(yyjson_arr_get(normal, 1));
+        const float normal_z = (float)yyjson_get_num(yyjson_arr_get(normal, 2));
+        if (!validation_float_finite(normal_x) || !validation_float_finite(normal_y) ||
+            !validation_float_finite(normal_z) ||
+            normal_x * normal_x + normal_y * normal_y + normal_z * normal_z <= 0.000001f)
+        {
+            return validation_error(ctx, json_path,
+                                    "editor.selection.flip_horizontal normal must be non-zero and finite");
+        }
+    }
+    static const char *const string_fields[] = {"normal_key", "view_mode_key", "top_mode",
+                                                "front_mode", "side_mode",     "flyby_mode"};
+    for (size_t i = 0; i < SDL_arraysize(string_fields); ++i)
+    {
+        yyjson_val *field = obj_get(action, string_fields[i]);
+        if (field != NULL && (!yyjson_is_str(field) || yyjson_get_str(field)[0] == '\0'))
+            return validation_error(ctx, json_path, "editor.selection.flip_horizontal %s must be a non-empty string",
+                                    string_fields[i]);
+    }
+    static const char *const output_keys[] = {"valid_key", "message_key", "axis_key", "center_key"};
+    return validate_optional_output_keys(ctx, action, json_path, "editor.selection.flip_horizontal", output_keys,
+                                         SDL_arraysize(output_keys));
+}
+
 bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type)
 {

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -33,6 +33,8 @@ bool validate_editor_selection_scale_selected_action(validation_context *ctx, yy
                                                      validation_names *names, const char *type);
 bool validate_editor_selection_flip_vertical_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                     validation_names *names, const char *type);
+bool validate_editor_selection_flip_horizontal_action(validation_context *ctx, yyjson_val *action,
+                                                      const char *json_path, validation_names *names, const char *type);
 bool validate_editor_selection_shear_selected_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                      validation_names *names, const char *type);
 bool validate_editor_selection_run_action(validation_context *ctx, yyjson_val *action, const char *json_path,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -313,6 +313,9 @@ extern "C"
                                                           slayer3d_vec3 factors);
     bool slayer3d_game_data_flip_selected_editor_brushes(slayer3d_game_data_runtime *runtime, slayer3d_vec3 plane_point,
                                                          slayer3d_vec3 plane_normal);
+    bool slayer3d_game_data_flip_selected_editor_brushes_horizontal(slayer3d_game_data_runtime *runtime,
+                                                                    slayer3d_vec3 plane_point,
+                                                                    slayer3d_vec3 plane_normal);
     bool slayer3d_game_data_shear_selected_editor_brushes(slayer3d_game_data_runtime *runtime,
                                                           slayer3d_bounding_box bounds, slayer3d_vec3 side_normal,
                                                           slayer3d_vec3 delta);
@@ -19995,6 +19998,34 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
         EXPECT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_rect, &capture));
         return capture.found;
     };
+    auto ui_rect = [&](const char *name) {
+        struct RectCapture
+        {
+            const slayer3d_game_data_runtime *runtime = nullptr;
+            const char *name = nullptr;
+            slayer3d_game_data_ui_rect rect{};
+            bool found = false;
+        } capture{runtime, name, {}, false};
+        auto capture_rect = [](void *userdata, const slayer3d_game_data_ui_rect *rect) -> bool {
+            auto *capture = static_cast<RectCapture *>(userdata);
+            if (rect == nullptr || rect->name == nullptr || capture->name == nullptr ||
+                SDL_strcmp(rect->name, capture->name) != 0)
+            {
+                return true;
+            }
+            if (slayer3d_game_data_ui_rect_is_visible(capture->runtime, rect, nullptr))
+            {
+                capture->rect = *rect;
+                capture->found = true;
+                return false;
+            }
+            return true;
+        };
+        EXPECT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_rect, &capture));
+        if (!capture.found)
+            ADD_FAILURE() << "visible rect not found: " << (name != nullptr ? name : "<null>");
+        return capture.rect;
+    };
     auto visible_ui_rect_color = [&](const char *name, slayer3d_color *out_color) {
         struct RectColorCapture
         {
@@ -20144,7 +20175,9 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "shear");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "shear");
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
-    click_editor(934.0f, 60.0f, SDL_BUTTON_LEFT, SDL_KMOD_NONE, 116);
+    const slayer3d_game_data_ui_rect flip_vertical_rect = ui_rect("ui.editor_shell.tool_toolbar.flip_vertical.button");
+    click_editor(flip_vertical_rect.x + 2.0f, flip_vertical_rect.y + flip_vertical_rect.h * 0.5f, SDL_BUTTON_LEFT,
+                 SDL_KMOD_NONE, 116);
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_vertical.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.flip_vertical.message", ""),
@@ -22087,6 +22120,179 @@ TEST(GameDataRuntime, EditorShellDojoBrushKeyboardNudgeUsesCameraRelativeDirecti
     slayer3d_game_session_destroy(session);
 }
 
+TEST(GameDataRuntime, EditorShellDojoHorizontalFlipToolbarMirrorsMultiSelection)
+{
+    const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
+    ASSERT_TRUE(std::filesystem::exists(dojo_path)) << dojo_path;
+
+    slayer3d_game_session *session = nullptr;
+    ASSERT_TRUE(slayer3d_game_session_create(nullptr, &session));
+    char error[512]{};
+    slayer3d_game_data_runtime *runtime = nullptr;
+    ASSERT_TRUE(slayer3d_game_data_load_file(dojo_path.string().c_str(), session, &runtime, error, sizeof(error)))
+        << error;
+
+    const slayer3d_properties *scene_state = slayer3d_game_data_scene_state(runtime);
+    ASSERT_NE(scene_state, nullptr);
+    slayer3d_input_manager *input = slayer3d_game_session_get_input(session);
+    ASSERT_NE(input, nullptr);
+
+    editor_brush_source_prefab_result slab_result{};
+    const int slab_min[3] = {-500, 0, -1500};
+    const int slab_max[3] = {500, 200, -500};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.floor", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, slab_min,
+        slab_max, &slab_result));
+    ASSERT_TRUE(slab_result.valid);
+    ASSERT_STRNE(slab_result.brush_name, "");
+
+    editor_brush_source_prefab_result cube_result{};
+    const int cube_min[3] = {-500, 200, -500};
+    const int cube_max[3] = {500, 1200, 500};
+    ASSERT_TRUE(slayer3d_game_data_create_editor_source_box_brush(
+        runtime, "brush.editor_shell.target", "mat.editor.wall", SLAYER3D_GAME_DATA_BRUSH_CONTENT_SOLID, cube_min,
+        cube_max, &cube_result));
+    ASSERT_TRUE(cube_result.valid);
+    ASSERT_STRNE(cube_result.brush_name, "");
+
+    auto brush_world = [&]() {
+        slayer3d_game_data_brush_world world{};
+        EXPECT_TRUE(slayer3d_game_data_get_brush_world(runtime, "brush.editor_shell.target", &world));
+        return world;
+    };
+    auto brush_index = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return i;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return -1;
+    };
+    auto brush_bounds = [&](const char *brush_name) {
+        const slayer3d_game_data_brush_world world = brush_world();
+        for (int i = 0; i < world.brush_count; ++i)
+        {
+            const slayer3d_game_data_brush &brush = world.brushes[i];
+            if (brush.name != nullptr && SDL_strcmp(brush.name, brush_name) == 0)
+                return brush.bounds;
+        }
+        ADD_FAILURE() << "brush not found: " << (brush_name != nullptr ? brush_name : "<null>");
+        return slayer3d_bounding_box{};
+    };
+    auto click_editor = [&](float x, float y, Uint64 frame) {
+        SDL_Event click_motion{};
+        click_motion.type = SDL_EVENT_MOUSE_MOTION;
+        click_motion.motion.x = x;
+        click_motion.motion.y = y;
+        SDL_Event mouse_down{};
+        mouse_down.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+        mouse_down.button.button = SDL_BUTTON_LEFT;
+        mouse_down.button.x = x;
+        mouse_down.button.y = y;
+        slayer3d_input_process_event(input, &click_motion);
+        slayer3d_input_process_event(input, &mouse_down);
+        slayer3d_input_update(input, frame);
+        EXPECT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+        mouse_down.type = SDL_EVENT_MOUSE_BUTTON_UP;
+        slayer3d_input_process_event(input, &mouse_down);
+        slayer3d_input_update(input, frame + 1U);
+    };
+    auto ui_rect = [&](const char *name) {
+        struct RectCapture
+        {
+            const slayer3d_game_data_runtime *runtime = nullptr;
+            const char *name = nullptr;
+            slayer3d_game_data_ui_rect rect{};
+            bool found = false;
+        } capture{runtime, name, {}, false};
+        auto capture_rect = [](void *userdata, const slayer3d_game_data_ui_rect *rect) -> bool {
+            auto *capture = static_cast<RectCapture *>(userdata);
+            if (rect == nullptr || rect->name == nullptr || capture->name == nullptr ||
+                SDL_strcmp(rect->name, capture->name) != 0)
+            {
+                return true;
+            }
+            if (slayer3d_game_data_ui_rect_is_visible(capture->runtime, rect, nullptr))
+            {
+                capture->rect = *rect;
+                capture->found = true;
+                return false;
+            }
+            return true;
+        };
+        EXPECT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_rect, &capture));
+        if (!capture.found)
+            ADD_FAILURE() << "visible rect not found: " << (name != nullptr ? name : "<null>");
+        return capture.rect;
+    };
+
+    slayer3d_game_data_editor_selection slab_selection{};
+    slayer3d_game_data_editor_selection cube_selection{};
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(slab_result.brush_name), -1, &slab_selection));
+    ASSERT_TRUE(editor_selection_from_brush_index(runtime, "brush.editor_shell.target",
+                                                  brush_index(cube_result.brush_name), -1, &cube_selection));
+
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &slab_selection));
+    SDL_SetModState(SDL_KMOD_SHIFT);
+    ASSERT_TRUE(editor_select_mode_primary_click(runtime, &cube_selection));
+    SDL_SetModState(SDL_KMOD_NONE);
+    ASSERT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+    ASSERT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.selection.multiple", false));
+
+    const slayer3d_bounding_box slab_before = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_before = brush_bounds(cube_result.brush_name);
+    ASSERT_NEAR(slab_before.min.z, -1.5f, 0.001f);
+    ASSERT_NEAR(slab_before.max.z, -0.5f, 0.001f);
+    ASSERT_NEAR(cube_before.min.z, -0.5f, 0.001f);
+    ASSERT_NEAR(cube_before.max.z, 0.5f, 0.001f);
+
+    const slayer3d_game_data_ui_rect flip_horizontal_rect =
+        ui_rect("ui.editor_shell.tool_toolbar.flip_horizontal.button");
+    click_editor(flip_horizontal_rect.x + flip_horizontal_rect.w * 0.5f,
+                 flip_horizontal_rect.y + flip_horizontal_rect.h * 0.5f, 200);
+
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_horizontal.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.flip_horizontal.message", ""),
+                 "flipped selected brushes horizontally around +Z");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "flipped 2 selected brushes horizontally");
+
+    const slayer3d_bounding_box slab_after = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_after = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_after.min.z, -0.5f, 0.001f);
+    EXPECT_NEAR(slab_after.max.z, 0.5f, 0.001f);
+    EXPECT_NEAR(cube_after.min.z, -1.5f, 0.001f);
+    EXPECT_NEAR(cube_after.max.z, -0.5f, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    ASSERT_TRUE(slayer3d_game_data_undo_editor_command(runtime, nullptr, nullptr));
+    const slayer3d_bounding_box slab_undo = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_undo = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_undo.min.z, slab_before.min.z, 0.001f);
+    EXPECT_NEAR(slab_undo.max.z, slab_before.max.z, 0.001f);
+    EXPECT_NEAR(cube_undo.min.z, cube_before.min.z, 0.001f);
+    EXPECT_NEAR(cube_undo.max.z, cube_before.max.z, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    ASSERT_TRUE(slayer3d_game_data_redo_editor_command(runtime, nullptr, nullptr));
+    const slayer3d_bounding_box slab_redo = brush_bounds(slab_result.brush_name);
+    const slayer3d_bounding_box cube_redo = brush_bounds(cube_result.brush_name);
+    EXPECT_NEAR(slab_redo.min.z, slab_after.min.z, 0.001f);
+    EXPECT_NEAR(slab_redo.max.z, slab_after.max.z, 0.001f);
+    EXPECT_NEAR(cube_redo.min.z, cube_after.min.z, 0.001f);
+    EXPECT_NEAR(cube_redo.max.z, cube_after.max.z, 0.001f);
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.selection.count", 0), 2);
+
+    slayer3d_game_data_destroy(runtime);
+    slayer3d_game_session_destroy(session);
+}
+
 TEST(GameDataRuntime, EditorShellDojoVerticalFlipToolbarMirrorsMultiSelection)
 {
     const std::filesystem::path dojo_path = editor_shell_dojo_data_path();
@@ -22167,6 +22373,34 @@ TEST(GameDataRuntime, EditorShellDojoVerticalFlipToolbarMirrorsMultiSelection)
         slayer3d_input_process_event(input, &mouse_down);
         slayer3d_input_update(input, frame + 1U);
     };
+    auto ui_rect = [&](const char *name) {
+        struct RectCapture
+        {
+            const slayer3d_game_data_runtime *runtime = nullptr;
+            const char *name = nullptr;
+            slayer3d_game_data_ui_rect rect{};
+            bool found = false;
+        } capture{runtime, name, {}, false};
+        auto capture_rect = [](void *userdata, const slayer3d_game_data_ui_rect *rect) -> bool {
+            auto *capture = static_cast<RectCapture *>(userdata);
+            if (rect == nullptr || rect->name == nullptr || capture->name == nullptr ||
+                SDL_strcmp(rect->name, capture->name) != 0)
+            {
+                return true;
+            }
+            if (slayer3d_game_data_ui_rect_is_visible(capture->runtime, rect, nullptr))
+            {
+                capture->rect = *rect;
+                capture->found = true;
+                return false;
+            }
+            return true;
+        };
+        EXPECT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, capture_rect, &capture));
+        if (!capture.found)
+            ADD_FAILURE() << "visible rect not found: " << (name != nullptr ? name : "<null>");
+        return capture.rect;
+    };
 
     slayer3d_game_data_editor_selection slab_selection{};
     slayer3d_game_data_editor_selection cube_selection{};
@@ -22190,7 +22424,8 @@ TEST(GameDataRuntime, EditorShellDojoVerticalFlipToolbarMirrorsMultiSelection)
     ASSERT_NEAR(cube_before.min.y, 0.2f, 0.001f);
     ASSERT_NEAR(cube_before.max.y, 1.2f, 0.001f);
 
-    click_editor(934.0f, 60.0f, 200);
+    const slayer3d_game_data_ui_rect flip_vertical_rect = ui_rect("ui.editor_shell.tool_toolbar.flip_vertical.button");
+    click_editor(flip_vertical_rect.x + 2.0f, flip_vertical_rect.y + flip_vertical_rect.h * 0.5f, 200);
 
     EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.grid.menu.open", false));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.flip_vertical.valid", false));


### PR DESCRIPTION
## Summary
- Add camera-relative horizontal flip for selected source-backed editor brushes using the active camera right axis
- Reuse the source-brush mirror transaction path with a distinct flip_horizontal command for grouped undo/redo
- Wire Flip H into Editor Shell Dojo toolbar, actions, validation, and signal handling while keeping Flip V clickable before the grid control
- Add multi-selection toolbar coverage for horizontal flip and update vertical flip toolbar coverage to use resolved UI rects

Closes #450

## Tests
- cmake --build build/default --target slayer3d_game_data_test -j 8
- ./build/default/tests/slayer3d_game_data_test