### PR TITLE
Add editor actor placement workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ target_sources(
         src/game_data_editor_command_transactions.c
         src/game_data_editor_output_actions.c
         src/game_data_editor_placement_preview.c
+        src/game_data_editor_actor.c
         src/game_data_editor_player_start.c
         src/game_data_editor_selection_output.c
         src/game_data_editor_selection_helpers.c

--- a/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
+++ b/demos/editor_shell_dojo/data/editor_shell_dojo.game.json
@@ -322,6 +322,12 @@
     "signal.editor.texture.paint.mode.brush",
     "signal.editor.texture.paint.mode.face",
     "signal.editor.texture.viewer.toggle",
+    "signal.editor.actor.select.player_capsule",
+    "signal.editor.actor.select.opponent_rectangle",
+    "signal.editor.actor.select.simple_robot",
+    "signal.editor.actor.viewer.toggle",
+    "signal.editor.actor.group.placeholders.toggle",
+    "signal.editor.actor.group.models.toggle",
     "signal.editor.export",
     "signal.editor.test_run.prepare",
     "signal.editor.test_run.enter"
@@ -722,9 +728,61 @@
         "signal": "signal.editor.palette.game_object",
         "actions": [
           { "type": "scene_state.set", "key": "editor.mode", "value": "thing" },
-          { "type": "scene_state.set", "key": "editor.palette.active", "value": "game_object" },
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "actor_player" },
+          { "type": "scene_state.set", "key": "editor.palette.active", "value": "" },
+          { "type": "scene_state.set", "key": "editor.actor.viewer.active", "value": true },
+          { "type": "scene_state.set", "key": "editor.actor.viewer.collapsed", "value": false },
           { "type": "scene_state.set", "key": "editor.palette.game_object.cursor", "value": "player_start" },
-          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "game object palette opened" }
+          { "type": "scene_state.set", "key": "editor.actor.selected", "value": "player_capsule" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "actor placement mode" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.select.player_capsule",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.mode", "value": "thing" },
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "actor_player" },
+          { "type": "scene_state.set", "key": "editor.actor.selected", "value": "player_capsule" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player capsule actor selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.select.opponent_rectangle",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.mode", "value": "thing" },
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "actor_opponent" },
+          { "type": "scene_state.set", "key": "editor.actor.selected", "value": "opponent_rectangle" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "opponent rectangle actor selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.select.simple_robot",
+        "actions": [
+          { "type": "scene_state.set", "key": "editor.mode", "value": "thing" },
+          { "type": "scene_state.set", "key": "editor.tool.mode", "value": "actor_robot" },
+          { "type": "scene_state.set", "key": "editor.actor.selected", "value": "simple_robot" },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "simple robot actor selected" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.viewer.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "editor.actor.viewer.collapsed", "default": false },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "actor viewer toggled" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.group.placeholders.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "editor.actor.group.placeholders.collapsed", "default": false },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "actor placeholders group toggled" }
+        ]
+      },
+      {
+        "signal": "signal.editor.actor.group.models.toggle",
+        "actions": [
+          { "type": "scene_state.toggle", "key": "editor.actor.group.models.collapsed", "default": false },
+          { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "actor models group toggled" }
         ]
       },
       {
@@ -737,6 +795,15 @@
               { "type": "scene_state.set", "key": "editor.palette.active", "value": "" },
               { "type": "scene_state.set", "key": "editor.texture.viewer.active", "value": false },
               { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "palette closed" }
+            ]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.actor.viewer.active", "op": "==", "value": true, "default": false },
+            "then": [
+              { "type": "scene_state.set", "key": "editor.actor.viewer.active", "value": false },
+              { "type": "scene_state.set", "key": "editor.actor.viewer.collapsed", "value": false },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "actor viewer closed" }
             ]
           }
         ]
@@ -1343,6 +1410,21 @@
               "default": "select"
             },
             "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_player" },
+            "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_opponent" },
+            "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_robot" },
+            "then": [{ "type": "signal.emit", "signal": "signal.editor.command.commit" }]
           }
         ]
       },
@@ -1351,7 +1433,115 @@
         "actions": [
           {
             "type": "branch",
-            "if": { "type": "scene_state.compare", "key": "editor.palette.active", "op": "==", "value": "", "default": "" },
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_player" },
+            "then": [
+              {
+                "type": "editor.actor.place",
+                "name_prefix": "actor.editor_shell.player",
+                "scene": "scene.editor_shell.dojo",
+                "display_name": "Player Capsule",
+                "archetype": "actor.editor_shell.player_placeholder",
+                "mesh": "capsule",
+                "group": "Player",
+                "position_from": "placement_preview",
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+                "color": [80, 235, 130, 205],
+                "properties": {
+                  "classname": "player_start_placeholder",
+                  "role": "player",
+                  "sensor_profile": "player"
+                },
+                "outputs": {
+                  "valid_key": "editor.actor.valid",
+                  "message_key": "editor.actor.message",
+                  "actor_key": "editor.actor.name",
+                  "dirty_key": "editor.actor.dirty",
+                  "revision_key": "editor.actor.revision",
+                  "count_key": "editor.actor.count"
+                }
+              },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "player capsule actor placed" }
+            ]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_opponent" },
+            "then": [
+              {
+                "type": "editor.actor.place",
+                "name_prefix": "actor.editor_shell.opponent",
+                "scene": "scene.editor_shell.dojo",
+                "display_name": "Opponent Rectangle",
+                "archetype": "actor.editor_shell.opponent_placeholder",
+                "mesh": "rectangle",
+                "group": "Opponents",
+                "position_from": "placement_preview",
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+                "color": [235, 128, 84, 190],
+                "properties": {
+                  "classname": "opponent_placeholder",
+                  "role": "opponent",
+                  "sensor_profile": "enemy"
+                },
+                "outputs": {
+                  "valid_key": "editor.actor.valid",
+                  "message_key": "editor.actor.message",
+                  "actor_key": "editor.actor.name",
+                  "dirty_key": "editor.actor.dirty",
+                  "revision_key": "editor.actor.revision",
+                  "count_key": "editor.actor.count"
+                }
+              },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "opponent rectangle actor placed" }
+            ]
+          },
+          {
+            "type": "branch",
+            "if": { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "==", "value": "actor_robot" },
+            "then": [
+              {
+                "type": "editor.actor.place",
+                "name_prefix": "actor.editor_shell.robot",
+                "scene": "scene.editor_shell.dojo",
+                "display_name": "Simple Robot",
+                "archetype": "actor.editor_shell.simple_robot",
+                "mesh": "box",
+                "model": "model.editor_shell.simple_robot",
+                "group": "Meshes",
+                "position_from": "placement_preview",
+                "rotation": [0.0, 0.0, 0.0],
+                "scale": [1.0, 1.0, 1.0],
+                "color": [112, 178, 255, 210],
+                "properties": {
+                  "classname": "simple_robot",
+                  "role": "actor",
+                  "sensor_profile": "robot"
+                },
+                "outputs": {
+                  "valid_key": "editor.actor.valid",
+                  "message_key": "editor.actor.message",
+                  "actor_key": "editor.actor.name",
+                  "dirty_key": "editor.actor.dirty",
+                  "revision_key": "editor.actor.revision",
+                  "count_key": "editor.actor.count"
+                }
+              },
+              { "type": "scene_state.set", "key": "editor.tool.last_action", "value": "simple robot actor placed" }
+            ]
+          },
+          {
+            "type": "branch",
+            "if": {
+              "type": "all",
+              "conditions": [
+                { "type": "scene_state.compare", "key": "editor.palette.active", "op": "==", "value": "", "default": "" },
+                { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "actor_player" },
+                { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "actor_opponent" },
+                { "type": "scene_state.compare", "key": "editor.tool.mode", "op": "!=", "value": "actor_robot" }
+              ]
+            },
             "then": [
               {
                 "type": "branch",
@@ -2138,6 +2328,63 @@
     ]
   },
   "editor_player_starts": [],
+  "editor_actors": [],
+  "actor_archetypes": [
+    {
+      "name": "actor.editor_shell.player_placeholder",
+      "active": true,
+      "tags": ["editor", "player", "placeholder"],
+      "properties": {
+        "classname": { "type": "string", "value": "player_start_placeholder" },
+        "role": { "type": "string", "value": "player" }
+      },
+      "components": [
+        {
+          "type": "render.mesh_primitive",
+          "primitive": "capsule",
+          "radius": 0.35,
+          "height": 1.8,
+          "color": [80, 235, 130, 205],
+          "lighting": false
+        }
+      ]
+    },
+    {
+      "name": "actor.editor_shell.opponent_placeholder",
+      "active": true,
+      "tags": ["editor", "opponent", "placeholder"],
+      "properties": {
+        "classname": { "type": "string", "value": "opponent_placeholder" },
+        "role": { "type": "string", "value": "opponent" }
+      },
+      "components": [
+        {
+          "type": "render.cube",
+          "size": [0.9, 1.8, 0.5],
+          "color": [235, 128, 84, 190],
+          "lighting": false
+        }
+      ]
+    },
+    {
+      "name": "actor.editor_shell.simple_robot",
+      "active": true,
+      "tags": ["editor", "robot", "model"],
+      "properties": {
+        "classname": { "type": "string", "value": "simple_robot" },
+        "role": { "type": "string", "value": "actor" }
+      },
+      "components": [
+        {
+          "type": "render.model",
+          "model": "model.editor_shell.simple_robot",
+          "scale": [1.0, 1.0, 1.0],
+          "color": [112, 178, 255, 210],
+          "lighting": true
+        }
+      ]
+    }
+  ],
   "brush_worlds": [
     {
       "name": "brush.editor_shell.target",

--- a/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
+++ b/demos/editor_shell_dojo/data/scenes/editor_shell.scene.json
@@ -246,6 +246,30 @@
           "snap_mode": "nearest",
           "size": [0.5, 1.8, 0.5],
           "message": "player start preview"
+        },
+        {
+          "mode": "actor_player",
+          "kind": "actor",
+          "snap": 0.25,
+          "snap_mode": "nearest",
+          "size": [0.7, 1.8, 0.7],
+          "message": "player capsule actor preview"
+        },
+        {
+          "mode": "actor_opponent",
+          "kind": "actor",
+          "snap": 0.25,
+          "snap_mode": "nearest",
+          "size": [0.9, 1.8, 0.5],
+          "message": "opponent rectangle actor preview"
+        },
+        {
+          "mode": "actor_robot",
+          "kind": "actor",
+          "snap": 0.25,
+          "snap_mode": "nearest",
+          "size": [0.8, 1.6, 0.8],
+          "message": "simple robot actor preview"
         }
       ]
     },
@@ -356,6 +380,30 @@
           "label": "Player",
           "category": "things",
           "description": "play-test spawn marker"
+        },
+        {
+          "mode": "actor_player",
+          "preview": "actor_player",
+          "kind": "actor",
+          "label": "Player Capsule",
+          "category": "actors/player",
+          "description": "capsule placeholder for the player actor"
+        },
+        {
+          "mode": "actor_opponent",
+          "preview": "actor_opponent",
+          "kind": "actor",
+          "label": "Opponent Rect",
+          "category": "actors/opponents",
+          "description": "rectangle placeholder for an opponent actor"
+        },
+        {
+          "mode": "actor_robot",
+          "preview": "actor_robot",
+          "kind": "actor",
+          "label": "Simple Robot",
+          "category": "actors/models",
+          "description": "model-backed actor placement"
         }
       ]
     },
@@ -371,6 +419,7 @@
         "work_plane_grid",
         "world_bounds",
         "player_starts",
+        "actors",
         "selection_bounds",
         "selection_face",
         "vertex_handles",
@@ -446,6 +495,17 @@
           { "id": "ui.editor_shell.toolbar.edit.button", "type": "button", "w": 62, "h": 28, "text": "Edit", "interactive": true },
           { "id": "ui.editor_shell.toolbar.selection.button", "type": "button", "w": 100, "h": 28, "text": "Selection", "interactive": true },
           { "id": "ui.editor_shell.toolbar.groups.button", "type": "button", "w": 86, "h": 28, "text": "Groups", "interactive": true },
+          {
+            "id": "ui.editor_shell.toolbar.actors.button",
+            "type": "button",
+            "w": 86,
+            "h": 28,
+            "text": "Actors (g)",
+            "text_scale": 0.42,
+            "interactive": true,
+            "action": "editor.palette.game_object",
+            "selected_if": { "type": "scene_state.compare", "key": "editor.actor.viewer.active", "op": "==", "value": true, "default": false }
+          },
           { "id": "ui.editor_shell.toolbar.tools.button", "type": "button", "w": 76, "h": 28, "text": "Tools", "interactive": true },
           { "id": "ui.editor_shell.toolbar.view.button", "type": "button", "w": 70, "h": 28, "text": "View", "interactive": true },
           { "id": "ui.editor_shell.toolbar.run.button", "type": "button", "w": 64, "h": 28, "text": "Run", "interactive": true },
@@ -1100,6 +1160,247 @@
           "conditions": [
             { "type": "scene_state.compare", "key": "editor.texture.viewer.active", "op": "==", "value": true, "default": false },
             { "type": "scene_state.compare", "key": "editor.texture.viewer.collapsed", "op": "==", "value": true, "default": false }
+          ]
+        }
+      },
+      {
+        "id": "ui.editor_shell.actor_viewer.panel",
+        "type": "panel",
+        "layout": "none",
+        "x": 1030,
+        "y": 92,
+        "w": 238,
+        "h": 460,
+        "layer": 120,
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "editor.actor.viewer.active", "op": "==", "value": true, "default": false },
+            { "type": "scene_state.compare", "key": "editor.actor.viewer.collapsed", "op": "==", "value": false, "default": false }
+          ]
+        },
+        "children": [
+          {
+            "id": "ui.editor_shell.actor_viewer.header",
+            "type": "panel",
+            "x": 8,
+            "y": 8,
+            "w": 222,
+            "h": 34,
+            "layer": 121,
+            "children": [
+              { "id": "ui.editor_shell.actor_viewer.title", "type": "label", "x": 12, "y": 6, "w": 120, "h": 20, "text": "Actors" },
+              {
+                "id": "ui.editor_shell.actor_viewer.collapse.button",
+                "type": "button",
+                "x": 164,
+                "y": 4,
+                "w": 50,
+                "h": 24,
+                "text": "hide",
+                "text_scale": 0.42,
+                "interactive": true,
+                "action": "editor.actor.viewer.toggle"
+              }
+            ]
+          },
+          {
+            "id": "ui.editor_shell.actor_viewer.list.panel",
+            "type": "panel",
+            "x": 10,
+            "y": 52,
+            "w": 218,
+            "h": 396,
+            "layer": 121,
+            "children": [
+              {
+                "id": "ui.editor_shell.actor_viewer.group.placeholders.button",
+                "type": "button",
+                "x": 10,
+                "y": 10,
+                "w": 186,
+                "h": 26,
+                "text": "Placeholders",
+                "text_scale": 0.42,
+                "interactive": true,
+                "action": "editor.actor.group.placeholders.toggle",
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.player_capsule.button",
+                "type": "button",
+                "x": 14,
+                "y": 48,
+                "w": 82,
+                "h": 82,
+                "text": "",
+                "interactive": true,
+                "action": "editor.actor.select.player_capsule",
+                "selected_if": { "type": "scene_state.compare", "key": "editor.actor.selected", "op": "==", "value": "player_capsule", "default": "player_capsule" },
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.player_capsule.preview.body",
+                "type": "panel",
+                "x": 43,
+                "y": 65,
+                "w": 24,
+                "h": 48,
+                "color": [80, 235, 130, 205],
+                "border_color": [170, 255, 200, 255],
+                "border_thickness": 1,
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 123
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.player_capsule.label",
+                "type": "label",
+                "x": 10,
+                "y": 132,
+                "w": 90,
+                "h": 18,
+                "text": "Player",
+                "text_scale": 0.38,
+                "align": "center",
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.opponent_rectangle.button",
+                "type": "button",
+                "x": 108,
+                "y": 48,
+                "w": 82,
+                "h": 82,
+                "text": "",
+                "interactive": true,
+                "action": "editor.actor.select.opponent_rectangle",
+                "selected_if": { "type": "scene_state.compare", "key": "editor.actor.selected", "op": "==", "value": "opponent_rectangle" },
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.opponent_rectangle.preview.body",
+                "type": "panel",
+                "x": 132,
+                "y": 69,
+                "w": 34,
+                "h": 42,
+                "color": [235, 128, 84, 190],
+                "border_color": [255, 196, 150, 255],
+                "border_thickness": 1,
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 123
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.opponent_rectangle.label",
+                "type": "label",
+                "x": 104,
+                "y": 132,
+                "w": 90,
+                "h": 18,
+                "text": "Opponent",
+                "text_scale": 0.38,
+                "align": "center",
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.placeholders.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.group.models.button",
+                "type": "button",
+                "x": 10,
+                "y": 168,
+                "w": 186,
+                "h": 26,
+                "text": "Meshes",
+                "text_scale": 0.42,
+                "interactive": true,
+                "action": "editor.actor.group.models.toggle",
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.simple_robot.button",
+                "type": "button",
+                "x": 14,
+                "y": 206,
+                "w": 82,
+                "h": 82,
+                "text": "",
+                "interactive": true,
+                "action": "editor.actor.select.simple_robot",
+                "selected_if": { "type": "scene_state.compare", "key": "editor.actor.selected", "op": "==", "value": "simple_robot" },
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.models.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.simple_robot.preview.body",
+                "type": "panel",
+                "x": 42,
+                "y": 230,
+                "w": 28,
+                "h": 38,
+                "color": [112, 178, 255, 210],
+                "border_color": [190, 228, 255, 255],
+                "border_thickness": 1,
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.models.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 123
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.simple_robot.ready_badge",
+                "type": "panel",
+                "x": 25,
+                "y": 217,
+                "w": 14,
+                "h": 14,
+                "color": [64, 235, 150, 245],
+                "border_color": [172, 255, 210, 255],
+                "border_thickness": 1,
+                "visible_if": {
+                  "type": "all",
+                  "conditions": [
+                    { "type": "scene_state.compare", "key": "editor.actor.group.models.collapsed", "op": "==", "value": false, "default": false },
+                    { "type": "scene_state.compare", "key": "asset_warmup.model.model.editor_shell.simple_robot.ready", "op": "==", "value": true, "default": false }
+                  ]
+                },
+                "layer": 124
+              },
+              {
+                "id": "ui.editor_shell.actor_viewer.simple_robot.label",
+                "type": "label",
+                "x": 10,
+                "y": 290,
+                "w": 90,
+                "h": 18,
+                "text": "Robot",
+                "text_scale": 0.38,
+                "align": "center",
+                "visible_if": { "type": "scene_state.compare", "key": "editor.actor.group.models.collapsed", "op": "==", "value": false, "default": false },
+                "layer": 122
+              },
+              { "id": "ui.editor_shell.actor_viewer.scroll.track", "type": "panel", "x": 198, "y": 10, "w": 10, "h": 354, "layer": 122 },
+              { "id": "ui.editor_shell.actor_viewer.scroll.thumb", "type": "panel", "x": 200, "y": 14, "w": 6, "h": 330, "layer": 123 }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ui.editor_shell.actor_viewer.collapsed",
+        "type": "button",
+        "x": 1116,
+        "y": 92,
+        "w": 152,
+        "h": 32,
+        "text": "Actors",
+        "text_scale": 0.48,
+        "interactive": true,
+        "action": "editor.actor.viewer.toggle",
+        "layer": 120,
+        "visible_if": {
+          "type": "all",
+          "conditions": [
+            { "type": "scene_state.compare", "key": "editor.actor.viewer.active", "op": "==", "value": true, "default": false },
+            { "type": "scene_state.compare", "key": "editor.actor.viewer.collapsed", "op": "==", "value": true, "default": false }
           ]
         }
       },

--- a/include/slayer3d/game_data_editor.h
+++ b/include/slayer3d/game_data_editor.h
@@ -145,6 +145,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_SHEAR_PREVIEW_EDGE = 40,
         /** @brief Dedicated editor origin axis line. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_ORIGIN_AXIS = 41,
+        /** @brief Editor-authored actor placement marker line. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_ACTOR_EDGE = 42,
     } slayer3d_game_data_editor_debug_primitive_type;
 
     enum
@@ -181,6 +183,8 @@ extern "C"
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES = 1u << 14,
         /** @brief Emit shear tool bounds side handles. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES = 1u << 15,
+        /** @brief Emit editor-authored actor placement markers. */
+        SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ACTORS = 1u << 16,
         /** @brief Emit every supported editor debug primitive. */
         SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ALL =
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_WORLD_BOUNDS | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_BOUNDS |
@@ -191,7 +195,7 @@ extern "C"
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SELECTION_FACE | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_VERTEX_HANDLES |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_CLIP_PREVIEW | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_EDGE_HANDLES |
             SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ROTATE_HANDLES | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SCALE_HANDLES |
-            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES,
+            SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_SHEAR_HANDLES | SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ACTORS,
     };
 
     /** @brief One renderer-agnostic editor debug line segment. */

--- a/include/slayer3d/game_data_editor_runtime.h
+++ b/include/slayer3d/game_data_editor_runtime.h
@@ -14,6 +14,7 @@
 #include "slayer3d/game_data_brush.h"
 #include "slayer3d/game_data_editor.h"
 #include "slayer3d/game_data_world_model.h"
+#include "slayer3d/properties.h"
 #include "slayer3d/types.h"
 
 #ifdef __cplusplus
@@ -303,6 +304,103 @@ extern "C"
     bool slayer3d_game_data_create_box_brush(slayer3d_game_data_runtime *runtime,
                                              const slayer3d_game_data_create_box_brush_desc *desc, char *out_brush_name,
                                              size_t out_brush_name_size, char *error_buffer, int error_buffer_size);
+
+    /** @brief Runtime-authored actor placement marker for editor workflows. */
+    typedef struct slayer3d_game_data_editor_actor
+    {
+        /** @brief Stable actor placement name. Pointer is runtime-owned. */
+        const char *name;
+        /** @brief Scene where this actor placement is valid, or NULL for scene-agnostic actors. */
+        const char *scene;
+        /** @brief Human-facing label for the actor palette/inspector. */
+        const char *display_name;
+        /** @brief Actor archetype id to instantiate when exported/test-run. */
+        const char *archetype;
+        /** @brief Editor mesh primitive name, such as capsule, box, or rectangle. */
+        const char *mesh;
+        /** @brief Optional render model asset id for finished models. */
+        const char *model;
+        /** @brief Palette category/group, such as Player, Opponents, or Sensors. */
+        const char *group;
+        /** @brief Actor world position in meters. */
+        slayer3d_vec3 position;
+        /** @brief Euler rotation in radians. */
+        slayer3d_vec3 rotation;
+        /** @brief Per-axis actor scale. */
+        slayer3d_vec3 scale;
+        /** @brief Editor display color, including alpha/transparency. */
+        slayer3d_color color;
+        /** @brief Arbitrary designer-authored properties. Pointer is runtime-owned. */
+        const slayer3d_properties *properties;
+    } slayer3d_game_data_editor_actor;
+
+    /** @brief Editor save state for actor placement markers. */
+    typedef struct slayer3d_game_data_editor_actor_state
+    {
+        /** @brief True when runtime mutations have not been marked saved. */
+        bool dirty;
+        /** @brief Monotonic runtime mutation revision. */
+        Uint64 revision;
+        /** @brief Number of editor actors currently loaded in the runtime. */
+        int count;
+    } slayer3d_game_data_editor_actor_state;
+
+    /** @brief Descriptor for creating or updating one editor actor placement. */
+    typedef struct slayer3d_game_data_place_editor_actor_desc
+    {
+        /** @brief Actor placement name. Optional when @p name_prefix is provided. */
+        const char *name;
+        /** @brief Prefix used to generate a unique placement name when @p name is omitted. */
+        const char *name_prefix;
+        /** @brief Optional scene reference. Defaults to the active scene when omitted. */
+        const char *scene;
+        /** @brief Human-facing label for the actor palette/inspector. */
+        const char *display_name;
+        /** @brief Actor archetype id to instantiate when exported/test-run. */
+        const char *archetype;
+        /** @brief Editor mesh primitive name, such as capsule, box, or rectangle. */
+        const char *mesh;
+        /** @brief Optional render model asset id for finished models. */
+        const char *model;
+        /** @brief Palette category/group. */
+        const char *group;
+        /** @brief Actor position. Used only when @p has_position is true. */
+        slayer3d_vec3 position;
+        /** @brief Whether @p position is explicit. Defaults to selection point or placement preview. */
+        bool has_position;
+        /** @brief Actor Euler rotation in radians. */
+        slayer3d_vec3 rotation;
+        /** @brief Whether @p rotation is explicit. */
+        bool has_rotation;
+        /** @brief Actor scale. */
+        slayer3d_vec3 scale;
+        /** @brief Whether @p scale is explicit. */
+        bool has_scale;
+        /** @brief Editor display color, including alpha/transparency. */
+        slayer3d_color color;
+        /** @brief Whether @p color is explicit. */
+        bool has_color;
+        /** @brief Optional arbitrary designer-authored properties to copy into the actor. */
+        const slayer3d_properties *properties;
+    } slayer3d_game_data_place_editor_actor_desc;
+
+    /**
+     * @brief Query one editor actor placement by name.
+     *
+     * Returned pointers are runtime-owned and remain valid until editor actors
+     * are mutated or the runtime is destroyed.
+     */
+    bool slayer3d_game_data_get_editor_actor(const slayer3d_game_data_runtime *runtime, const char *name,
+                                             slayer3d_game_data_editor_actor *out_actor);
+
+    /** @brief Query editor save state for runtime actor placements. */
+    bool slayer3d_game_data_get_editor_actor_state(const slayer3d_game_data_runtime *runtime,
+                                                   slayer3d_game_data_editor_actor_state *out_state);
+
+    /** @brief Create or update one runtime editor actor placement. */
+    bool slayer3d_game_data_place_editor_actor(slayer3d_game_data_runtime *runtime,
+                                               const slayer3d_game_data_place_editor_actor_desc *desc, char *out_name,
+                                               size_t out_name_size, char *error_buffer, int error_buffer_size);
 
     /** @brief Runtime-authored player start marker for editor and test-run workflows. */
     typedef struct slayer3d_game_data_editor_player_start

--- a/include/slayer3d/game_data_world_model.h
+++ b/include/slayer3d/game_data_world_model.h
@@ -31,6 +31,8 @@ extern "C"
         SLAYER3D_GAME_DATA_WORLD_MODEL_BRUSH_WORLD = 2,
         /** @brief Editor-authored player-start marker selected by tooling. */
         SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_PLAYER_START = 3,
+        /** @brief Editor-authored actor placement marker selected by tooling. */
+        SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_ACTOR = 4,
     } slayer3d_game_data_world_model_type;
 
     enum

--- a/src/game_data.c
+++ b/src/game_data.c
@@ -373,6 +373,7 @@ void slayer3d_game_data_destroy(slayer3d_game_data_runtime *runtime)
     for (int i = 0; i < runtime->brush_world_count; ++i)
         free_brush_world_runtime(&runtime->brush_worlds[i]);
     free_editor_player_starts_runtime(runtime);
+    free_editor_actors_runtime(runtime);
     for (int i = 0; i < runtime->actor_pool_count; ++i)
     {
         SDL_free(runtime->actor_pools[i].name);

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -885,11 +885,14 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
         if (runtime == NULL || runtime->scene_state == NULL)
             return false;
         if (editor_mode_is_paint(runtime) ||
-            slayer3d_properties_get_bool(runtime->scene_state, "editor.texture.viewer.active", false))
+            slayer3d_properties_get_bool(runtime->scene_state, "editor.texture.viewer.active", false) ||
+            slayer3d_properties_get_bool(runtime->scene_state, "editor.actor.viewer.active", false))
         {
             slayer3d_properties_set_string(runtime->scene_state, "editor.palette.active", "");
             slayer3d_properties_set_bool(runtime->scene_state, "editor.texture.viewer.active", false);
             slayer3d_properties_set_bool(runtime->scene_state, "editor.texture.viewer.collapsed", false);
+            slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.viewer.active", false);
+            slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.viewer.collapsed", false);
             (void)slayer3d_game_data_set_editor_tool_mode(runtime, "select", NULL);
             return true;
         }
@@ -1055,6 +1058,9 @@ bool execute_one_action(slayer3d_game_data_runtime *runtime, yyjson_val *action,
 
     if (SDL_strcmp(type, "editor.player_start.delete") == 0)
         return slayer3d_game_data_delete_editor_player_start_action(runtime, action);
+
+    if (SDL_strcmp(type, "editor.actor.place") == 0)
+        return slayer3d_game_data_place_editor_actor_action(runtime, action);
 
     if (SDL_strcmp(type, "network.direct_connect.start") == 0)
     {

--- a/src/game_data_editor_actions_internal.h
+++ b/src/game_data_editor_actions_internal.h
@@ -55,11 +55,13 @@ bool slayer3d_game_data_create_box_brush_action(slayer3d_game_data_runtime *runt
 bool slayer3d_game_data_place_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_apply_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool slayer3d_game_data_delete_editor_player_start_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
+bool slayer3d_game_data_place_editor_actor_action(slayer3d_game_data_runtime *runtime, yyjson_val *action);
 bool publish_editor_brush_world_status(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, const char *world_name,
                                        const char *message, bool publish_result);
 bool editor_brush_world_generate_brush_name(const brush_world_runtime *world_runtime, char *buffer, size_t buffer_size);
 void free_brush_world_runtime(brush_world_runtime *world_runtime);
 void free_editor_player_starts_runtime(slayer3d_game_data_runtime *runtime);
+void free_editor_actors_runtime(slayer3d_game_data_runtime *runtime);
 void free_editor_command_history(editor_command_history_state *history);
 slayer3d_bounding_box editor_resized_preview_bounds(slayer3d_bounding_box bounds, slayer3d_vec3 normal, float distance);
 void publish_editor_command_preview(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool valid,

--- a/src/game_data_editor_actor.c
+++ b/src/game_data_editor_actor.c
@@ -1,0 +1,469 @@
+/**
+ * @file game_data_editor_actor.c
+ * @brief Editor actor placement, state, and selection helpers.
+ */
+
+#include "game_data_internal.h"
+
+#include <SDL3/SDL_stdinc.h>
+
+static editor_actor_runtime *find_editor_actor_mutable(slayer3d_game_data_runtime *runtime, const char *name)
+{
+    if (runtime == NULL || name == NULL)
+        return NULL;
+    for (int i = 0; i < runtime->editor_actor_count; ++i)
+    {
+        if (runtime->editor_actors[i].name != NULL && SDL_strcmp(runtime->editor_actors[i].name, name) == 0)
+            return &runtime->editor_actors[i];
+    }
+    return NULL;
+}
+
+const editor_actor_runtime *find_editor_actor(const slayer3d_game_data_runtime *runtime, const char *name)
+{
+    return find_editor_actor_mutable((slayer3d_game_data_runtime *)runtime, name);
+}
+
+static bool runtime_scene_exists(const slayer3d_game_data_runtime *runtime, const char *scene)
+{
+    return scene == NULL || scene[0] == '\0' || find_scene_const(runtime, scene) != NULL;
+}
+
+static bool duplicate_optional_string(const char *value, char **out_copy)
+{
+    if (out_copy != NULL)
+        *out_copy = NULL;
+    if (out_copy == NULL)
+        return false;
+    if (value == NULL || value[0] == '\0')
+        return true;
+    *out_copy = SDL_strdup(value);
+    return *out_copy != NULL;
+}
+
+static bool ensure_editor_actor_capacity(slayer3d_game_data_runtime *runtime, int required_capacity)
+{
+    if (runtime == NULL || required_capacity <= runtime->editor_actor_capacity)
+        return runtime != NULL;
+    int capacity = runtime->editor_actor_capacity > 0 ? runtime->editor_actor_capacity : 8;
+    while (capacity < required_capacity)
+        capacity *= 2;
+    editor_actor_runtime *actors =
+        (editor_actor_runtime *)SDL_realloc(runtime->editor_actors, (size_t)capacity * sizeof(*actors));
+    if (actors == NULL)
+        return false;
+    SDL_memset(actors + runtime->editor_actor_capacity, 0,
+               (size_t)(capacity - runtime->editor_actor_capacity) * sizeof(*actors));
+    runtime->editor_actors = actors;
+    runtime->editor_actor_capacity = capacity;
+    return true;
+}
+
+static bool editor_actor_name_exists(const slayer3d_game_data_runtime *runtime, const char *name)
+{
+    return find_editor_actor(runtime, name) != NULL;
+}
+
+static bool generate_editor_actor_name(const slayer3d_game_data_runtime *runtime, const char *prefix, char *buffer,
+                                       size_t buffer_size)
+{
+    if (buffer == NULL || buffer_size == 0U)
+        return false;
+    const char *base = prefix != NULL && prefix[0] != '\0' ? prefix : "actor.editor";
+    for (int i = 1; i < 100000; ++i)
+    {
+        SDL_snprintf(buffer, buffer_size, "%s.%d", base, i);
+        if (!editor_actor_name_exists(runtime, buffer))
+            return true;
+    }
+    buffer[0] = '\0';
+    return false;
+}
+
+static bool copy_properties(const slayer3d_properties *source, slayer3d_properties **out_copy)
+{
+    if (out_copy != NULL)
+        *out_copy = NULL;
+    if (out_copy == NULL)
+        return false;
+    slayer3d_properties *copy = slayer3d_properties_create();
+    if (copy == NULL)
+        return false;
+    const int count = source != NULL ? slayer3d_properties_count(source) : 0;
+    for (int i = 0; i < count; ++i)
+    {
+        const char *key = NULL;
+        slayer3d_value_type type = SLAYER3D_VALUE_STRING;
+        if (!slayer3d_properties_get_key_at(source, i, &key, &type))
+            continue;
+        const slayer3d_value *value = slayer3d_properties_get_value(source, key);
+        if (key != NULL && value != NULL && !set_property_from_value(copy, key, value))
+        {
+            slayer3d_properties_destroy(copy);
+            return false;
+        }
+    }
+    *out_copy = copy;
+    return true;
+}
+
+static bool copy_properties_from_json(yyjson_val *properties, slayer3d_properties **out_copy)
+{
+    if (out_copy != NULL)
+        *out_copy = NULL;
+    if (properties == NULL)
+        return copy_properties(NULL, out_copy);
+    if (!yyjson_is_obj(properties))
+        return false;
+    slayer3d_properties *copy = slayer3d_properties_create();
+    if (copy == NULL)
+        return false;
+
+    yyjson_val *key;
+    yyjson_val *value;
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(properties, &iter);
+    while ((key = yyjson_obj_iter_next(&iter)) != NULL)
+    {
+        const char *name = yyjson_get_str(key);
+        value = yyjson_obj_iter_get_val(key);
+        if (name == NULL || name[0] == '\0' || !set_property_from_json(copy, name, value))
+        {
+            slayer3d_properties_destroy(copy);
+            return false;
+        }
+    }
+    *out_copy = copy;
+    return true;
+}
+
+static void free_editor_actor_entry(editor_actor_runtime *actor)
+{
+    if (actor == NULL)
+        return;
+    SDL_free(actor->name);
+    SDL_free(actor->scene);
+    SDL_free(actor->display_name);
+    SDL_free(actor->archetype);
+    SDL_free(actor->mesh);
+    SDL_free(actor->model);
+    SDL_free(actor->group);
+    slayer3d_properties_destroy(actor->properties);
+    SDL_zero(*actor);
+}
+
+void free_editor_actors_runtime(slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL)
+        return;
+    for (int i = 0; i < runtime->editor_actor_count; ++i)
+        free_editor_actor_entry(&runtime->editor_actors[i]);
+    SDL_free(runtime->editor_actors);
+    runtime->editor_actors = NULL;
+    runtime->editor_actor_count = 0;
+    runtime->editor_actor_capacity = 0;
+    runtime->editor_actor_revision = 0;
+    runtime->editor_actor_dirty = false;
+}
+
+static void mark_editor_actors_dirty(slayer3d_game_data_runtime *runtime)
+{
+    runtime->editor_actor_revision++;
+    runtime->editor_actor_dirty = true;
+}
+
+bool slayer3d_game_data_get_editor_actor(const slayer3d_game_data_runtime *runtime, const char *name,
+                                         slayer3d_game_data_editor_actor *out_actor)
+{
+    if (out_actor != NULL)
+        SDL_zero(*out_actor);
+    const editor_actor_runtime *actor = find_editor_actor(runtime, name);
+    if (actor == NULL || out_actor == NULL)
+        return false;
+    out_actor->name = actor->name;
+    out_actor->scene = actor->scene;
+    out_actor->display_name = actor->display_name;
+    out_actor->archetype = actor->archetype;
+    out_actor->mesh = actor->mesh;
+    out_actor->model = actor->model;
+    out_actor->group = actor->group;
+    out_actor->position = actor->position;
+    out_actor->rotation = actor->rotation;
+    out_actor->scale = actor->scale;
+    out_actor->color = actor->color;
+    out_actor->properties = actor->properties;
+    return true;
+}
+
+bool slayer3d_game_data_get_editor_actor_state(const slayer3d_game_data_runtime *runtime,
+                                               slayer3d_game_data_editor_actor_state *out_state)
+{
+    if (out_state != NULL)
+        SDL_zero(*out_state);
+    if (runtime == NULL || out_state == NULL)
+        return false;
+    out_state->dirty = runtime->editor_actor_dirty;
+    out_state->revision = runtime->editor_actor_revision;
+    out_state->count = runtime->editor_actor_count;
+    return true;
+}
+
+static bool assign_editor_actor_strings(editor_actor_runtime *entry,
+                                        const slayer3d_game_data_place_editor_actor_desc *desc, const char *scene,
+                                        const char *name, char *error_buffer, int error_buffer_size)
+{
+    char *name_copy = NULL;
+    char *scene_copy = NULL;
+    char *display_name_copy = NULL;
+    char *archetype_copy = NULL;
+    char *mesh_copy = NULL;
+    char *model_copy = NULL;
+    char *group_copy = NULL;
+    if (!duplicate_optional_string(name, &name_copy) || !duplicate_optional_string(scene, &scene_copy) ||
+        !duplicate_optional_string(desc->display_name, &display_name_copy) ||
+        !duplicate_optional_string(desc->archetype, &archetype_copy) ||
+        !duplicate_optional_string(desc->mesh, &mesh_copy) || !duplicate_optional_string(desc->model, &model_copy) ||
+        !duplicate_optional_string(desc->group, &group_copy))
+    {
+        SDL_free(name_copy);
+        SDL_free(scene_copy);
+        SDL_free(display_name_copy);
+        SDL_free(archetype_copy);
+        SDL_free(mesh_copy);
+        SDL_free(model_copy);
+        SDL_free(group_copy);
+        set_error(error_buffer, error_buffer_size, "failed to allocate editor actor fields");
+        return false;
+    }
+
+    SDL_free(entry->name);
+    SDL_free(entry->scene);
+    SDL_free(entry->display_name);
+    SDL_free(entry->archetype);
+    SDL_free(entry->mesh);
+    SDL_free(entry->model);
+    SDL_free(entry->group);
+    entry->name = name_copy;
+    entry->scene = scene_copy;
+    entry->display_name = display_name_copy;
+    entry->archetype = archetype_copy;
+    entry->mesh = mesh_copy;
+    entry->model = model_copy;
+    entry->group = group_copy;
+    return true;
+}
+
+bool slayer3d_game_data_place_editor_actor(slayer3d_game_data_runtime *runtime,
+                                           const slayer3d_game_data_place_editor_actor_desc *desc, char *out_name,
+                                           size_t out_name_size, char *error_buffer, int error_buffer_size)
+{
+    if (out_name != NULL && out_name_size > 0U)
+        out_name[0] = '\0';
+    if (runtime == NULL || desc == NULL)
+    {
+        set_error(error_buffer, error_buffer_size, "actor placement requires a runtime and descriptor");
+        return false;
+    }
+
+    char generated_name[128];
+    const char *name = desc->name;
+    if (name == NULL || name[0] == '\0')
+    {
+        if (!generate_editor_actor_name(runtime, desc->name_prefix, generated_name, sizeof(generated_name)))
+        {
+            set_error(error_buffer, error_buffer_size, "failed to generate editor actor name");
+            return false;
+        }
+        name = generated_name;
+    }
+
+    const char *scene = first_non_empty_string(desc->scene, slayer3d_game_data_active_scene(runtime), NULL);
+    if (!runtime_scene_exists(runtime, scene))
+    {
+        set_errorf(error_buffer, error_buffer_size, "actor scene '%s' not found", scene);
+        return false;
+    }
+
+    slayer3d_vec3 position = desc->position;
+    if (!desc->has_position)
+    {
+        if (editor_placement_preview_active_for_scene(runtime) && runtime->editor_placement_preview.active)
+            position = runtime->editor_placement_preview.anchor;
+        else
+        {
+            slayer3d_game_data_editor_selection selection;
+            SDL_zero(selection);
+            if (slayer3d_game_data_get_active_editor_selection(runtime, &selection) && selection.hit)
+                position = selection.point;
+            else
+            {
+                set_error(error_buffer, error_buffer_size, "actor placement requires a position or hovered preview");
+                return false;
+            }
+        }
+    }
+
+    slayer3d_properties *properties = NULL;
+    if (!copy_properties(desc->properties, &properties))
+    {
+        set_error(error_buffer, error_buffer_size, "failed to allocate actor properties");
+        return false;
+    }
+
+    editor_actor_runtime *entry = find_editor_actor_mutable(runtime, name);
+    if (entry == NULL)
+    {
+        if (!ensure_editor_actor_capacity(runtime, runtime->editor_actor_count + 1))
+        {
+            slayer3d_properties_destroy(properties);
+            set_error(error_buffer, error_buffer_size, "failed to allocate editor actor");
+            return false;
+        }
+        entry = &runtime->editor_actors[runtime->editor_actor_count++];
+    }
+
+    if (!assign_editor_actor_strings(entry, desc, scene, name, error_buffer, error_buffer_size))
+    {
+        slayer3d_properties_destroy(properties);
+        return false;
+    }
+    slayer3d_properties_destroy(entry->properties);
+    entry->properties = properties;
+    entry->position = position;
+    entry->rotation = desc->has_rotation ? desc->rotation : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    entry->scale = desc->has_scale ? desc->scale : slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    entry->color = desc->has_color ? desc->color : (slayer3d_color){120, 200, 255, 210};
+    mark_editor_actors_dirty(runtime);
+    if (out_name != NULL && out_name_size > 0U)
+        SDL_strlcpy(out_name, name, out_name_size);
+    return true;
+}
+
+bool load_editor_actors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                        int error_buffer_size)
+{
+    yyjson_val *actors = obj_get(root, "editor_actors");
+    if (actors == NULL)
+        return true;
+    if (runtime == NULL || !yyjson_is_arr(actors))
+    {
+        set_error(error_buffer, error_buffer_size, "editor_actors must be an array");
+        return false;
+    }
+
+    for (size_t i = 0; i < yyjson_arr_size(actors); ++i)
+    {
+        yyjson_val *json = yyjson_arr_get(actors, i);
+        if (!yyjson_is_obj(json))
+        {
+            set_error(error_buffer, error_buffer_size, "editor actor entry must be an object");
+            return false;
+        }
+        slayer3d_properties *properties = NULL;
+        if (!copy_properties_from_json(obj_get(json, "properties"), &properties))
+        {
+            set_error(error_buffer, error_buffer_size, "editor actor properties must be an object");
+            return false;
+        }
+        slayer3d_game_data_place_editor_actor_desc desc;
+        SDL_zero(desc);
+        desc.name = json_string(json, "name", NULL);
+        desc.scene = json_string(json, "scene", NULL);
+        desc.display_name = json_string(json, "display_name", NULL);
+        desc.archetype = json_string(json, "archetype", NULL);
+        desc.mesh = json_string(json, "mesh", "box");
+        desc.model = json_string(json, "model", NULL);
+        desc.group = json_string(json, "group", NULL);
+        desc.position = json_vec3(json, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        desc.has_position = obj_get(json, "position") != NULL;
+        desc.rotation = json_vec3(json, "rotation", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        desc.has_rotation = obj_get(json, "rotation") != NULL;
+        desc.scale = json_vec3(json, "scale", slayer3d_vec3_make(1.0f, 1.0f, 1.0f));
+        desc.has_scale = obj_get(json, "scale") != NULL;
+        desc.color = json_color(json, "color", (slayer3d_color){120, 200, 255, 210});
+        desc.has_color = obj_get(json, "color") != NULL;
+        desc.properties = properties;
+        char name[128];
+        const bool ok =
+            slayer3d_game_data_place_editor_actor(runtime, &desc, name, sizeof(name), error_buffer, error_buffer_size);
+        slayer3d_properties_destroy(properties);
+        if (!ok)
+            return false;
+    }
+    runtime->editor_actor_dirty = false;
+    runtime->editor_actor_revision = 0;
+    return true;
+}
+
+static void publish_editor_actor_outputs(slayer3d_game_data_runtime *runtime, yyjson_val *outputs, bool ok,
+                                         const char *message, const char *name)
+{
+    slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
+    editor_set_bool_output(scene_state, outputs, "valid_key", ok);
+    editor_set_string_output(scene_state, outputs, "message_key", message != NULL ? message : "");
+    editor_set_string_output(scene_state, outputs, "actor_key", ok ? name : "");
+    editor_set_bool_output(scene_state, outputs, "dirty_key", runtime != NULL ? runtime->editor_actor_dirty : false);
+    editor_set_int_output(scene_state, outputs, "revision_key",
+                          runtime != NULL ? (int)runtime->editor_actor_revision : 0);
+    editor_set_int_output(scene_state, outputs, "count_key", runtime != NULL ? runtime->editor_actor_count : 0);
+}
+
+bool slayer3d_game_data_place_editor_actor_action(slayer3d_game_data_runtime *runtime, yyjson_val *action)
+{
+    yyjson_val *outputs = obj_get(action, "outputs");
+    slayer3d_properties *properties = properties_from_json_payload(obj_get(action, "properties"), NULL);
+    if (properties == NULL)
+    {
+        publish_editor_actor_outputs(runtime, outputs, false, "actor properties must be an object", "");
+        return true;
+    }
+
+    slayer3d_game_data_place_editor_actor_desc desc;
+    SDL_zero(desc);
+    desc.name = json_string(action, "name", NULL);
+    desc.name_prefix = json_string(action, "name_prefix", "actor.editor_shell");
+    desc.scene = json_string(action, "scene", NULL);
+    desc.display_name = json_string(action, "display_name", NULL);
+    desc.archetype = json_string(action, "archetype", NULL);
+    desc.mesh = json_string(action, "mesh", "box");
+    desc.model = json_string(action, "model", NULL);
+    desc.group = json_string(action, "group", NULL);
+    const char *position_from = json_string(action, "position_from", NULL);
+    if (position_from != NULL && SDL_strcmp(position_from, "placement_preview") == 0)
+    {
+        desc.position =
+            runtime != NULL ? runtime->editor_placement_preview.anchor : slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+        desc.has_position = runtime != NULL && editor_placement_preview_active_for_scene(runtime);
+    }
+    else if (position_from != NULL && SDL_strcmp(position_from, "selection_point") == 0)
+    {
+        slayer3d_game_data_editor_selection selection;
+        SDL_zero(selection);
+        if (slayer3d_game_data_get_active_editor_selection(runtime, &selection) && selection.hit)
+        {
+            desc.position = selection.point;
+            desc.has_position = true;
+        }
+    }
+    else
+    {
+        desc.position = json_vec3(action, "position", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+        desc.has_position = obj_get(action, "position") != NULL;
+    }
+    desc.rotation = json_vec3(action, "rotation", slayer3d_vec3_make(0.0f, 0.0f, 0.0f));
+    desc.has_rotation = obj_get(action, "rotation") != NULL;
+    desc.scale = json_vec3(action, "scale", slayer3d_vec3_make(1.0f, 1.0f, 1.0f));
+    desc.has_scale = obj_get(action, "scale") != NULL;
+    desc.color = json_color(action, "color", (slayer3d_color){120, 200, 255, 210});
+    desc.has_color = obj_get(action, "color") != NULL;
+    desc.properties = properties;
+
+    char actor_name[128];
+    char error[192];
+    const bool ok =
+        slayer3d_game_data_place_editor_actor(runtime, &desc, actor_name, sizeof(actor_name), error, sizeof(error));
+    slayer3d_properties_destroy(properties);
+    publish_editor_actor_outputs(runtime, outputs, ok, ok ? json_string(action, "message", "actor placed") : error,
+                                 ok ? actor_name : "");
+    return true;
+}

--- a/src/game_data_editor_debug_primitives.c
+++ b/src/game_data_editor_debug_primitives.c
@@ -122,6 +122,8 @@ static unsigned int editor_debug_flag_from_string(const char *value)
     {
         return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_PLAYER_STARTS;
     }
+    if (SDL_strcmp(value != NULL ? value : "", "actors") == 0)
+        return SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ACTORS;
     if (SDL_strcmp(value != NULL ? value : "", "markers") == 0 ||
         SDL_strcmp(value != NULL ? value : "", "diagnostic_markers") == 0)
     {
@@ -2070,6 +2072,53 @@ static bool emit_editor_debug_player_start_marker(const slayer3d_game_data_runti
     return true;
 }
 
+static slayer3d_bounding_box editor_debug_actor_bounds(const editor_actor_runtime *actor)
+{
+    slayer3d_vec3 scale = actor != NULL && slayer3d_vec3_length_squared(actor->scale) > 0.000001f
+                              ? actor->scale
+                              : slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    slayer3d_vec3 half = slayer3d_vec3_make(0.5f * scale.x, 0.5f * scale.y, 0.5f * scale.z);
+    const char *mesh = actor != NULL ? actor->mesh : NULL;
+    if (mesh != NULL && SDL_strcmp(mesh, "capsule") == 0)
+        half = slayer3d_vec3_make(0.35f * scale.x, 0.9f * scale.y, 0.35f * scale.z);
+    else if (mesh != NULL && SDL_strcmp(mesh, "rectangle") == 0)
+        half = slayer3d_vec3_make(0.45f * scale.x, 0.9f * scale.y, 0.25f * scale.z);
+
+    slayer3d_bounding_box bounds;
+    bounds.min = slayer3d_vec3_make(actor->position.x - half.x, actor->position.y, actor->position.z - half.z);
+    bounds.max =
+        slayer3d_vec3_make(actor->position.x + half.x, actor->position.y + half.y * 2.0f, actor->position.z + half.z);
+    return bounds;
+}
+
+static bool emit_editor_debug_actor_markers(const slayer3d_game_data_runtime *runtime,
+                                            const slayer3d_game_data_editor_debug_desc *desc,
+                                            slayer3d_game_data_editor_debug_primitive_fn callback, void *userdata)
+{
+    if (runtime == NULL || desc == NULL || callback == NULL)
+        return false;
+
+    editor_debug_iteration_context context;
+    SDL_zero(context);
+    context.callback = callback;
+    context.userdata = userdata;
+    context.type = SLAYER3D_GAME_DATA_EDITOR_DEBUG_ACTOR_EDGE;
+    context.world_name = "editor_actors";
+    context.face_index = -1;
+
+    for (int actor_index = 0; actor_index < runtime->editor_actor_count; ++actor_index)
+    {
+        const editor_actor_runtime *actor = &runtime->editor_actors[actor_index];
+        if (actor->name == NULL || actor->name[0] == '\0')
+            continue;
+        context.element_name = actor->name;
+        context.color = actor->color.a > 0 ? actor->color : (slayer3d_color){120, 200, 255, 210};
+        if (!emit_editor_debug_bounds(&context, editor_debug_actor_bounds(actor)))
+            return true;
+    }
+    return true;
+}
+
 static bool editor_rotate_tool_selection_bounds(const slayer3d_game_data_runtime *runtime,
                                                 slayer3d_bounding_box *out_bounds)
 {
@@ -2679,6 +2728,11 @@ bool slayer3d_game_data_for_each_editor_debug_primitive(const slayer3d_game_data
 
     if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_PLAYER_STARTS) != 0u &&
         !emit_editor_debug_player_start_marker(runtime, desc, callback, userdata))
+    {
+        return true;
+    }
+    if ((flags & SLAYER3D_GAME_DATA_EDITOR_DEBUG_DRAW_ACTORS) != 0u &&
+        !emit_editor_debug_actor_markers(runtime, desc, callback, userdata))
     {
         return true;
     }

--- a/src/game_data_editor_internal.h
+++ b/src/game_data_editor_internal.h
@@ -122,6 +122,8 @@ bool editor_work_plane_desc_from_trace_json(const slayer3d_game_data_runtime *ru
 bool pick_editor_player_start(const slayer3d_game_data_runtime *runtime,
                               const slayer3d_game_data_world_trace_desc *trace,
                               slayer3d_game_data_editor_selection *out_selection);
+bool pick_editor_actor(const slayer3d_game_data_runtime *runtime, const slayer3d_game_data_world_trace_desc *trace,
+                       slayer3d_game_data_editor_selection *out_selection);
 bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, yyjson_val *selection,
                                      const slayer3d_game_data_world_trace_desc *trace,
                                      slayer3d_game_data_editor_selection *out_selection);

--- a/src/game_data_editor_placement_preview.c
+++ b/src/game_data_editor_placement_preview.c
@@ -921,7 +921,7 @@ void update_editor_placement_preview(slayer3d_game_data_runtime *runtime, yyjson
     preview->anchor = anchor;
     preview->snap = snap;
     preview->has_bounds = true;
-    if (SDL_strcmp(preview->kind, "player_start") == 0)
+    if (SDL_strcmp(preview->kind, "player_start") == 0 || SDL_strcmp(preview->kind, "actor") == 0)
     {
         const slayer3d_vec3 size = json_vec3(preview_json, "size", slayer3d_vec3_make(0.5f, 1.8f, 0.5f));
         preview->bounds.min = slayer3d_vec3_make(anchor.x - size.x * 0.5f, anchor.y, anchor.z - size.z * 0.5f);

--- a/src/game_data_editor_selection_helpers.c
+++ b/src/game_data_editor_selection_helpers.c
@@ -120,7 +120,8 @@ bool editor_select_mode_primary_click(slayer3d_game_data_runtime *runtime,
     if (!editor_selection_is_selectable_brush(hover_selection))
     {
         if (hover_selection != NULL && hover_selection->hit &&
-            hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_PLAYER_START)
+            (hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_PLAYER_START ||
+             hover_selection->type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_ACTOR))
         {
             clear_editor_selected_brushes(runtime);
             runtime->editor_active_selection = *hover_selection;

--- a/src/game_data_editor_selection_output.c
+++ b/src/game_data_editor_selection_output.c
@@ -18,6 +18,8 @@ const char *editor_selection_type_name(slayer3d_game_data_world_model_type type)
         return "brush_world";
     if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_PLAYER_START)
         return "editor_player_start";
+    if (type == SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_ACTOR)
+        return "editor_actor";
     return "none";
 }
 

--- a/src/game_data_editor_selection_queries.c
+++ b/src/game_data_editor_selection_queries.c
@@ -122,6 +122,25 @@ static slayer3d_bounding_box editor_player_start_bounds(const editor_player_star
     return bounds;
 }
 
+static slayer3d_bounding_box editor_actor_bounds(const editor_actor_runtime *actor)
+{
+    const slayer3d_vec3 scale = actor != NULL && slayer3d_vec3_length_squared(actor->scale) > 0.000001f
+                                    ? actor->scale
+                                    : slayer3d_vec3_make(1.0f, 1.0f, 1.0f);
+    slayer3d_vec3 half = slayer3d_vec3_make(0.5f * scale.x, 0.5f * scale.y, 0.5f * scale.z);
+    const char *mesh = actor != NULL ? actor->mesh : NULL;
+    if (mesh != NULL && SDL_strcmp(mesh, "capsule") == 0)
+        half = slayer3d_vec3_make(0.35f * scale.x, 0.9f * scale.y, 0.35f * scale.z);
+    else if (mesh != NULL && SDL_strcmp(mesh, "rectangle") == 0)
+        half = slayer3d_vec3_make(0.45f * scale.x, 0.9f * scale.y, 0.25f * scale.z);
+
+    slayer3d_bounding_box bounds;
+    bounds.min = slayer3d_vec3_make(actor->position.x - half.x, actor->position.y, actor->position.z - half.z);
+    bounds.max =
+        slayer3d_vec3_make(actor->position.x + half.x, actor->position.y + half.y * 2.0f, actor->position.z + half.z);
+    return bounds;
+}
+
 static bool editor_segment_aabb_intersection(slayer3d_vec3 start, slayer3d_vec3 end, slayer3d_bounding_box bounds,
                                              float *out_fraction)
 {
@@ -203,6 +222,53 @@ bool pick_editor_player_start(const slayer3d_game_data_runtime *runtime,
     out_selection->world_position = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
     out_selection->element_name = best_start->name;
     out_selection->element_index = (int)(best_start - runtime->editor_player_starts);
+    out_selection->face_index = -1;
+    out_selection->fraction = best_fraction;
+    out_selection->point = slayer3d_vec3_add(
+        trace->start, slayer3d_vec3_scale(slayer3d_vec3_sub(trace->end, trace->start), best_fraction));
+    out_selection->normal = slayer3d_vec3_make(0.0f, 1.0f, 0.0f);
+    out_selection->bounds = best_bounds;
+    out_selection->has_bounds = true;
+    return true;
+}
+
+bool pick_editor_actor(const slayer3d_game_data_runtime *runtime, const slayer3d_game_data_world_trace_desc *trace,
+                       slayer3d_game_data_editor_selection *out_selection)
+{
+    if (runtime == NULL || trace == NULL || out_selection == NULL)
+        return false;
+
+    float best_fraction = 1.0f;
+    const editor_actor_runtime *best_actor = NULL;
+    slayer3d_bounding_box best_bounds;
+    SDL_zero(best_bounds);
+    for (int i = 0; i < runtime->editor_actor_count; ++i)
+    {
+        const editor_actor_runtime *actor = &runtime->editor_actors[i];
+        if (actor->name == NULL || actor->name[0] == '\0')
+            continue;
+        const slayer3d_bounding_box bounds = editor_actor_bounds(actor);
+        float fraction = 1.0f;
+        if (!editor_segment_aabb_intersection(trace->start, trace->end, bounds, &fraction))
+            continue;
+        if (best_actor == NULL || fraction < best_fraction)
+        {
+            best_actor = actor;
+            best_fraction = fraction;
+            best_bounds = bounds;
+        }
+    }
+
+    if (best_actor == NULL)
+        return false;
+
+    init_editor_selection(out_selection);
+    out_selection->hit = true;
+    out_selection->type = SLAYER3D_GAME_DATA_WORLD_MODEL_EDITOR_ACTOR;
+    out_selection->world_name = "editor_actors";
+    out_selection->world_position = slayer3d_vec3_make(0.0f, 0.0f, 0.0f);
+    out_selection->element_name = best_actor->name;
+    out_selection->element_index = (int)(best_actor - runtime->editor_actors);
     out_selection->face_index = -1;
     out_selection->fraction = best_fraction;
     out_selection->point = slayer3d_vec3_add(

--- a/src/game_data_editor_toolbar.c
+++ b/src/game_data_editor_toolbar.c
@@ -58,6 +58,35 @@ static bool editor_hit_is_texture_viewer(const slayer3d_ui_layout_hit_region *hi
     return editor_hit_id_has_prefix(hit, "ui.editor_shell.texture_viewer.");
 }
 
+static bool editor_hit_is_actor_viewer(const slayer3d_ui_layout_hit_region *hit)
+{
+    return editor_hit_id_has_prefix(hit, "ui.editor_shell.actor_viewer.");
+}
+
+static bool editor_actor_select_action(const char *action)
+{
+    static const char *prefix = "editor.actor.select.";
+    return action != NULL && SDL_strncmp(action, prefix, SDL_strlen(prefix)) == 0 && action[SDL_strlen(prefix)] != '\0';
+}
+
+static bool editor_actor_placement_mode(const slayer3d_game_data_runtime *runtime)
+{
+    if (runtime == NULL || runtime->scene_state == NULL)
+        return false;
+    const char *mode = slayer3d_properties_get_string(runtime->scene_state, "editor.tool.mode", "");
+    return mode != NULL && SDL_strncmp(mode, "actor_", 6) == 0;
+}
+
+static bool editor_emit_signal(slayer3d_game_data_runtime *runtime, const char *signal)
+{
+    slayer3d_signal_bus *bus = runtime_bus(runtime);
+    const int signal_id = slayer3d_game_data_find_signal(runtime, signal);
+    if (bus == NULL || signal_id < 0)
+        return false;
+    slayer3d_signal_emit(bus, signal_id, NULL);
+    return true;
+}
+
 static bool editor_texture_select_action_is_blocked(slayer3d_game_data_runtime *runtime, const char *action)
 {
     static const char *prefix = "editor.texture.select.";
@@ -213,6 +242,8 @@ bool slayer3d_game_data_set_editor_tool_mode(slayer3d_game_data_runtime *runtime
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", message);
     slayer3d_properties_set_string(runtime->scene_state, "editor.palette.active", "");
     slayer3d_properties_set_bool(runtime->scene_state, "editor.texture.viewer.active", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.viewer.active", false);
+    slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.drag.active", false);
     slayer3d_properties_set_bool(runtime->scene_state, "editor.grid.menu.open", false);
     clear_editor_command_preview(runtime);
     if (entering_clip)
@@ -235,31 +266,22 @@ static bool editor_apply_tool_action(slayer3d_game_data_runtime *runtime, const 
         (SDL_strcmp(action, "editor.brush.duplicate") == 0 || SDL_strcmp(action, "editor.brush.flip_vertical") == 0 ||
          SDL_strcmp(action, "editor.brush.flip_horizontal") == 0))
     {
-        slayer3d_signal_bus *bus = runtime_bus(runtime);
         const char *signal = "signal.editor.brush.duplicate";
         if (SDL_strcmp(action, "editor.brush.flip_horizontal") == 0)
             signal = "signal.editor.brush.flip_horizontal";
         else if (SDL_strcmp(action, "editor.brush.flip_vertical") == 0)
             signal = "signal.editor.brush.flip_vertical";
-        const int signal_id = slayer3d_game_data_find_signal(runtime, signal);
-        if (bus != NULL && signal_id >= 0)
-        {
-            slayer3d_signal_emit(bus, signal_id, NULL);
+        if (editor_emit_signal(runtime, signal))
             return true;
-        }
     }
     if (runtime != NULL &&
-        (SDL_strncmp(action, "editor.texture.", 15) == 0 || SDL_strncmp(action, "editor.palette.", 15) == 0))
+        (SDL_strncmp(action, "editor.texture.", 15) == 0 || SDL_strncmp(action, "editor.palette.", 15) == 0 ||
+         SDL_strncmp(action, "editor.actor.", 13) == 0))
     {
         char signal[128];
         SDL_snprintf(signal, sizeof(signal), "signal.%s", action);
-        slayer3d_signal_bus *bus = runtime_bus(runtime);
-        const int signal_id = slayer3d_game_data_find_signal(runtime, signal);
-        if (bus != NULL && signal_id >= 0)
-        {
-            slayer3d_signal_emit(bus, signal_id, NULL);
+        if (editor_emit_signal(runtime, signal))
             return true;
-        }
     }
     return false;
 }
@@ -279,19 +301,48 @@ bool editor_handle_tool_mode_buttons(slayer3d_game_data_runtime *runtime, yyjson
         return true;
 
     const bool clicked = slayer3d_input_is_mouse_button_pressed(input, SDL_BUTTON_LEFT);
+    const bool left_down = slayer3d_input_is_mouse_button_down(input, SDL_BUTTON_LEFT);
+    const bool released = slayer3d_input_is_mouse_button_released(input, SDL_BUTTON_LEFT);
     slayer3d_ui_layout_model *layout = NULL;
     const slayer3d_ui_layout_hit_region *hit = NULL;
     (void)editor_retained_ui_hit(runtime, mouse_x, mouse_y, &layout, &hit);
-    if (editor_hit_is_toolbar(hit) || editor_hit_is_palette(hit) || editor_hit_is_texture_viewer(hit))
+    if (editor_hit_is_toolbar(hit) || editor_hit_is_palette(hit) || editor_hit_is_texture_viewer(hit) ||
+        editor_hit_is_actor_viewer(hit))
     {
         if (out_consumed != NULL)
             *out_consumed = true;
+        if (released || !left_down)
+            slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.drag.active", false);
         if (clicked && hit->action[0] != '\0' && !editor_texture_select_action_is_blocked(runtime, hit->action))
+        {
             (void)editor_apply_tool_action(runtime, hit->action);
+            if (editor_actor_select_action(hit->action))
+            {
+                slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.drag.active", true);
+                slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action",
+                                               "drag actor into viewport");
+            }
+        }
         slayer3d_ui_layout_destroy(layout);
         return true;
     }
     slayer3d_ui_layout_destroy(layout);
+
+    if (slayer3d_properties_get_bool(runtime->scene_state, "editor.actor.drag.active", false))
+    {
+        if (released || !left_down)
+        {
+            slayer3d_properties_set_bool(runtime->scene_state, "editor.actor.drag.active", false);
+            if (released && editor_actor_placement_mode(runtime) &&
+                slayer3d_properties_get_bool(runtime->scene_state, "editor.placement_preview.active", false))
+            {
+                if (out_consumed != NULL)
+                    *out_consumed = true;
+                (void)editor_emit_signal(runtime, "signal.editor.command.commit");
+                return true;
+            }
+        }
+    }
 
     for (size_t i = 0, count = yyjson_arr_size(buttons); i < count; ++i)
     {

--- a/src/game_data_editor_trace.c
+++ b/src/game_data_editor_trace.c
@@ -394,25 +394,24 @@ bool editor_pick_selection_from_json(const slayer3d_game_data_runtime *runtime, 
 
     slayer3d_game_data_editor_selection world_selection;
     slayer3d_game_data_editor_selection player_start_selection;
+    slayer3d_game_data_editor_selection actor_selection;
     init_editor_selection(&world_selection);
     init_editor_selection(&player_start_selection);
+    init_editor_selection(&actor_selection);
     if (!slayer3d_game_data_pick_editor_world_model(runtime, trace, &world_selection))
         return editor_work_plane_selection_from_trace(runtime, selection, trace, out_selection);
     const bool player_start_hit = pick_editor_player_start(runtime, trace, &player_start_selection);
-    if (world_selection.hit && player_start_hit)
-    {
-        *out_selection =
-            player_start_selection.fraction <= world_selection.fraction ? player_start_selection : world_selection;
-        return true;
-    }
-    if (player_start_hit)
-    {
-        *out_selection = player_start_selection;
-        return true;
-    }
+    const bool actor_hit = pick_editor_actor(runtime, trace, &actor_selection);
+    const slayer3d_game_data_editor_selection *best = NULL;
     if (world_selection.hit)
+        best = &world_selection;
+    if (player_start_hit)
+        best = best == NULL || player_start_selection.fraction <= best->fraction ? &player_start_selection : best;
+    if (actor_hit)
+        best = best == NULL || actor_selection.fraction <= best->fraction ? &actor_selection : best;
+    if (best != NULL)
     {
-        *out_selection = world_selection;
+        *out_selection = *best;
         return true;
     }
     if (editor_work_plane_selection_from_trace(runtime, selection, trace, out_selection))

--- a/src/game_data_editor_types.h
+++ b/src/game_data_editor_types.h
@@ -43,6 +43,22 @@ typedef struct editor_placement_preview_state
     char source_warning[256];
 } editor_placement_preview_state;
 
+typedef struct editor_actor_runtime
+{
+    char *name;
+    char *scene;
+    char *display_name;
+    char *archetype;
+    char *mesh;
+    char *model;
+    char *group;
+    slayer3d_vec3 position;
+    slayer3d_vec3 rotation;
+    slayer3d_vec3 scale;
+    slayer3d_color color;
+    slayer3d_properties *properties;
+} editor_actor_runtime;
+
 typedef enum editor_drag_create_phase
 {
     EDITOR_DRAG_CREATE_IDLE = 0,

--- a/src/game_data_internal.h
+++ b/src/game_data_internal.h
@@ -115,6 +115,11 @@ typedef struct slayer3d_game_data_runtime
     Uint64 editor_player_start_revision;
     Uint64 editor_player_start_saved_revision;
     bool editor_player_start_dirty;
+    editor_actor_runtime *editor_actors;
+    int editor_actor_count;
+    int editor_actor_capacity;
+    Uint64 editor_actor_revision;
+    bool editor_actor_dirty;
     slayer3d_game_data_brush_diagnostics brush_diagnostics;
     Uint64 world_model_trace_count;
     Uint64 world_model_point_query_count;
@@ -396,6 +401,8 @@ bool load_signals(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *e
 bool load_entities(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_editor_player_starts(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
                                int error_buffer_size);
+bool load_editor_actors(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer,
+                        int error_buffer_size);
 bool load_actor_pools(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_input(slayer3d_game_data_runtime *runtime, yyjson_val *root, char *error_buffer, int error_buffer_size);
 bool load_bindings(slayer3d_game_data_runtime *runtime, yyjson_val *logic, char *error_buffer, int error_buffer_size);

--- a/src/game_data_load_runtime.c
+++ b/src/game_data_load_runtime.c
@@ -413,6 +413,7 @@ bool slayer3d_game_data_load_asset_with_options(slayer3d_asset_resolver *assets,
     bool ok = load_signals(runtime, root, error_buffer, error_buffer_size) &&
               load_entities(runtime, root, error_buffer, error_buffer_size) &&
               load_editor_player_starts(runtime, root, error_buffer, error_buffer_size) &&
+              load_editor_actors(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_maps(runtime, root, error_buffer, error_buffer_size) &&
               load_grid_pickup_layers(runtime, root, error_buffer, error_buffer_size) &&
               load_sector_levels(runtime, root, error_buffer, error_buffer_size) &&

--- a/src/game_data_validation.c
+++ b/src/game_data_validation.c
@@ -624,9 +624,10 @@ static bool validate_details(validation_context *ctx, yyjson_val *root, validati
            validate_update_phases(ctx, obj_get(root, "update_phases"), "$.update_phases", names) &&
            validate_transitions(ctx, root, names) && validate_scenes(ctx, root, names) &&
            validate_editor_brush_sources(ctx, root, names) && validate_editor_player_starts(ctx, root, names) &&
-           validate_sector_doors(ctx, root, names) && validate_sector_platforms(ctx, root, names) &&
-           validate_actor_archetypes_and_pools(ctx, root, names) && validate_network(ctx, root, names) &&
-           validate_app_refs(ctx, root, names) && validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
+           validate_editor_actors(ctx, root, names) && validate_sector_doors(ctx, root, names) &&
+           validate_sector_platforms(ctx, root, names) && validate_actor_archetypes_and_pools(ctx, root, names) &&
+           validate_network(ctx, root, names) && validate_app_refs(ctx, root, names) &&
+           validate_cameras(ctx, root, names) && validate_ui(ctx, root, names) &&
            validate_presentation(ctx, root, names) && validate_render_settings(ctx, root) &&
            validate_render_effects(ctx, root, names) && validate_lights(ctx, root, names) &&
            validate_haptics(ctx, root, names) && validate_editor_metadata_tree(ctx, root, names) &&

--- a/src/game_data_validation_actions.c
+++ b/src/game_data_validation_actions.c
@@ -1014,6 +1014,7 @@ static const action_validation_rule *find_action_validation_rule(const char *typ
         ACTION_RULE_EXACT_HANDLER("editor.player_start.place", validate_editor_player_start_place_action),
         ACTION_RULE_EXACT_HANDLER("editor.player_start.apply", validate_editor_player_start_apply_action),
         ACTION_RULE_EXACT_HANDLER("editor.player_start.delete", validate_editor_player_start_delete_action),
+        ACTION_RULE_EXACT_HANDLER("editor.actor.place", validate_editor_actor_place_action),
         ACTION_RULE_EXACT_HANDLER("network.direct_connect.start", validate_network_direct_connect_start_action),
         ACTION_RULE_EXACT_HANDLER("network.direct_connect.cancel", validate_network_named_session_action),
         ACTION_RULE_EXACT_HANDLER("network.direct_connect.observe", validate_network_named_session_action),

--- a/src/game_data_validation_actions_editor.c
+++ b/src/game_data_validation_actions_editor.c
@@ -1042,3 +1042,52 @@ bool validate_editor_player_start_delete_action(validation_context *ctx, yyjson_
                                  "dirty_key", "revision_key", "saved_revision_key"};
     return validate_optional_output_keys(ctx, action, json_path, type, output_keys, SDL_arraysize(output_keys));
 }
+
+bool validate_editor_actor_place_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                        validation_names *names, const char *type)
+{
+    const char *name = json_string(action, "name");
+    const char *name_prefix = json_string(action, "name_prefix");
+    if ((name == NULL || name[0] == '\0') && (name_prefix == NULL || name_prefix[0] == '\0'))
+        return validation_error(ctx, json_path, "%s requires name or name_prefix", type);
+    const char *scene = json_string(action, "scene");
+    if (scene != NULL && !require_ref(ctx, &names->scenes, "scene", scene, json_path))
+        return false;
+    static const char *const optional_string_fields[] = {"name",  "name_prefix", "display_name",  "archetype", "mesh",
+                                                         "model", "group",       "position_from", "message"};
+    char field_path[PATH_BUFFER_SIZE];
+    for (size_t i = 0; i < SDL_arraysize(optional_string_fields); ++i)
+    {
+        format_path(field_path, sizeof(field_path), "%s.%s", json_path, optional_string_fields[i]);
+        if (!validate_optional_non_empty_string_value(ctx, obj_get(action, optional_string_fields[i]), field_path,
+                                                      "editor.actor.place field"))
+            return false;
+    }
+    const char *position_from = json_string(action, "position_from");
+    if (position_from != NULL && SDL_strcmp(position_from, "selection_point") != 0 &&
+        SDL_strcmp(position_from, "placement_preview") != 0)
+    {
+        return validation_error(ctx, json_path, "%s position_from must be selection_point or placement_preview", type);
+    }
+    yyjson_val *position = obj_get(action, "position");
+    if (position != NULL && !is_exact_vec_array(position, 3))
+        return validation_error(ctx, json_path, "%s position must be a vec3", type);
+    if (position != NULL && position_from != NULL)
+        return validation_error(ctx, json_path, "%s requires position or position_from, not both", type);
+    yyjson_val *rotation = obj_get(action, "rotation");
+    yyjson_val *scale = obj_get(action, "scale");
+    yyjson_val *color = obj_get(action, "color");
+    yyjson_val *properties = obj_get(action, "properties");
+    if (rotation != NULL && !is_exact_vec_array(rotation, 3))
+        return validation_error(ctx, json_path, "%s rotation must be a vec3", type);
+    if (scale != NULL &&
+        (!is_exact_vec_array(scale, 3) || yyjson_get_num(yyjson_arr_get(scale, 0)) <= 0.0 ||
+         yyjson_get_num(yyjson_arr_get(scale, 1)) <= 0.0 || yyjson_get_num(yyjson_arr_get(scale, 2)) <= 0.0))
+        return validation_error(ctx, json_path, "%s scale must be a positive vec3", type);
+    if (color != NULL && !is_exact_vec3_or_vec4_array(color))
+        return validation_error(ctx, json_path, "%s color must be a color array", type);
+    if (properties != NULL && !yyjson_is_obj(properties))
+        return validation_error(ctx, json_path, "%s properties must be an object", type);
+    const char *output_keys[] = {"valid_key", "message_key", "actor_key", "dirty_key", "revision_key", "count_key"};
+    return validate_optional_output_keys(ctx, action, json_path, type, output_keys, SDL_arraysize(output_keys));
+}

--- a/src/game_data_validation_actions_internal.h
+++ b/src/game_data_validation_actions_internal.h
@@ -77,5 +77,7 @@ bool validate_editor_player_start_apply_action(validation_context *ctx, yyjson_v
                                                validation_names *names, const char *type);
 bool validate_editor_player_start_delete_action(validation_context *ctx, yyjson_val *action, const char *json_path,
                                                 validation_names *names, const char *type);
+bool validate_editor_actor_place_action(validation_context *ctx, yyjson_val *action, const char *json_path,
+                                        validation_names *names, const char *type);
 
 #endif

--- a/src/game_data_validation_editor_metadata.c
+++ b/src/game_data_validation_editor_metadata.c
@@ -354,6 +354,53 @@ bool validate_editor_player_starts(validation_context *ctx, yyjson_val *root, va
     return ok;
 }
 
+bool validate_editor_actors(validation_context *ctx, yyjson_val *root, validation_names *names)
+{
+    yyjson_val *actors = obj_get(root, "editor_actors");
+    if (actors == NULL)
+        return true;
+    if (!yyjson_is_arr(actors))
+        return validation_error(ctx, "$.editor_actors", "editor_actors must be an array");
+
+    name_table actor_names;
+    SDL_zero(actor_names);
+    bool ok = true;
+    for (size_t i = 0; ok && i < yyjson_arr_size(actors); ++i)
+    {
+        char path[PATH_BUFFER_SIZE];
+        format_path(path, sizeof(path), "$.editor_actors[%zu]", i);
+        yyjson_val *actor = yyjson_arr_get(actors, i);
+        if (!yyjson_is_obj(actor))
+        {
+            ok = validation_error(ctx, path, "editor actor entries must be objects");
+            break;
+        }
+        const char *scene = json_string(actor, "scene");
+        const char *archetype = json_string(actor, "archetype");
+        const char *model = json_string(actor, "model");
+        yyjson_val *position = obj_get(actor, "position");
+        yyjson_val *rotation = obj_get(actor, "rotation");
+        yyjson_val *scale = obj_get(actor, "scale");
+        yyjson_val *color = obj_get(actor, "color");
+        yyjson_val *properties = obj_get(actor, "properties");
+        ok = require_unique_name(ctx, &actor_names, "editor actor", json_string(actor, "name"), path) &&
+             (scene == NULL || require_ref(ctx, &names->scenes, "scene", scene, path)) &&
+             (archetype == NULL || require_ref(ctx, &names->actor_archetypes, "actor archetype", archetype, path)) &&
+             (model == NULL || require_ref(ctx, &names->models, "model", model, path)) &&
+             (position == NULL || is_exact_vec_array(position, 3)) &&
+             (rotation == NULL || is_exact_vec_array(rotation, 3)) &&
+             (scale == NULL ||
+              (is_exact_vec_array(scale, 3) && yyjson_get_num(yyjson_arr_get(scale, 0)) > 0.0 &&
+               yyjson_get_num(yyjson_arr_get(scale, 1)) > 0.0 && yyjson_get_num(yyjson_arr_get(scale, 2)) > 0.0)) &&
+             (color == NULL || is_exact_vec3_or_vec4_array(color)) && (properties == NULL || yyjson_is_obj(properties));
+        if (!ok && !ctx->failed)
+            ok = validation_error(ctx, path,
+                                  "editor actor requires valid name, transform, color, properties, and references");
+    }
+    name_table_destroy(&actor_names);
+    return ok;
+}
+
 static bool is_exact_int_vec3_array(yyjson_val *value)
 {
     if (!yyjson_is_arr(value) || yyjson_arr_size(value) != 3u)

--- a/src/game_data_validation_imports.c
+++ b/src/game_data_validation_imports.c
@@ -235,6 +235,7 @@ static bool import_section_name_allowed(const char *name)
                                           "brush_worlds",
                                           "editor_brush_sources",
                                           "editor_player_starts",
+                                          "editor_actors",
                                           "sector_navigation",
                                           "sector_doors",
                                           "sector_platforms",

--- a/src/game_data_validation_internal.h
+++ b/src/game_data_validation_internal.h
@@ -140,6 +140,7 @@ bool validate_editor_metadata(validation_context *ctx, yyjson_val *metadata, con
 bool validate_editor_metadata_tree(validation_context *ctx, yyjson_val *root, validation_names *names);
 bool validate_editor_brush_sources(validation_context *ctx, yyjson_val *root, validation_names *names);
 bool validate_editor_player_starts(validation_context *ctx, yyjson_val *root, validation_names *names);
+bool validate_editor_actors(validation_context *ctx, yyjson_val *root, validation_names *names);
 bool require_unique_editor_stable_id(validation_context *ctx, name_table *stable_ids, yyjson_val *json,
                                      const char *json_path);
 bool validation_mouse_button_name_valid(const char *name);

--- a/src/game_data_validation_scene_editor.c
+++ b/src/game_data_validation_scene_editor.c
@@ -49,7 +49,8 @@ static bool editor_debug_flag_name_valid(const char *value)
                              SDL_strcmp(value, "diagnostic_markers") == 0 || SDL_strcmp(value, "selection_face") == 0 ||
                              SDL_strcmp(value, "vertex_handles") == 0 || SDL_strcmp(value, "edge_handles") == 0 ||
                              SDL_strcmp(value, "rotate_handles") == 0 || SDL_strcmp(value, "scale_handles") == 0 ||
-                             SDL_strcmp(value, "shear_handles") == 0 || SDL_strcmp(value, "clip_preview") == 0);
+                             SDL_strcmp(value, "shear_handles") == 0 || SDL_strcmp(value, "clip_preview") == 0 ||
+                             SDL_strcmp(value, "actors") == 0);
 }
 
 static bool validate_string_or_string_array_names(validation_context *ctx, yyjson_val *value, const char *path,
@@ -365,9 +366,9 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         const char *kind = json_string(preview, "kind");
         if (kind == NULL)
             kind = "box";
-        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0)
+        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0 && SDL_strcmp(kind, "actor") != 0)
             return validation_error(ctx, preview_path,
-                                    "scene editor placement preview kind must be box or player_start");
+                                    "scene editor placement preview kind must be box, player_start, or actor");
         static const char *const preview_string_fields[] = {"axis_key", "grid_size_key", "auto_axis_camera",
                                                             "auto_axis_view_key", "auto_axis_view"};
         for (size_t field_index = 0; field_index < SDL_arraysize(preview_string_fields); ++field_index)
@@ -414,7 +415,7 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
         yyjson_val *grid_size = obj_get(preview, "grid_size");
         if (grid_size != NULL && (!yyjson_is_num(grid_size) || yyjson_get_num(grid_size) <= 0.0))
             return validation_error(ctx, preview_path, "scene editor placement preview grid_size must be positive");
-        if (SDL_strcmp(kind, "player_start") == 0)
+        if (SDL_strcmp(kind, "player_start") == 0 || SDL_strcmp(kind, "actor") == 0)
         {
             yyjson_val *size = obj_get(preview, "size");
             if (size != NULL &&
@@ -422,7 +423,7 @@ static bool validate_scene_editor_placement(validation_context *ctx, yyjson_val 
                  yyjson_get_num(yyjson_arr_get(size, 1)) <= 0.0 || yyjson_get_num(yyjson_arr_get(size, 2)) <= 0.0))
             {
                 return validation_error(ctx, preview_path,
-                                        "scene editor placement player_start size must be a positive vec3");
+                                        "scene editor placement marker size must be a positive vec3");
             }
             continue;
         }
@@ -521,9 +522,10 @@ static bool validate_scene_editor_palette(validation_context *ctx, yyjson_val *p
         }
 
         const char *kind = json_string_default(entry, "kind", "box");
-        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0 && SDL_strcmp(kind, "thing") != 0)
+        if (SDL_strcmp(kind, "box") != 0 && SDL_strcmp(kind, "player_start") != 0 && SDL_strcmp(kind, "thing") != 0 &&
+            SDL_strcmp(kind, "actor") != 0)
             return validation_error(ctx, entry_path,
-                                    "scene editor palette entry kind must be box, player_start, or thing");
+                                    "scene editor palette entry kind must be box, player_start, thing, or actor");
 
         const char *preview = json_string_default(entry, "preview", json_string(entry, "mode"));
         if (!scene_editor_placement_has_preview_mode(placement, preview))

--- a/src/game_data_world_internal.h
+++ b/src/game_data_world_internal.h
@@ -41,6 +41,7 @@ brush_world_runtime *find_brush_world_runtime_mutable(slayer3d_game_data_runtime
 void editor_brush_world_mark_dirty(brush_world_runtime *world_runtime);
 const editor_player_start_runtime *find_editor_player_start(const slayer3d_game_data_runtime *runtime,
                                                             const char *name);
+const editor_actor_runtime *find_editor_actor(const slayer3d_game_data_runtime *runtime, const char *name);
 slayer3d_game_data_sector_level_variant sector_level_variant_from_string(const char *variant,
                                                                          const slayer3d_level **out_level,
                                                                          const sector_level_runtime *level,

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -10754,7 +10754,7 @@ TEST(GameDataRuntime, RejectsInvalidSceneEditorTooling)
     char placement_error[512]{};
     EXPECT_FALSE(slayer3d_game_data_validate_file((dir / "bad_placement.game.json").string().c_str(), nullptr,
                                                   placement_error, sizeof(placement_error)));
-    EXPECT_NE(std::string(placement_error).find("preview kind must be box or player_start"), std::string::npos)
+    EXPECT_NE(std::string(placement_error).find("preview kind must be box, player_start, or actor"), std::string::npos)
         << placement_error;
 
     write_text(dir / "bad_grid_placement.game.json", R"json({
@@ -18115,7 +18115,10 @@ TEST(GameDataRuntime, EditorShellDojoGameObjectPaletteShowsModelWarmupState)
 
     slayer3d_properties *scene_state = slayer3d_game_data_mutable_scene_state(runtime);
     ASSERT_NE(scene_state, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "game_object");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.actor.viewer.active", false));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.actor.viewer.collapsed", true));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "actor_player");
 
     auto visible_palette_text = [&]() {
         struct Capture
@@ -18128,7 +18131,7 @@ TEST(GameDataRuntime, EditorShellDojoGameObjectPaletteShowsModelWarmupState)
             if (capture == nullptr || text == nullptr || text->name == nullptr)
                 return true;
             const std::string name = text->name;
-            if (name.rfind("ui.editor_shell.palette.", 0) != 0)
+            if (name.rfind("ui.editor_shell.actor_viewer.", 0) != 0)
                 return true;
             slayer3d_game_data_ui_text resolved{};
             bool visible = false;
@@ -18148,32 +18151,51 @@ TEST(GameDataRuntime, EditorShellDojoGameObjectPaletteShowsModelWarmupState)
     };
 
     std::vector<std::string> labels = visible_palette_text();
-    EXPECT_TRUE(contains_text(labels, "Game Objects"));
-    EXPECT_TRUE(contains_text(labels, "Player Start"));
-    EXPECT_TRUE(contains_text(labels, "Simple Robot"));
-    EXPECT_FALSE(contains_text(labels, "Loading"));
-    EXPECT_FALSE(contains_text(labels, "Ready"));
-    EXPECT_FALSE(contains_text(labels, "Failed"));
+    EXPECT_TRUE(contains_text(labels, "Actors"));
+    EXPECT_TRUE(contains_text(labels, "Placeholders"));
+    EXPECT_TRUE(contains_text(labels, "Meshes"));
+    EXPECT_TRUE(contains_text(labels, "Player"));
+    EXPECT_TRUE(contains_text(labels, "Opponent"));
+    EXPECT_TRUE(contains_text(labels, "Robot"));
+
+    auto visible_actor_rect = [&](const char *expected) {
+        struct Capture
+        {
+            slayer3d_game_data_runtime *runtime = nullptr;
+            const char *expected = nullptr;
+            bool visible = false;
+        } capture{runtime, expected, false};
+        auto collect = [](void *userdata, const slayer3d_game_data_ui_rect *rect) -> bool {
+            auto *capture = static_cast<Capture *>(userdata);
+            if (capture == nullptr || rect == nullptr || rect->name == nullptr ||
+                SDL_strcmp(rect->name, capture->expected) != 0)
+            {
+                return true;
+            }
+            slayer3d_game_data_ui_rect resolved{};
+            bool visible = false;
+            if (slayer3d_game_data_resolve_ui_rect(capture->runtime, rect, nullptr, &resolved, &visible) && visible)
+            {
+                capture->visible = true;
+                return false;
+            }
+            return true;
+        };
+        EXPECT_TRUE(slayer3d_game_data_for_each_ui_rect(runtime, collect, &capture));
+        return capture.visible;
+    };
+    EXPECT_FALSE(visible_actor_rect("ui.editor_shell.actor_viewer.simple_robot.ready_badge"));
 
     slayer3d_properties_set_bool(scene_state, "asset_warmup.model.model.editor_shell.simple_robot.pending", true);
-    labels = visible_palette_text();
-    EXPECT_TRUE(contains_text(labels, "Loading"));
-    EXPECT_FALSE(contains_text(labels, "Ready"));
-    EXPECT_FALSE(contains_text(labels, "Failed"));
+    EXPECT_FALSE(visible_actor_rect("ui.editor_shell.actor_viewer.simple_robot.ready_badge"));
 
     slayer3d_properties_set_bool(scene_state, "asset_warmup.model.model.editor_shell.simple_robot.pending", false);
     slayer3d_properties_set_bool(scene_state, "asset_warmup.model.model.editor_shell.simple_robot.ready", true);
-    labels = visible_palette_text();
-    EXPECT_FALSE(contains_text(labels, "Loading"));
-    EXPECT_TRUE(contains_text(labels, "Ready"));
-    EXPECT_FALSE(contains_text(labels, "Failed"));
+    EXPECT_TRUE(visible_actor_rect("ui.editor_shell.actor_viewer.simple_robot.ready_badge"));
 
     slayer3d_properties_set_bool(scene_state, "asset_warmup.model.model.editor_shell.simple_robot.ready", false);
     slayer3d_properties_set_bool(scene_state, "asset_warmup.model.model.editor_shell.simple_robot.failed", true);
-    labels = visible_palette_text();
-    EXPECT_FALSE(contains_text(labels, "Loading"));
-    EXPECT_FALSE(contains_text(labels, "Ready"));
-    EXPECT_TRUE(contains_text(labels, "Failed"));
+    EXPECT_FALSE(visible_actor_rect("ui.editor_shell.actor_viewer.simple_robot.ready_badge"));
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -21809,13 +21831,16 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     slayer3d_properties_set_float(mutable_scene_state, "editor.brush.grid_size", 0.25f);
     configure_editor_shell_drag_camera(runtime);
     slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "game_object");
-    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.palette.modal"));
-    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.palette.game_object.player.cell"));
-    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.palette.game_object.simple_robot.cell"));
-    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.palette.game_object.player.selected"));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.actor.viewer.active", false));
+    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.actor_viewer.panel"));
+    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.actor_viewer.player_capsule.button"));
+    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.actor_viewer.opponent_rectangle.button"));
+    EXPECT_TRUE(visible_ui_rect("ui.editor_shell.actor_viewer.simple_robot.button"));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.actor.selected", ""), "player_capsule");
     slayer3d_signal_emit(bus, palette_close_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "");
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.actor.viewer.active", true));
 
     slayer3d_signal_emit(bus, floor_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "floor");
@@ -22219,28 +22244,98 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
     EXPECT_EQ(world().brush_count, initial_brush_count + 3);
 
     slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "game_object");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "thing");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.game_object.cursor", ""), "player_start");
-    std::vector<std::string> modal_text = visible_ui_text("ui.editor_shell.palette.");
-    EXPECT_TRUE(contains_ui_text(modal_text, "Game Objects"));
-    EXPECT_TRUE(contains_ui_text(modal_text, "Player Start"));
-    EXPECT_TRUE(contains_ui_text(modal_text, "Simple Robot"));
-    EXPECT_TRUE(contains_ui_text(modal_text, "Selected: player_start"));
-    slayer3d_signal_emit(bus, palette_accept_signal, nullptr);
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.palette.active", ""), "");
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.mode", ""), "thing");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "player_start");
-    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.game_object.selected", ""), "player_start");
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.actor.viewer.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.mode", ""), "actor_player");
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.actor.selected", ""), "player_capsule");
+    std::vector<std::string> actor_text = visible_ui_text("ui.editor_shell.actor_viewer.");
+    EXPECT_TRUE(contains_ui_text(actor_text, "Actors"));
+    EXPECT_TRUE(contains_ui_text(actor_text, "Placeholders"));
+    EXPECT_TRUE(contains_ui_text(actor_text, "Meshes"));
+    EXPECT_TRUE(contains_ui_text(actor_text, "Player"));
+    EXPECT_TRUE(contains_ui_text(actor_text, "Opponent"));
+    EXPECT_TRUE(contains_ui_text(actor_text, "Robot"));
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.placement_preview.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.kind", ""), "actor");
+
+    const slayer3d_game_data_ui_rect player_actor_rect = ui_rect("ui.editor_shell.actor_viewer.player_capsule.button");
+    SDL_Event actor_drag{};
+    actor_drag.type = SDL_EVENT_MOUSE_MOTION;
+    actor_drag.motion.x = player_actor_rect.x + player_actor_rect.w * 0.5f;
+    actor_drag.motion.y = player_actor_rect.y + player_actor_rect.h * 0.5f;
+    slayer3d_input_process_event(input, &actor_drag);
+    actor_drag.type = SDL_EVENT_MOUSE_BUTTON_DOWN;
+    actor_drag.button.button = SDL_BUTTON_LEFT;
+    actor_drag.button.x = player_actor_rect.x + player_actor_rect.w * 0.5f;
+    actor_drag.button.y = player_actor_rect.y + player_actor_rect.h * 0.5f;
+    slayer3d_input_process_event(input, &actor_drag);
+    slayer3d_input_update(input, 17);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.actor.drag.active", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.tool.last_action", ""),
+                 "drag actor into viewport");
+
+    actor_drag.type = SDL_EVENT_MOUSE_MOTION;
+    actor_drag.motion.x = click.button.x;
+    actor_drag.motion.y = click.button.y;
+    slayer3d_input_process_event(input, &actor_drag);
+    slayer3d_input_update(input, 18);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+
+    const slayer3d_value *actor_anchor = slayer3d_properties_get_value(scene_state, "editor.placement_preview.anchor");
+    ASSERT_NE(actor_anchor, nullptr);
+    ASSERT_EQ(actor_anchor->type, SLAYER3D_VALUE_VEC3);
+    const slayer3d_vec3 actor_origin = actor_anchor->as_vec3;
+    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 0.25f, 0.001f);
+    actor_drag.type = SDL_EVENT_MOUSE_BUTTON_UP;
+    actor_drag.button.button = SDL_BUTTON_LEFT;
+    actor_drag.button.x = click.button.x;
+    actor_drag.button.y = click.button.y;
+    slayer3d_input_process_event(input, &actor_drag);
+    slayer3d_input_update(input, 19);
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
+    EXPECT_FALSE(slayer3d_properties_get_bool(scene_state, "editor.actor.drag.active", true));
+    EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.actor.valid", false));
+    EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.actor.name", ""), "actor.editor_shell.player.1");
+    slayer3d_game_data_editor_actor placed_actor{};
+    ASSERT_TRUE(slayer3d_game_data_get_editor_actor(runtime, "actor.editor_shell.player.1", &placed_actor));
+    EXPECT_STREQ(placed_actor.archetype, "actor.editor_shell.player_placeholder");
+    EXPECT_STREQ(placed_actor.mesh, "capsule");
+    EXPECT_STREQ(placed_actor.group, "Player");
+    EXPECT_NEAR(placed_actor.position.x, actor_origin.x, 0.001f);
+    EXPECT_NEAR(placed_actor.position.y, actor_origin.y, 0.001f);
+    EXPECT_NEAR(placed_actor.position.z, actor_origin.z, 0.001f);
+    ASSERT_NE(placed_actor.properties, nullptr);
+    EXPECT_STREQ(slayer3d_properties_get_string(placed_actor.properties, "role", ""), "player");
+    EXPECT_EQ(slayer3d_properties_get_int(scene_state, "editor.actor.count", 0), 1);
+
+    struct ActorDebug
+    {
+        int edges = 0;
+    } actor_debug;
+    auto count_actor_debug = [](void *userdata, const slayer3d_game_data_editor_debug_primitive *primitive) {
+        auto *debug = static_cast<ActorDebug *>(userdata);
+        if (primitive != nullptr && primitive->type == SLAYER3D_GAME_DATA_EDITOR_DEBUG_ACTOR_EDGE &&
+            primitive->element_name != nullptr && std::string(primitive->element_name) == "actor.editor_shell.player.1")
+        {
+            debug->edges++;
+        }
+        return true;
+    };
+    ASSERT_TRUE(slayer3d_game_data_for_each_active_editor_debug_primitive(runtime, count_actor_debug, &actor_debug));
+    EXPECT_EQ(actor_debug.edges, 12);
+
+    slayer3d_properties_set_string(mutable_scene_state, "editor.mode", "thing");
+    slayer3d_properties_set_string(mutable_scene_state, "editor.tool.mode", "player_start");
+    ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.placement_preview.kind", ""), "player_start");
     const slayer3d_value *player_start_anchor =
         slayer3d_properties_get_value(scene_state, "editor.placement_preview.anchor");
     ASSERT_NE(player_start_anchor, nullptr);
     ASSERT_EQ(player_start_anchor->type, SLAYER3D_VALUE_VEC3);
     player_start_origin = player_start_anchor->as_vec3;
-    EXPECT_NEAR(slayer3d_properties_get_float(scene_state, "editor.placement_preview.snap", 0.0f), 1.0f, 0.001f);
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     EXPECT_TRUE(slayer3d_properties_get_bool(scene_state, "editor.player_start.valid", false));
     EXPECT_STREQ(slayer3d_properties_get_string(scene_state, "editor.player_start.name", ""),
@@ -22290,8 +22385,8 @@ TEST(GameDataRuntime, EditorShellDojoCreatesBlockoutPrefabTools)
                  "player start deleted");
     EXPECT_FALSE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));
 
-    slayer3d_signal_emit(bus, palette_game_object_signal, nullptr);
-    slayer3d_signal_emit(bus, palette_accept_signal, nullptr);
+    slayer3d_properties_set_string(mutable_scene_state, "editor.mode", "thing");
+    slayer3d_properties_set_string(mutable_scene_state, "editor.tool.mode", "player_start");
     ASSERT_TRUE(slayer3d_game_data_update_active_editor_tooling(runtime));
     slayer3d_signal_emit(bus, commit_signal, nullptr);
     ASSERT_TRUE(slayer3d_game_data_get_editor_player_start(runtime, "player_start.editor_shell", &start));


### PR DESCRIPTION
## Summary
- Add runtime editor actor placements with data-driven archetype, mesh/model, transform, color, alpha, group, and arbitrary property support.
- Add an Actors toolbar entry and right-side actor viewer with collapsible groups, scroll affordance, placeholder/model presets, and drag-to-drop placement into the viewport.
- Include actor picking, selection metadata, debug bounds, placement previews, validation/import support, and editor shell test coverage.

## Testing
- cmake --build build/debug -j 8
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='*EditorShellDojo*:*EditorActor*:*PlayerStart*'
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter=GameDataRuntime.RejectsInvalidSceneEditorTooling
- ctest --test-dir build/debug --output-on-failure (1407 passed, 1 skipped)
