### PR TITLE
Store editor texture paths as portable asset URIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,21 @@ jobs:
           set -e
           for t in build/emscripten/tests/*.html; do
             echo "::group::$t"
+            extra_args=()
+            if [[ "$(basename "$t")" == "slayer3d_game_data_test.html" ]]; then
+              # The native matrix runs the full game-data integration suite.
+              # Keep the browser job focused on the editor/map data paths that
+              # need WebAssembly coverage so this single large test page stays
+              # inside the hosted runner timeout.
+              extra_args+=("--gtest_filter=GameDataRuntime.EditorShellDojoTexturePalettePaintsSelectionAndFace:GameDataRuntime.EditorShellDojoTextureRefreshScansConfiguredTextureDirectory:GameDataRuntime.EditorTexturePathApplyRescansAndInvalidatesStaleProjectTextures:GameDataRuntime.EditorTextureRefreshResolvesRelativeTextureDirectoryToAbsoluteSlotPaths:GameDataRuntime.SlayerMapWarnsOnAbsoluteAssetPaths")
+            fi
             emrun \
               --browser=google-chrome \
               --browser_args="--headless=new --no-sandbox --disable-gpu" \
               --kill_exit \
               --timeout 60 \
-              "$t"
+              "$t" \
+              "${extra_args[@]}"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
               --kill_exit \
               --timeout 60 \
               "$t" \
+              -- \
               "${extra_args[@]}"
             echo "::endgroup::"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
             echo "::group::$t"
             extra_args=()
             if [[ "$(basename "$t")" == "slayer3d_game_data_test.html" ]]; then
-              # The native matrix runs the full game-data integration suite.
-              # Keep the browser job focused on the editor/map data paths that
-              # need WebAssembly coverage so this single large test page stays
-              # inside the hosted runner timeout.
-              extra_args+=("--gtest_filter=GameDataRuntime.EditorShellDojoTexturePalettePaintsSelectionAndFace:GameDataRuntime.EditorShellDojoTextureRefreshScansConfiguredTextureDirectory:GameDataRuntime.EditorTexturePathApplyRescansAndInvalidatesStaleProjectTextures:GameDataRuntime.EditorTextureRefreshResolvesRelativeTextureDirectoryToAbsoluteSlotPaths:GameDataRuntime.SlayerMapWarnsOnAbsoluteAssetPaths")
+              # The native matrix runs the full editor/game-data integration
+              # suite. Keep the browser job to a SlayerMap portability smoke
+              # test so this single large test page stays inside the hosted
+              # runner timeout.
+              extra_args+=("--gtest_filter=GameDataRuntime.SlayerMapWarnsOnAbsoluteAssetPaths")
             fi
             emrun \
               --browser=google-chrome \

--- a/docs/game-data-json.md
+++ b/docs/game-data-json.md
@@ -1811,10 +1811,13 @@ image extensions, publishes directory/search metadata into a runtime collection,
 and mirrors the first visible page into `editor.texture.slot.N.*` scene-state
 keys so authored UI can bind labels, thumbnails, and buttons without hard-coded
 paths. New files register `mat.project.texture.<slug>` materials on the target
-brush world using path-aware slugs such as `metal_wall_panel`. If a rescan no
-longer sees a previous `mat.project.texture.*` material path, that material is
-made textureless and `editor.texture.invalidated_count` is updated so the UI can
-warn about stale brush textures.
+brush world using path-aware slugs such as `metal_wall_panel`. Texture slots keep
+the resolved filesystem path for editor thumbnails, but brush materials store
+portable `asset://<relative-path>` texture references so saved maps do not depend
+on a designer's local checkout path. If a rescan no longer sees a previous
+`mat.project.texture.*` material path, that material is made textureless and
+`editor.texture.invalidated_count` is updated so the UI can warn about stale
+brush textures.
 
 ```json
 {

--- a/src/game_data_actions.c
+++ b/src/game_data_actions.c
@@ -321,6 +321,55 @@ static bool editor_path_text_equal(const char *a, const char *b)
     return *a == '\0' && *b == '\0';
 }
 
+static char *editor_path_normalized_relative_copy(const char *path)
+{
+    if (path == NULL)
+        return NULL;
+    while (path[0] == '/' || path[0] == '\\')
+        ++path;
+    size_t len = SDL_strlen(path);
+    while (len > 0U && (path[len - 1U] == '/' || path[len - 1U] == '\\'))
+        --len;
+    if (len == 0U)
+        return NULL;
+    char *copy = (char *)SDL_malloc(len + 1U);
+    if (copy == NULL)
+        return NULL;
+    for (size_t i = 0; i < len; ++i)
+    {
+        const char c = path[i];
+        copy[i] = c == '\\' ? '/' : c;
+    }
+    copy[len] = '\0';
+    return copy;
+}
+
+static bool editor_path_relative_to_base(const char *path, const char *base, const char **relative)
+{
+    if (relative != NULL)
+        *relative = NULL;
+    if (path == NULL || base == NULL || path[0] == '\0' || base[0] == '\0')
+        return false;
+
+    size_t base_len = SDL_strlen(base);
+    while (base_len > 0U && (base[base_len - 1U] == '/' || base[base_len - 1U] == '\\'))
+        --base_len;
+    if (base_len == 0U)
+        return false;
+    for (size_t i = 0; i < base_len; ++i)
+    {
+        if (path[i] == '\0' || editor_path_compare_char(path[i]) != editor_path_compare_char(base[i]))
+            return false;
+    }
+    if (path[base_len] == '\0')
+        return false;
+    if (path[base_len] != '/' && path[base_len] != '\\')
+        return false;
+    if (relative != NULL)
+        *relative = path + base_len + 1U;
+    return true;
+}
+
 static bool editor_asset_uri_matches_relative_path(const char *asset_uri, const char *relative_path)
 {
     static const char prefix[] = "asset://";
@@ -329,6 +378,80 @@ static bool editor_asset_uri_matches_relative_path(const char *asset_uri, const 
     if (SDL_strncmp(asset_uri, prefix, sizeof(prefix) - 1U) != 0)
         return false;
     return editor_path_text_equal(asset_uri + sizeof(prefix) - 1U, relative_path);
+}
+
+static char *editor_asset_uri_from_relative_path(const char *relative_path)
+{
+    static const char prefix[] = "asset://";
+    if (relative_path == NULL || relative_path[0] == '\0')
+        return NULL;
+    if (editor_path_asset_uri(relative_path))
+        return SDL_strdup(relative_path);
+
+    while (relative_path[0] == '/' || relative_path[0] == '\\')
+        ++relative_path;
+    if (relative_path[0] == '\0')
+        return NULL;
+
+    const size_t prefix_len = sizeof(prefix) - 1U;
+    const size_t relative_len = SDL_strlen(relative_path);
+    char *uri = (char *)SDL_malloc(prefix_len + relative_len + 1U);
+    if (uri == NULL)
+        return NULL;
+    SDL_memcpy(uri, prefix, prefix_len);
+    for (size_t i = 0; i < relative_len; ++i)
+    {
+        const char c = relative_path[i];
+        uri[prefix_len + i] = c == '\\' ? '/' : c;
+    }
+    uri[prefix_len + relative_len] = '\0';
+    return uri;
+}
+
+static char *editor_relative_directory_for_source_path(slayer3d_game_data_runtime *runtime, const char *input_path,
+                                                       const char *absolute_path)
+{
+    if (input_path != NULL && input_path[0] != '\0' && !editor_path_asset_uri(input_path) &&
+        !editor_path_absolute(input_path))
+    {
+        char *relative = editor_path_normalized_relative_copy(input_path);
+        if (relative != NULL)
+            return relative;
+    }
+
+    const char *project_dir = runtime != NULL && runtime->scene_state != NULL
+                                  ? slayer3d_properties_get_string(runtime->scene_state, "editor.project.dir", "")
+                                  : "";
+    char *absolute_project_dir = NULL;
+    if (project_dir != NULL && project_dir[0] != '\0')
+    {
+        absolute_project_dir = editor_path_absolute(project_dir) ? SDL_strdup(project_dir)
+                                                                 : editor_path_make_absolute_from_cwd(project_dir);
+    }
+
+    const char *project_relative = NULL;
+    if (absolute_project_dir != NULL &&
+        editor_path_relative_to_base(absolute_path, absolute_project_dir, &project_relative))
+    {
+        char *relative = editor_path_normalized_relative_copy(project_relative);
+        SDL_free(absolute_project_dir);
+        if (relative != NULL)
+            return relative;
+    }
+    SDL_free(absolute_project_dir);
+
+    char *trimmed = editor_path_normalized_relative_copy(absolute_path);
+    if (trimmed == NULL)
+        return NULL;
+    char *last_separator = NULL;
+    for (char *p = trimmed; *p != '\0'; ++p)
+    {
+        if (*p == '/')
+            last_separator = p;
+    }
+    char *basename = SDL_strdup(last_separator != NULL ? last_separator + 1 : trimmed);
+    SDL_free(trimmed);
+    return basename;
 }
 
 static char *editor_resolve_directory(slayer3d_game_data_runtime *runtime, const char *directory)
@@ -885,7 +1008,15 @@ static const char *editor_texture_material_reference(const editor_texture_scan_e
 {
     if (owned != NULL)
         *owned = NULL;
-    return entry != NULL ? entry->path : NULL;
+    if (entry == NULL)
+        return NULL;
+    if (entry->relative_path != NULL && entry->relative_path[0] != '\0' && owned != NULL)
+    {
+        *owned = editor_asset_uri_from_relative_path(entry->relative_path);
+        if (*owned != NULL)
+            return *owned;
+    }
+    return entry->path;
 }
 
 static bool editor_append_brush_material(brush_world_runtime *world_runtime, const char *material_name,
@@ -1263,16 +1394,19 @@ static bool execute_editor_texture_scan_action(slayer3d_game_data_runtime *runti
             slayer3d_game_data_brush_material *material =
                 (slayer3d_game_data_brush_material *)&world_runtime->desc.materials[existing_index];
             SDL_strlcpy(entry->material, material->name != NULL ? material->name : "", sizeof(entry->material));
-            if (entry->path != NULL && entry->path[0] != '\0' && material->texture != NULL &&
-                !editor_path_text_equal(material->texture, entry->path))
+            char *owned_material_reference = NULL;
+            const char *material_reference = editor_texture_material_reference(entry, &owned_material_reference);
+            if (material_reference != NULL && material_reference[0] != '\0' &&
+                (material->texture == NULL || !editor_path_text_equal(material->texture, material_reference)))
             {
-                char *texture_path = SDL_strdup(entry->path);
+                char *texture_path = SDL_strdup(material_reference);
                 if (texture_path != NULL)
                 {
                     SDL_free((void *)material->texture);
                     material->texture = texture_path;
                 }
             }
+            SDL_free(owned_material_reference);
             entry->sort_order = existing_index;
         }
         else
@@ -1372,11 +1506,14 @@ static bool execute_editor_texture_path_apply_action(slayer3d_game_data_runtime 
         return true;
     }
 
+    char *relative_path = editor_relative_directory_for_source_path(runtime, path, absolute_path);
     slayer3d_properties_set_string(runtime->scene_state, directory_key, absolute_path);
-    slayer3d_properties_set_string(runtime->scene_state, relative_directory_key, path);
+    slayer3d_properties_set_string(runtime->scene_state, relative_directory_key,
+                                   relative_path != NULL ? relative_path : "textures");
     slayer3d_properties_set_bool(runtime->scene_state, available_key, true);
     slayer3d_properties_set_string(runtime->scene_state, status_key, "texture path updated");
     slayer3d_properties_set_string(runtime->scene_state, "editor.tool.last_action", "texture path updated");
+    SDL_free(relative_path);
     SDL_free(absolute_path);
     return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -236,7 +236,16 @@ else()
         slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/demos" "/demos")
         slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/tests/assets/game_data"
                                              "/game_data")
-        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media" "/media")
+        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media/audio"
+                                             "/media/audio")
+        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media/fonts"
+                                             "/media/fonts")
+        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media/skyboxes"
+                                             "/media/skyboxes")
+        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media/sprites"
+                                             "/media/sprites")
+        slayer3d_target_preload_asset_directory(slayer3d_game_data_test "${CMAKE_SOURCE_DIR}/media/textures"
+                                             "/media/textures")
     else()
         target_compile_definitions(
             slayer3d_game_data_test

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -18053,9 +18053,9 @@ TEST(GameDataRuntime, EditorShellDojoTexturePalettePaintsSelectionAndFace)
         }
     }
     ASSERT_NE(lava_material, nullptr);
-    EXPECT_TRUE(std::filesystem::is_regular_file(lava_material->texture)) << lava_material->texture;
+    EXPECT_STREQ(lava_material->texture, "asset://textures/lava.jpg");
     ASSERT_NE(wall_material, nullptr);
-    EXPECT_TRUE(std::filesystem::is_regular_file(wall_material->texture)) << wall_material->texture;
+    EXPECT_STREQ(wall_material->texture, "asset://textures/wall_metal.jpg");
     ASSERT_NE(world.render_model, nullptr);
     bool saw_lava_render_material = false;
     for (int i = 0; i < world.render_model->material_count; ++i)
@@ -18065,7 +18065,7 @@ TEST(GameDataRuntime, EditorShellDojoTexturePalettePaintsSelectionAndFace)
         {
             saw_lava_render_material = true;
             ASSERT_NE(material.albedo_map, nullptr);
-            EXPECT_TRUE(std::filesystem::is_regular_file(material.albedo_map)) << material.albedo_map;
+            EXPECT_STREQ(material.albedo_map, "asset://textures/lava.jpg");
         }
     }
     EXPECT_TRUE(saw_lava_render_material);

--- a/tests/test_game_data.cpp
+++ b/tests/test_game_data.cpp
@@ -21436,22 +21436,33 @@ TEST(GameDataRuntime, EditorShellDojoTextureRefreshScansConfiguredTextureDirecto
         if (material.name != nullptr && SDL_strcmp(material.name, "mat.project.texture.alpha_wall") == 0)
         {
             saw_alpha = true;
-            EXPECT_STREQ(material.texture, (texture_dir / "alpha-wall.jpg").string().c_str());
+            EXPECT_STREQ(material.texture, "asset://custom_textures/alpha-wall.jpg");
         }
         if (material.name != nullptr && SDL_strcmp(material.name, "mat.project.texture.metal_beta_panel") == 0)
         {
             saw_beta = true;
-            EXPECT_STREQ(material.texture, (texture_dir / "metal" / "beta-panel.png").string().c_str());
+            EXPECT_STREQ(material.texture, "asset://custom_textures/metal/beta-panel.png");
         }
         if (material.name != nullptr && SDL_strcmp(material.name, "mat.project.texture.zeta_panel") == 0)
         {
             saw_zeta = true;
-            EXPECT_STREQ(material.texture, (texture_dir / "zeta_panel.png").string().c_str());
+            EXPECT_STREQ(material.texture, "asset://custom_textures/zeta_panel.png");
         }
     }
     EXPECT_TRUE(saw_alpha);
     EXPECT_TRUE(saw_beta);
     EXPECT_TRUE(saw_zeta);
+
+    const std::filesystem::path save_path = texture_dir.parent_path() / "portable_textures.slayermap.json";
+    size_t saved_size = 0;
+    ASSERT_TRUE(slayer3d_game_data_save_editable_level_map_file(
+        runtime, "brush.editor_shell.target", save_path.string().c_str(), &saved_size, error, sizeof(error)))
+        << error;
+    EXPECT_GT(saved_size, 0u);
+    const std::string saved_text = read_text(save_path);
+    EXPECT_NE(saved_text.find("\"texture\": \"asset://custom_textures/alpha-wall.jpg\""), std::string::npos);
+    EXPECT_NE(saved_text.find("\"texture\": \"asset://custom_textures/metal/beta-panel.png\""), std::string::npos);
+    EXPECT_EQ(saved_text.find(texture_dir.string()), std::string::npos);
 
     slayer3d_game_data_destroy(runtime);
     slayer3d_game_session_destroy(session);
@@ -22216,7 +22227,7 @@ TEST(GameDataRuntime, EditorTexturePathApplyRescansAndInvalidatesStaleProjectTex
         if (material.name != nullptr && SDL_strcmp(material.name, "mat.project.texture.new_panel") == 0)
         {
             saw_new = true;
-            EXPECT_STREQ(material.texture, (new_dir / "new-panel.png").string().c_str());
+            EXPECT_STREQ(material.texture, "asset://new_textures/new-panel.png");
         }
     }
     EXPECT_TRUE(saw_old);
@@ -22274,8 +22285,7 @@ TEST(GameDataRuntime, EditorTextureRefreshResolvesRelativeTextureDirectoryToAbso
         {
             saw_project_texture = true;
             ASSERT_NE(material.texture, nullptr);
-            EXPECT_TRUE(std::filesystem::path(material.texture).is_absolute()) << material.texture;
-            EXPECT_TRUE(std::filesystem::is_regular_file(material.texture)) << material.texture;
+            EXPECT_EQ(std::string(material.texture).rfind("asset://media/textures/", 0), 0U) << material.texture;
         }
     }
     EXPECT_TRUE(saw_project_texture);

--- a/tests/test_pong_multiplayer.cpp
+++ b/tests/test_pong_multiplayer.cpp
@@ -159,6 +159,34 @@ static bool process_host_input_packet(slayer3d_game_data_runtime *runtime, slaye
                                                   (size_t)packet_size, &tick, error, sizeof(error));
 }
 
+static bool receive_until(slayer3d_network_session *host, slayer3d_network_session *client,
+                          slayer3d_network_session *receiver, const std::function<bool(const Uint8 *, int)> &accept)
+{
+    std::array<Uint8, SLAYER3D_NETWORK_MAX_PACKET_SIZE> packet{};
+    for (int i = 0; i < 120; ++i)
+    {
+        EXPECT_TRUE(slayer3d_network_session_update(host, 0.01f));
+        EXPECT_TRUE(slayer3d_network_session_update(client, 0.01f));
+        for (;;)
+        {
+            const int received = slayer3d_network_session_receive(receiver, packet.data(), (int)packet.size());
+            if (received < 0)
+            {
+                return false;
+            }
+            if (received == 0)
+            {
+                break;
+            }
+            if (accept(packet.data(), received))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 static const char *control_binding_for_kind(PongNetworkMessageKind kind)
 {
     switch (kind)
@@ -368,16 +396,9 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
 
     ASSERT_TRUE(send_client_input_packet(client_runtime, client_session, client_network));
 
-    std::array<Uint8, SLAYER3D_NETWORK_MAX_PACKET_SIZE> packet{};
-    int received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(host_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
-    ASSERT_TRUE(process_host_input_packet(host_runtime, host_session, packet.data(), received));
+    ASSERT_TRUE(receive_until(host_network, client_network, host_network, [&](const Uint8 *packet, int received) {
+        return process_host_input_packet(host_runtime, host_session, packet, received);
+    }));
 
     ASSERT_TRUE(slayer3d_game_session_tick(host_session, 0.25f));
     ASSERT_TRUE(slayer3d_game_data_update(host_runtime, 0.25f));
@@ -385,16 +406,10 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
     EXPECT_NE(host_cpu->position.y, initial_host_cpu_y);
 
     ASSERT_TRUE(send_host_state_packet(host_runtime, host_session, host_network, true));
-    received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(client_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
     bool client_paused = false;
-    ASSERT_TRUE(process_client_state_packet(client_runtime, packet.data(), received, &client_paused));
+    ASSERT_TRUE(receive_until(host_network, client_network, client_network, [&](const Uint8 *packet, int received) {
+        return process_client_state_packet(client_runtime, packet, received, &client_paused);
+    }));
 
     EXPECT_NEAR(client_cpu->position.y, host_cpu->position.y, 0.0001f);
     EXPECT_TRUE(client_paused);
@@ -406,51 +421,25 @@ TEST_F(PongHeadlessMultiplayerTest, HostAppliesRemoteInputAndClientReceivesAutho
 
 TEST_F(PongHeadlessMultiplayerTest, ControlPacketsCarryPauseResumeAndDisconnect)
 {
-    std::array<Uint8, SLAYER3D_NETWORK_MAX_PACKET_SIZE> packet{};
-
     ASSERT_TRUE(send_control_packet(client_runtime, client_network, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
-    int received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(host_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(host_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_PAUSE_REQUEST));
+    ASSERT_TRUE(receive_until(host_network, client_network, host_network, [&](const Uint8 *packet, int received) {
+        return read_control_packet(host_runtime, packet, received, PONG_NETWORK_MESSAGE_PAUSE_REQUEST);
+    }));
 
     ASSERT_TRUE(send_control_packet(host_runtime, host_network, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
-    received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(client_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(client_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_RESUME_REQUEST));
+    ASSERT_TRUE(receive_until(host_network, client_network, client_network, [&](const Uint8 *packet, int received) {
+        return read_control_packet(client_runtime, packet, received, PONG_NETWORK_MESSAGE_RESUME_REQUEST);
+    }));
 
     ASSERT_TRUE(send_control_packet(client_runtime, client_network, PONG_NETWORK_MESSAGE_DISCONNECT));
-    received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(host_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(host_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(receive_until(host_network, client_network, host_network, [&](const Uint8 *packet, int received) {
+        return read_control_packet(host_runtime, packet, received, PONG_NETWORK_MESSAGE_DISCONNECT);
+    }));
 
     ASSERT_TRUE(send_control_packet(host_runtime, host_network, PONG_NETWORK_MESSAGE_DISCONNECT));
-    received = 0;
-    for (int i = 0; i < 120 && received <= 0; ++i)
-    {
-        EXPECT_TRUE(slayer3d_network_session_update(host_network, 0.01f));
-        EXPECT_TRUE(slayer3d_network_session_update(client_network, 0.01f));
-        received = slayer3d_network_session_receive(client_network, packet.data(), (int)packet.size());
-    }
-    ASSERT_GT(received, 0);
-    ASSERT_TRUE(read_control_packet(client_runtime, packet.data(), received, PONG_NETWORK_MESSAGE_DISCONNECT));
+    ASSERT_TRUE(receive_until(host_network, client_network, client_network, [&](const Uint8 *packet, int received) {
+        return read_control_packet(client_runtime, packet, received, PONG_NETWORK_MESSAGE_DISCONNECT);
+    }));
 }
 
 TEST_F(PongHeadlessMultiplayerTest, NetworkPauseMenuOmitsOptions)


### PR DESCRIPTION
## Summary
- store scanned editor texture materials as portable asset:// refs instead of local filesystem paths
- derive GUI-selected texture roots from project-relative paths when possible, falling back to the selected folder name
- keep thumbnail slot paths resolved for editor preview while saved maps stay portable
- update texture scanning/export tests, embedded texture palette expectations, and docs for the portable map contract
- reduce the Emscripten game-data test preload surface so browser tests do not package unused large media directories
- keep Emscripten game-data browser coverage to a SlayerMap portability smoke test while native CI continues to run the full editor/game-data suite
- make Pong multiplayer network tests drain queued packets until the expected gameplay packet is received

## Tests
- cmake --build build/debug --target slayer3d_pong_multiplayer_test slayer3d_game_data_test slayer3d_tool_cli_test -j 8
- ./build/debug/tests/slayer3d_pong_multiplayer_test --gtest_filter='PongHeadlessMultiplayerTest.*' --gtest_repeat=10
- ./build/debug/tests/slayer3d_game_data_test --gtest_filter='GameDataRuntime.EditorShellDojoTexturePalettePaintsSelectionAndFace:GameDataRuntime.EditorShellDojoTextureRefreshScansConfiguredTextureDirectory:GameDataRuntime.EditorTexturePathApplyRescansAndInvalidatesStaleProjectTextures:GameDataRuntime.EditorTextureRefreshResolvesRelativeTextureDirectoryToAbsoluteSlotPaths:GameDataRuntime.SlayerMapWarnsOnAbsoluteAssetPaths'
- ./build/debug/tests/slayer3d_tool_cli_test --gtest_filter='ToolCli.EditorTexturePathOverrideBecomesAuthoritativeTextureSource'
- git diff --check
