### PR TITLE
Render 3D world at native viewport scale

### DIFF
--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -180,16 +180,22 @@ for the depth pre-pass and main geometry pass through UI metrics. These queries
 can block while reading GPU results, so use them for profiling and do not leave
 them enabled in production scenes by default.
 `world_render_scale` renders only the 3D/world layer at a lower internal
-resolution on capable backends, then upscales it into the normal logical
+resolution on capable backends, then upscales it into the native pixel
 viewport before drawing UI. Valid values are `0.25` through `1.0`; `1.0`
-preserves full logical resolution. UI overlays, menu text, mouse/input mapping,
-and camera aspect ratio remain tied to the authored logical resolution, so HUDs
-stay sharp even when the world layer is scaled down. Use
+preserves the current drawable viewport resolution instead of a fixed 720p
+target. UI overlays, menu text, mouse/input mapping, and camera aspect ratio
+remain tied to the authored logical resolution, so HUDs stay sharp even when
+the world layer is scaled down. Use
 `world_render_scale_key` for options menus or profiling scenes that need a
 runtime quality slider without host C. The UI metrics namespace exposes
 `render.window_pixel_width`, `render.window_pixel_height`, and
 `render.window_pixel_density` so profiling screens can verify the actual
 platform backing size independently from the authored logical size.
+`dynamic_world_render_scale` lets the managed loop automatically adjust the
+world render scale using recent frame times. Pair it with
+`dynamic_world_render_min_scale`, `dynamic_world_render_max_scale`, and
+`dynamic_world_render_target_fps` when a game should prefer crisp native output
+but gracefully lower only the 3D layer under sustained frame pressure.
 `quality_presets` are named render-setting bundles selected by `quality` or the
 scene-state value at `quality_key`. Presets may author the same performance
 knobs as the root `render` object, including world scale, depth pre-pass,

--- a/include/slayer3d/game.h
+++ b/include/slayer3d/game.h
@@ -342,20 +342,24 @@ extern "C"
      */
     typedef struct slayer3d_game_config
     {
-        const char *title;                 /**< Window title, or "SLAYER3D" when NULL. */
-        int width;                         /**< Initial window width in pixels, or logical width when <= 0. */
-        int height;                        /**< Initial window height in pixels, or logical height when <= 0. */
-        int logical_width;                 /**< Virtual render width, or 1280 when <= 0. */
-        int logical_height;                /**< Virtual render height, or 720 when <= 0. */
-        const char *icon_path;             /**< Optional filesystem path to a window icon image. */
-        slayer3d_backend backend;          /**< Requested backend, or SLAYER3D_BACKEND_AUTO when zero. */
-        slayer3d_window_mode display_mode; /**< Window presentation mode, or SLAYER3D default when zero. */
-        int vsync;                         /**< >0 enables vsync, <0 disables vsync, 0 uses the SLAYER3D default. */
-        int maximized;                     /**< >0 maximizes, <0 keeps window normal, 0 uses the SLAYER3D default. */
-        int high_pixel_density;            /**< >0 requests high-DPI backing, <0 disables it, 0 uses default. */
-        float tick_rate;                   /**< Fixed timestep in seconds, or 1/60 when <= 0. */
-        int max_ticks_per_frame;           /**< Catch-up tick cap per rendered frame, or 8 when <= 0. */
-        bool enable_audio;                 /**< When true, create session audio before init when available. */
+        const char *title;                    /**< Window title, or "SLAYER3D" when NULL. */
+        int width;                            /**< Initial window width in pixels, or logical width when <= 0. */
+        int height;                           /**< Initial window height in pixels, or logical height when <= 0. */
+        int logical_width;                    /**< Virtual render width, or 1280 when <= 0. */
+        int logical_height;                   /**< Virtual render height, or 720 when <= 0. */
+        const char *icon_path;                /**< Optional filesystem path to a window icon image. */
+        slayer3d_backend backend;             /**< Requested backend, or SLAYER3D_BACKEND_AUTO when zero. */
+        slayer3d_window_mode display_mode;    /**< Window presentation mode, or SLAYER3D default when zero. */
+        int vsync;                            /**< >0 enables vsync, <0 disables vsync, 0 uses the SLAYER3D default. */
+        int maximized;                        /**< >0 maximizes, <0 keeps window normal, 0 uses the SLAYER3D default. */
+        int high_pixel_density;               /**< >0 requests high-DPI backing, <0 disables it, 0 uses default. */
+        float tick_rate;                      /**< Fixed timestep in seconds, or 1/60 when <= 0. */
+        int max_ticks_per_frame;              /**< Catch-up tick cap per rendered frame, or 8 when <= 0. */
+        bool dynamic_world_render_scale;      /**< Enable adaptive 3D render resolution when true. */
+        float dynamic_world_render_min_scale; /**< Minimum adaptive 3D render scale, or 0.5 when <= 0. */
+        float dynamic_world_render_max_scale; /**< Maximum adaptive 3D render scale, or 1.0 when <= 0. */
+        float dynamic_world_render_target_fps; /**< Adaptive render target FPS, or 60 when <= 0. */
+        bool enable_audio;                     /**< When true, create session audio before init when available. */
     } slayer3d_game_config;
 
     /**

--- a/include/slayer3d/game_data_render.h
+++ b/include/slayer3d/game_data_render.h
@@ -311,6 +311,14 @@ extern "C"
         bool performance_queries_enabled;
         /** @brief Internal 3D/world render scale; UI and logical presentation remain full resolution. */
         float world_render_scale;
+        /** @brief Whether the managed loop may adjust world render scale to hold frame rate. */
+        bool dynamic_world_render_scale_enabled;
+        /** @brief Lower bound for adaptive world render scale. */
+        float dynamic_world_render_min_scale;
+        /** @brief Upper bound for adaptive world render scale. */
+        float dynamic_world_render_max_scale;
+        /** @brief Frame-rate target used by adaptive world render scaling. */
+        float dynamic_world_render_target_fps;
         /** @brief Tonemap operator for lit rendering. */
         slayer3d_tonemap_mode tonemap;
     } slayer3d_game_data_render_settings;

--- a/include/slayer3d/render_context.h
+++ b/include/slayer3d/render_context.h
@@ -118,8 +118,8 @@ extern "C"
      *
      * Use slayer3d_init_window_config() for sensible defaults, then override what
      * the game needs. Windowed mode is resizable by default. Games should
-     * prefer logical_width/logical_height for authored layout and world scale;
-     * width/height only describe the initial desktop window size.
+     * prefer logical_width/logical_height for authored layout and input
+     * mapping; width/height describe the initial desktop window size.
      */
     typedef struct slayer3d_window_config
     {
@@ -181,9 +181,10 @@ extern "C"
      *
      * Handles backend-specific setup, SDL_Renderer creation for the software
      * path, window flags, optional title/icon metadata, presentation mode, and
-     * logical resolution. High-level windows present the logical resolution
-     * with letterboxing so resizable windows preserve the authored aspect
-     * ratio. The caller receives an SDL_Window* for event polling and an
+     * logical resolution. High-level windows preserve the authored aspect
+     * ratio with letterboxing. Capable 3D backends render the world layer
+     * against the native pixel viewport, while overlays use logical
+     * coordinates. The caller receives an SDL_Window* for event polling and an
      * slayer3d_render_context* for rendering.
      *
      * @param config Optional window configuration. NULL selects defaults.
@@ -249,12 +250,25 @@ extern "C"
      *
      * The logical presentation size, UI coordinates, input mapping, and camera
      * aspect ratio are unchanged. Capable backends render the world layer to a
-     * smaller framebuffer and upscale it before drawing the UI overlay at full
-     * logical resolution. Valid scales are 0.25 through 1.0.
+     * smaller framebuffer and upscale it into the native presentation
+     * viewport before drawing the UI overlay. Valid scales are 0.25 through
+     * 1.0.
      */
     bool slayer3d_set_world_render_scale(slayer3d_render_context *context, float scale);
     /** @brief Return the requested 3D/world render scale. */
     float slayer3d_get_world_render_scale(const slayer3d_render_context *context);
+    /**
+     * @brief Configure automatic 3D/world render scaling.
+     *
+     * When enabled, SLAYER3D may lower or raise only the world render target
+     * between @p min_scale and @p max_scale based on frame times supplied to
+     * slayer3d_update_dynamic_world_render_scale(). Overlay/UI rendering stays
+     * at the native presentation resolution.
+     */
+    bool slayer3d_configure_dynamic_world_render_scale(slayer3d_render_context *context, bool enabled, float min_scale,
+                                                       float max_scale, float target_fps);
+    /** @brief Feed a completed frame time to the dynamic world scaler. */
+    bool slayer3d_update_dynamic_world_render_scale(slayer3d_render_context *context, float frame_ms);
     /** @brief Return the active 3D/world framebuffer size. */
     bool slayer3d_get_world_render_size(const slayer3d_render_context *context, int *out_width, int *out_height);
     bool slayer3d_get_render_stats(const slayer3d_render_context *context, slayer3d_render_stats *out_stats);

--- a/src/game.c
+++ b/src/game.c
@@ -382,6 +382,11 @@ static int slayer3d_game_max_ticks_per_frame(const slayer3d_game_config *config)
                                                                : SLAYER3D_GAME_DEFAULT_MAX_TICKS;
 }
 
+static float slayer3d_game_dynamic_scale_value(float value, float fallback)
+{
+    return value > 0.0f ? value : fallback;
+}
+
 static bool slayer3d_game_create_context(const slayer3d_game_config *config, slayer3d_game_context *ctx)
 {
     slayer3d_window_config window_config;
@@ -415,6 +420,20 @@ static bool slayer3d_game_create_context(const slayer3d_game_config *config, sla
     if (!slayer3d_create_window(&window_config, &ctx->window, &ctx->renderer))
     {
         return false;
+    }
+    if (config != NULL && config->dynamic_world_render_scale)
+    {
+        const float min_scale = slayer3d_game_dynamic_scale_value(config->dynamic_world_render_min_scale, 0.5f);
+        const float max_scale = slayer3d_game_dynamic_scale_value(config->dynamic_world_render_max_scale, 1.0f);
+        const float target_fps = slayer3d_game_dynamic_scale_value(config->dynamic_world_render_target_fps, 60.0f);
+        if (!slayer3d_configure_dynamic_world_render_scale(ctx->renderer, true, min_scale, max_scale, target_fps))
+        {
+            slayer3d_destroy_render_context(ctx->renderer);
+            SDL_DestroyWindow(ctx->window);
+            ctx->renderer = NULL;
+            ctx->window = NULL;
+            return false;
+        }
     }
 
     slayer3d_game_session_desc_init(&session_desc);
@@ -652,6 +671,14 @@ int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_ca
             ctx.quit_requested = true;
         }
         present_end_counter = SDL_GetPerformanceCounter();
+        const float frame_ms = (float)((double)(present_end_counter - frame_start_counter) * 1000.0 /
+                                       (double)SDL_GetPerformanceFrequency());
+        if (!slayer3d_update_dynamic_world_render_scale(ctx.renderer, frame_ms))
+        {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D dynamic render scale update failed: %s",
+                        SDL_GetError());
+            SDL_ClearError();
+        }
 
         if (profile_frames)
         {

--- a/src/game_data_load_runtime.c
+++ b/src/game_data_load_runtime.c
@@ -219,6 +219,20 @@ static bool apply_app_config_from_root(yyjson_val *root, slayer3d_game_config *o
     out_config->tick_rate = json_float(app, "tick_rate", out_config->tick_rate);
     out_config->max_ticks_per_frame = json_int(app, "max_ticks_per_frame", out_config->max_ticks_per_frame);
     out_config->enable_audio = json_bool(app, "enable_audio", out_config->enable_audio);
+
+    yyjson_val *render = obj_get(root, "render");
+    if (yyjson_is_obj(render))
+    {
+        yyjson_val *dynamic_world_render_scale = obj_get(render, "dynamic_world_render_scale");
+        if (yyjson_is_bool(dynamic_world_render_scale))
+            out_config->dynamic_world_render_scale = yyjson_get_bool(dynamic_world_render_scale);
+        out_config->dynamic_world_render_min_scale =
+            json_float(render, "dynamic_world_render_min_scale", out_config->dynamic_world_render_min_scale);
+        out_config->dynamic_world_render_max_scale =
+            json_float(render, "dynamic_world_render_max_scale", out_config->dynamic_world_render_max_scale);
+        out_config->dynamic_world_render_target_fps =
+            json_float(render, "dynamic_world_render_target_fps", out_config->dynamic_world_render_target_fps);
+    }
     return true;
 }
 

--- a/src/game_data_render_runtime.c
+++ b/src/game_data_render_runtime.c
@@ -2021,6 +2021,10 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
         out_settings->model_lod_cull_pixels = 4.0f;
         out_settings->performance_queries_enabled = false;
         out_settings->world_render_scale = 1.0f;
+        out_settings->dynamic_world_render_scale_enabled = false;
+        out_settings->dynamic_world_render_min_scale = 0.5f;
+        out_settings->dynamic_world_render_max_scale = 1.0f;
+        out_settings->dynamic_world_render_target_fps = 60.0f;
         out_settings->tonemap = SLAYER3D_TONEMAP_ACES;
     }
     if (runtime == NULL || out_settings == NULL)
@@ -2076,6 +2080,25 @@ bool slayer3d_game_data_get_render_settings(const slayer3d_game_data_runtime *ru
     out_settings->world_render_scale = render_float_setting(runtime, render, quality_preset, "world_render_scale",
                                                             "world_render_scale_key", out_settings->world_render_scale);
     out_settings->world_render_scale = SDL_clamp(out_settings->world_render_scale, 0.25f, 1.0f);
+    out_settings->dynamic_world_render_scale_enabled =
+        render_bool_setting(runtime, render, quality_preset, "dynamic_world_render_scale",
+                            "dynamic_world_render_scale_key", out_settings->dynamic_world_render_scale_enabled);
+    out_settings->dynamic_world_render_min_scale =
+        render_float_setting(runtime, render, quality_preset, "dynamic_world_render_min_scale",
+                             "dynamic_world_render_min_scale_key", out_settings->dynamic_world_render_min_scale);
+    out_settings->dynamic_world_render_max_scale =
+        render_float_setting(runtime, render, quality_preset, "dynamic_world_render_max_scale",
+                             "dynamic_world_render_max_scale_key", out_settings->dynamic_world_render_max_scale);
+    out_settings->dynamic_world_render_target_fps =
+        render_float_setting(runtime, render, quality_preset, "dynamic_world_render_target_fps",
+                             "dynamic_world_render_target_fps_key", out_settings->dynamic_world_render_target_fps);
+    out_settings->dynamic_world_render_min_scale =
+        SDL_clamp(out_settings->dynamic_world_render_min_scale, 0.25f, out_settings->world_render_scale);
+    out_settings->dynamic_world_render_max_scale =
+        SDL_clamp(out_settings->dynamic_world_render_max_scale, out_settings->dynamic_world_render_min_scale,
+                  out_settings->world_render_scale);
+    out_settings->dynamic_world_render_target_fps =
+        SDL_clamp(out_settings->dynamic_world_render_target_fps, 15.0f, 500.0f);
     const char *tonemap_name =
         scene_state_string(runtime, json_string(render, "tonemap_key", NULL), json_string(render, "tonemap", NULL));
     out_settings->tonemap = parse_tonemap(tonemap_name, out_settings->tonemap);

--- a/src/game_data_validation_render.c
+++ b/src/game_data_validation_render.c
@@ -180,16 +180,19 @@ static bool validate_render_tunable_values(validation_context *ctx, yyjson_val *
     yyjson_val *procedural_lod = obj_get(object, "procedural_lod");
     yyjson_val *model_lod_culling = obj_get(object, "model_lod_culling");
     yyjson_val *performance_queries = obj_get(object, "performance_queries");
+    yyjson_val *dynamic_world_render_scale = obj_get(object, "dynamic_world_render_scale");
     if ((lighting != NULL && !yyjson_is_bool(lighting)) || (bloom != NULL && !yyjson_is_bool(bloom)) ||
         (ssao != NULL && !yyjson_is_bool(ssao)) || (depth_prepass != NULL && !yyjson_is_bool(depth_prepass)) ||
         (per_object_light_selection != NULL && !yyjson_is_bool(per_object_light_selection)) ||
         (procedural_lod != NULL && !yyjson_is_bool(procedural_lod)) ||
         (model_lod_culling != NULL && !yyjson_is_bool(model_lod_culling)) ||
-        (performance_queries != NULL && !yyjson_is_bool(performance_queries)))
+        (performance_queries != NULL && !yyjson_is_bool(performance_queries)) ||
+        (dynamic_world_render_scale != NULL && !yyjson_is_bool(dynamic_world_render_scale)))
     {
         return validation_error(ctx, path,
                                 "render lighting, bloom, ssao, depth_prepass, per_object_light_selection, "
-                                "procedural_lod, model_lod_culling, and performance_queries must be booleans");
+                                "procedural_lod, model_lod_culling, performance_queries, and "
+                                "dynamic_world_render_scale must be booleans");
     }
     yyjson_val *per_object_light_limit = obj_get(object, "per_object_light_limit");
     if (per_object_light_limit != NULL &&
@@ -205,6 +208,33 @@ static bool validate_render_tunable_values(validation_context *ctx, yyjson_val *
          yyjson_get_num(world_render_scale) > 1.0))
     {
         return validation_error(ctx, path, "render world_render_scale must be a number from 0.25 to 1.0");
+    }
+    yyjson_val *dynamic_world_render_min_scale = obj_get(object, "dynamic_world_render_min_scale");
+    yyjson_val *dynamic_world_render_max_scale = obj_get(object, "dynamic_world_render_max_scale");
+    yyjson_val *dynamic_world_render_target_fps = obj_get(object, "dynamic_world_render_target_fps");
+    if ((dynamic_world_render_min_scale != NULL &&
+         (!yyjson_is_num(dynamic_world_render_min_scale) || yyjson_get_num(dynamic_world_render_min_scale) < 0.25 ||
+          yyjson_get_num(dynamic_world_render_min_scale) > 1.0)) ||
+        (dynamic_world_render_max_scale != NULL &&
+         (!yyjson_is_num(dynamic_world_render_max_scale) || yyjson_get_num(dynamic_world_render_max_scale) < 0.25 ||
+          yyjson_get_num(dynamic_world_render_max_scale) > 1.0)))
+    {
+        return validation_error(ctx, path,
+                                "render dynamic_world_render_min_scale and dynamic_world_render_max_scale must be "
+                                "numbers from 0.25 to 1.0");
+    }
+    if (dynamic_world_render_min_scale != NULL && dynamic_world_render_max_scale != NULL &&
+        yyjson_get_num(dynamic_world_render_min_scale) > yyjson_get_num(dynamic_world_render_max_scale))
+    {
+        return validation_error(ctx, path,
+                                "render dynamic_world_render_min_scale must be less than or equal to "
+                                "dynamic_world_render_max_scale");
+    }
+    if (dynamic_world_render_target_fps != NULL &&
+        (!yyjson_is_num(dynamic_world_render_target_fps) || yyjson_get_num(dynamic_world_render_target_fps) < 15.0 ||
+         yyjson_get_num(dynamic_world_render_target_fps) > 500.0))
+    {
+        return validation_error(ctx, path, "render dynamic_world_render_target_fps must be a number from 15 to 500");
     }
     yyjson_val *procedural_lod_near_pixels = obj_get(object, "procedural_lod_near_pixels");
     yyjson_val *procedural_lod_far_pixels = obj_get(object, "procedural_lod_far_pixels");

--- a/src/game_presentation.c
+++ b/src/game_presentation.c
@@ -73,6 +73,10 @@ static bool apply_render_settings(const slayer3d_game_data_runtime *runtime, sla
     ok = slayer3d_set_per_object_light_limit(renderer, settings.per_object_light_limit) && ok;
     ok = slayer3d_set_render_sample_queries_enabled(renderer, settings.performance_queries_enabled) && ok;
     ok = slayer3d_set_world_render_scale(renderer, settings.world_render_scale) && ok;
+    ok = slayer3d_configure_dynamic_world_render_scale(
+             renderer, settings.dynamic_world_render_scale_enabled, settings.dynamic_world_render_min_scale,
+             settings.dynamic_world_render_max_scale, settings.dynamic_world_render_target_fps) &&
+         ok;
     ok = slayer3d_set_tonemap_mode(renderer, settings.tonemap) && ok;
     ok = slayer3d_clear_render_context(renderer, settings.clear_color) && ok;
     return ok;

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -2839,6 +2839,12 @@ static bool gl_clear(slayer3d_render_context *context, slayer3d_color color)
     }
 
     SDL_GL_MakeCurrent(ctx->window, ctx->gl_context);
+    if (!slayer3d_gl_sync_world_render_target(ctx, context->width, context->height, context->world_render_scale,
+                                              &context->world_render_width, &context->world_render_height))
+    {
+        return false;
+    }
+    context->world_render_scale = slayer3d_gl_world_render_scale(ctx);
 
     gl->BindFramebuffer(GL_FRAMEBUFFER, ctx->fbo);
     gl->Viewport(0, 0, ctx->world_w, ctx->world_h);
@@ -3127,6 +3133,13 @@ static bool gl_present(slayer3d_render_context *context)
 {
     slayer3d_gl_context *ctx = context->gl;
     slayer3d_gl_funcs *gl = &ctx->gl;
+
+    if (!slayer3d_gl_sync_world_render_target(ctx, context->width, context->height, context->world_render_scale,
+                                              &context->world_render_width, &context->world_render_height))
+    {
+        return false;
+    }
+    context->world_render_scale = slayer3d_gl_world_render_scale(ctx);
 
     /* Flush UBO before any replay. */
     flush_scene_ubo(ctx);

--- a/src/gl_renderer.h
+++ b/src/gl_renderer.h
@@ -17,6 +17,8 @@ slayer3d_gl_context *slayer3d_gl_create(SDL_Window *window, int width, int heigh
 void slayer3d_gl_destroy(slayer3d_gl_context *ctx);
 bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_width, int logical_height, float scale,
                                         int *out_width, int *out_height);
+bool slayer3d_gl_sync_world_render_target(slayer3d_gl_context *ctx, int logical_width, int logical_height, float scale,
+                                          int *out_width, int *out_height);
 float slayer3d_gl_world_render_scale(const slayer3d_gl_context *ctx);
 void slayer3d_gl_world_render_size(const slayer3d_gl_context *ctx, int *out_width, int *out_height);
 

--- a/src/gl_renderer_targets.c
+++ b/src/gl_renderer_targets.c
@@ -123,8 +123,30 @@ int slayer3d_gl_scaled_world_dimension(int logical_dimension, float scale)
     return SDL_max(1, (int)SDL_floorf((float)logical_dimension * scale + 0.5f));
 }
 
-bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_width, int logical_height, float scale,
-                                        int *out_width, int *out_height)
+static bool gl_presentation_viewport_size(slayer3d_gl_context *ctx, int logical_width, int logical_height,
+                                          int *out_width, int *out_height)
+{
+    int output_width = 0;
+    int output_height = 0;
+    if (!SDL_GetWindowSizeInPixels(ctx->window, &output_width, &output_height))
+    {
+        return false;
+    }
+    if (output_width <= 0 || output_height <= 0)
+    {
+        return SDL_SetError("The GL window does not currently expose a valid pixel size.");
+    }
+
+    const float scale_x = (float)output_width / (float)logical_width;
+    const float scale_y = (float)output_height / (float)logical_height;
+    const float scale = (scale_x < scale_y) ? scale_x : scale_y;
+    *out_width = SDL_max(1, (int)SDL_floorf((float)logical_width * scale + 0.5f));
+    *out_height = SDL_max(1, (int)SDL_floorf((float)logical_height * scale + 0.5f));
+    return true;
+}
+
+bool slayer3d_gl_sync_world_render_target(slayer3d_gl_context *ctx, int logical_width, int logical_height, float scale,
+                                          int *out_width, int *out_height)
 {
     if (ctx == NULL)
     {
@@ -139,8 +161,15 @@ bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_wi
         return SDL_SetError("World render scale must be between 0.25 and 1.0.");
     }
 
-    const int new_width = slayer3d_gl_scaled_world_dimension(logical_width, scale);
-    const int new_height = slayer3d_gl_scaled_world_dimension(logical_height, scale);
+    int presentation_width = logical_width;
+    int presentation_height = logical_height;
+    if (!gl_presentation_viewport_size(ctx, logical_width, logical_height, &presentation_width, &presentation_height))
+    {
+        return false;
+    }
+
+    const int new_width = slayer3d_gl_scaled_world_dimension(presentation_width, scale);
+    const int new_height = slayer3d_gl_scaled_world_dimension(presentation_height, scale);
     if (ctx->logical_w == logical_width && ctx->logical_h == logical_height && ctx->world_w == new_width &&
         ctx->world_h == new_height)
     {
@@ -152,10 +181,11 @@ bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_wi
         return true;
     }
 
-    const int old_width = ctx->world_w > 0 ? ctx->world_w : logical_width;
-    const int old_height = ctx->world_h > 0 ? ctx->world_h : logical_height;
+    const int old_width = ctx->world_w > 0 ? ctx->world_w : presentation_width;
+    const int old_height = ctx->world_h > 0 ? ctx->world_h : presentation_height;
     const float old_scale = ctx->world_render_scale > 0.0f ? ctx->world_render_scale : 1.0f;
 
+    SDL_GL_MakeCurrent(ctx->window, ctx->gl_context);
     slayer3d_gl_destroy_world_targets(ctx);
     if (!slayer3d_gl_create_world_targets(ctx, new_width, new_height))
     {
@@ -175,6 +205,25 @@ bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_wi
     if (out_height != NULL)
         *out_height = ctx->world_h;
     return true;
+}
+
+bool slayer3d_gl_set_world_render_scale(slayer3d_gl_context *ctx, int logical_width, int logical_height, float scale,
+                                        int *out_width, int *out_height)
+{
+    if (ctx == NULL)
+    {
+        return SDL_InvalidParamError("ctx");
+    }
+    if (logical_width <= 0 || logical_height <= 0)
+    {
+        return SDL_InvalidParamError("logical dimensions");
+    }
+    if (!(scale >= 0.25f && scale <= 1.0f))
+    {
+        return SDL_SetError("World render scale must be between 0.25 and 1.0.");
+    }
+
+    return slayer3d_gl_sync_world_render_target(ctx, logical_width, logical_height, scale, out_width, out_height);
 }
 
 float slayer3d_gl_world_render_scale(const slayer3d_gl_context *ctx)

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -14,6 +14,12 @@ static const char *const SLAYER3D_BACKEND_ENV = "SLAYER3D_BACKEND";
 static const char *const SLAYER3D_DISABLE_PARALLEL_RASTERIZER_ENV = "SLAYER3D_DISABLE_PARALLEL_RASTERIZER";
 static const float SLAYER3D_DEFAULT_NEAR_PLANE = 0.01f;
 static const float SLAYER3D_DEFAULT_FAR_PLANE = 1000.0f;
+static const float SLAYER3D_DYNAMIC_SCALE_SLOW_FRAME_RATIO = 1.10f;
+static const float SLAYER3D_DYNAMIC_SCALE_FAST_FRAME_RATIO = 0.82f;
+static const float SLAYER3D_DYNAMIC_SCALE_DOWN_STEP = 0.05f;
+static const float SLAYER3D_DYNAMIC_SCALE_UP_STEP = 0.025f;
+static const int SLAYER3D_DYNAMIC_SCALE_SLOW_FRAME_COUNT = 8;
+static const int SLAYER3D_DYNAMIC_SCALE_FAST_FRAME_COUNT = 60;
 
 static bool slayer3d_parallel_rasterizer_disabled_by_environment(void)
 {
@@ -550,23 +556,25 @@ bool slayer3d_update_dynamic_world_render_scale(slayer3d_render_context *context
 
     const float target_ms = 1000.0f / context->dynamic_world_render_target_fps;
     float next_scale = context->world_render_scale;
-    if (context->dynamic_world_render_frame_ms_ema > target_ms * 1.10f)
+    if (context->dynamic_world_render_frame_ms_ema > target_ms * SLAYER3D_DYNAMIC_SCALE_SLOW_FRAME_RATIO)
     {
         context->dynamic_world_render_slow_frames++;
         context->dynamic_world_render_fast_frames = 0;
-        if (context->dynamic_world_render_slow_frames >= 8)
+        if (context->dynamic_world_render_slow_frames >= SLAYER3D_DYNAMIC_SCALE_SLOW_FRAME_COUNT)
         {
-            next_scale = SDL_max(context->dynamic_world_render_min_scale, context->world_render_scale - 0.05f);
+            next_scale = SDL_max(context->dynamic_world_render_min_scale,
+                                 context->world_render_scale - SLAYER3D_DYNAMIC_SCALE_DOWN_STEP);
             context->dynamic_world_render_slow_frames = 0;
         }
     }
-    else if (context->dynamic_world_render_frame_ms_ema < target_ms * 0.82f)
+    else if (context->dynamic_world_render_frame_ms_ema < target_ms * SLAYER3D_DYNAMIC_SCALE_FAST_FRAME_RATIO)
     {
         context->dynamic_world_render_fast_frames++;
         context->dynamic_world_render_slow_frames = 0;
-        if (context->dynamic_world_render_fast_frames >= 60)
+        if (context->dynamic_world_render_fast_frames >= SLAYER3D_DYNAMIC_SCALE_FAST_FRAME_COUNT)
         {
-            next_scale = SDL_min(context->world_render_target_scale, context->world_render_scale + 0.025f);
+            next_scale = SDL_min(context->world_render_target_scale,
+                                 context->world_render_scale + SLAYER3D_DYNAMIC_SCALE_UP_STEP);
             context->dynamic_world_render_fast_frames = 0;
         }
     }

--- a/src/render_context.c
+++ b/src/render_context.c
@@ -308,8 +308,16 @@ bool slayer3d_create_render_context(SDL_Window *window, SDL_Renderer *renderer,
     context->width = render_width;
     context->height = render_height;
     context->world_render_scale = 1.0f;
+    context->world_render_target_scale = 1.0f;
     context->world_render_width = render_width;
     context->world_render_height = render_height;
+    context->dynamic_world_render_scale_enabled = false;
+    context->dynamic_world_render_min_scale = 0.5f;
+    context->dynamic_world_render_max_scale = 1.0f;
+    context->dynamic_world_render_target_fps = 60.0f;
+    context->dynamic_world_render_frame_ms_ema = 0.0f;
+    context->dynamic_world_render_slow_frames = 0;
+    context->dynamic_world_render_fast_frames = 0;
     context->near_plane = SLAYER3D_DEFAULT_NEAR_PLANE;
     context->far_plane = SLAYER3D_DEFAULT_FAR_PLANE;
     context->in_mode_3d = false;
@@ -419,7 +427,7 @@ int slayer3d_get_render_context_height(const slayer3d_render_context *context)
     return context->height;
 }
 
-bool slayer3d_set_world_render_scale(slayer3d_render_context *context, float scale)
+static bool apply_world_render_scale(slayer3d_render_context *context, float scale)
 {
     if (context == NULL)
     {
@@ -447,9 +455,132 @@ bool slayer3d_set_world_render_scale(slayer3d_render_context *context, float sca
     return true;
 }
 
+bool slayer3d_set_world_render_scale(slayer3d_render_context *context, float scale)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (!(scale >= 0.25f && scale <= 1.0f))
+    {
+        return SDL_SetError("World render scale must be between 0.25 and 1.0.");
+    }
+
+    context->world_render_target_scale = scale;
+    if (context->dynamic_world_render_scale_enabled)
+    {
+        float dynamic_scale = SDL_clamp(context->world_render_scale, context->dynamic_world_render_min_scale, scale);
+        if (!(dynamic_scale >= context->dynamic_world_render_min_scale))
+            dynamic_scale = scale;
+        return apply_world_render_scale(context, dynamic_scale);
+    }
+    return apply_world_render_scale(context, scale);
+}
+
 float slayer3d_get_world_render_scale(const slayer3d_render_context *context)
 {
     return context != NULL ? context->world_render_scale : 1.0f;
+}
+
+bool slayer3d_configure_dynamic_world_render_scale(slayer3d_render_context *context, bool enabled, float min_scale,
+                                                   float max_scale, float target_fps)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (!(min_scale >= 0.25f && min_scale <= 1.0f && max_scale >= 0.25f && max_scale <= 1.0f && min_scale <= max_scale))
+    {
+        return SDL_SetError("Dynamic world render scale bounds must be between 0.25 and 1.0.");
+    }
+    if (!(target_fps >= 15.0f && target_fps <= 500.0f))
+    {
+        return SDL_SetError("Dynamic world render scale target FPS must be between 15 and 500.");
+    }
+
+    const bool settings_changed = context->dynamic_world_render_scale_enabled != enabled ||
+                                  context->dynamic_world_render_min_scale != min_scale ||
+                                  context->dynamic_world_render_max_scale != max_scale ||
+                                  context->dynamic_world_render_target_fps != target_fps;
+    context->dynamic_world_render_scale_enabled = enabled;
+    context->dynamic_world_render_min_scale = min_scale;
+    context->dynamic_world_render_max_scale = max_scale;
+    context->dynamic_world_render_target_fps = target_fps;
+    context->world_render_target_scale = SDL_clamp(context->world_render_target_scale, min_scale, max_scale);
+    if (settings_changed)
+    {
+        context->dynamic_world_render_slow_frames = 0;
+        context->dynamic_world_render_fast_frames = 0;
+        context->dynamic_world_render_frame_ms_ema = 0.0f;
+    }
+    if (!enabled)
+    {
+        return apply_world_render_scale(context, context->world_render_target_scale);
+    }
+    if (context->world_render_scale > context->world_render_target_scale ||
+        context->world_render_scale < context->dynamic_world_render_min_scale)
+    {
+        return apply_world_render_scale(context,
+                                        SDL_clamp(context->world_render_scale, context->dynamic_world_render_min_scale,
+                                                  context->world_render_target_scale));
+    }
+    return true;
+}
+
+bool slayer3d_update_dynamic_world_render_scale(slayer3d_render_context *context, float frame_ms)
+{
+    if (context == NULL)
+    {
+        return SDL_InvalidParamError("context");
+    }
+    if (!context->dynamic_world_render_scale_enabled)
+    {
+        return true;
+    }
+    if (!(frame_ms > 0.0f))
+    {
+        return SDL_SetError("Dynamic world render scale frame time must be positive.");
+    }
+
+    if (context->dynamic_world_render_frame_ms_ema <= 0.0f)
+        context->dynamic_world_render_frame_ms_ema = frame_ms;
+    else
+        context->dynamic_world_render_frame_ms_ema =
+            context->dynamic_world_render_frame_ms_ema * 0.9f + frame_ms * 0.1f;
+
+    const float target_ms = 1000.0f / context->dynamic_world_render_target_fps;
+    float next_scale = context->world_render_scale;
+    if (context->dynamic_world_render_frame_ms_ema > target_ms * 1.10f)
+    {
+        context->dynamic_world_render_slow_frames++;
+        context->dynamic_world_render_fast_frames = 0;
+        if (context->dynamic_world_render_slow_frames >= 8)
+        {
+            next_scale = SDL_max(context->dynamic_world_render_min_scale, context->world_render_scale - 0.05f);
+            context->dynamic_world_render_slow_frames = 0;
+        }
+    }
+    else if (context->dynamic_world_render_frame_ms_ema < target_ms * 0.82f)
+    {
+        context->dynamic_world_render_fast_frames++;
+        context->dynamic_world_render_slow_frames = 0;
+        if (context->dynamic_world_render_fast_frames >= 60)
+        {
+            next_scale = SDL_min(context->world_render_target_scale, context->world_render_scale + 0.025f);
+            context->dynamic_world_render_fast_frames = 0;
+        }
+    }
+    else
+    {
+        context->dynamic_world_render_slow_frames = 0;
+        context->dynamic_world_render_fast_frames = 0;
+    }
+
+    if (next_scale != context->world_render_scale)
+    {
+        return apply_world_render_scale(context, next_scale);
+    }
+    return true;
 }
 
 bool slayer3d_get_world_render_size(const slayer3d_render_context *context, int *out_width, int *out_height)

--- a/src/render_context_internal.h
+++ b/src/render_context_internal.h
@@ -34,8 +34,16 @@ struct slayer3d_render_context
     int width;
     int height;
     float world_render_scale;
+    float world_render_target_scale;
     int world_render_width;
     int world_render_height;
+    bool dynamic_world_render_scale_enabled;
+    float dynamic_world_render_min_scale;
+    float dynamic_world_render_max_scale;
+    float dynamic_world_render_target_fps;
+    float dynamic_world_render_frame_ms_ema;
+    int dynamic_world_render_slow_frames;
+    int dynamic_world_render_fast_frames;
     slayer3d_render_stats stats;
 
     float near_plane;

--- a/tests/test_render_context.cpp
+++ b/tests/test_render_context.cpp
@@ -330,6 +330,34 @@ TEST_F(SDLVideoFixture, SoftwareBackendVtableIsFullyPopulated)
     slayer3d_destroy_render_context(context);
 }
 
+TEST_F(SDLVideoFixture, DynamicWorldRenderScaleAdjustsConservatively)
+{
+    SDLWindowRendererPair pair;
+    ASSERT_TRUE(pair.is_valid());
+
+    SLAYER3DBackendOverrideGuard guard("software");
+    slayer3d_render_context *context = nullptr;
+    ASSERT_TRUE(slayer3d_create_render_context(pair.window(), pair.renderer(), nullptr, &context)) << SDL_GetError();
+    ASSERT_NE(nullptr, context);
+
+    ASSERT_TRUE(slayer3d_set_world_render_scale(context, 1.0f)) << SDL_GetError();
+    ASSERT_TRUE(slayer3d_configure_dynamic_world_render_scale(context, true, 0.5f, 1.0f, 60.0f)) << SDL_GetError();
+    for (int i = 0; i < 8; ++i)
+    {
+        ASSERT_TRUE(slayer3d_update_dynamic_world_render_scale(context, 25.0f)) << SDL_GetError();
+    }
+    EXPECT_LT(slayer3d_get_world_render_scale(context), 1.0f);
+    const float reduced_scale = slayer3d_get_world_render_scale(context);
+
+    for (int i = 0; i < 120; ++i)
+    {
+        ASSERT_TRUE(slayer3d_update_dynamic_world_render_scale(context, 10.0f)) << SDL_GetError();
+    }
+    EXPECT_GT(slayer3d_get_world_render_scale(context), reduced_scale);
+
+    slayer3d_destroy_render_context(context);
+}
+
 TEST_F(SDLVideoFixture, OpenGLBackendClearAndPresentSucceedWhenAvailable)
 {
     SDLWindowRendererPair pair;


### PR DESCRIPTION
## Summary
- render the OpenGL world layer against the native pixel presentation viewport instead of the authored logical 1280x720 surface
- keep UI/overlay rendering on logical coordinates so editor and HUD text remain crisp and stable
- add optional dynamic world render scaling with JSON render settings, managed-loop frame-time updates, validation, docs, and a focused test
- name the adaptive scaling tuning constants so the thresholds are easy to audit and tune later

## Testing
- cmake --build build/debug -j 8
- ./build/debug/tests/slayer3d_render_context_test --gtest_filter='SDLVideoFixture.DynamicWorldRenderScaleAdjustsConservatively'
- ./build/debug/tests/slayer3d_gl_renderer_test --gtest_filter='GLRendererTest.WorldRenderScaleResizesOnlyWorldFramebuffer'
- ctest --test-dir build/debug --output-on-failure -j 8