### PR TITLE
Bring Slayer3D editor to web via Emscripten

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep Docker build contexts lean: local build trees and VCS metadata are
+# never needed inside image builds.
+build/
+.git/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,6 +552,56 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT EMSCRIPTEN)
     slayer3d_copy_runtime_dlls(slayer3d_editor)
 endif()
 
+if(EMSCRIPTEN)
+    # Browser build of the editor. Embedded asset packs require the native
+    # slayer3d_pack tool, so the web editor instead preloads the canonical
+    # editor project and the built-in media it references into the Emscripten
+    # virtual filesystem and resolves the default project from there.
+    add_executable(
+        slayer3d_editor_web
+        tools/slayer3d_editor.c
+        tools/slayer3d_editor_cli.c
+        tools/slayer3d_runner.c
+        tools/slayer3d_runner_cli.c
+        tools/slayer3d_runner_manifest.c
+        tools/slayer3d_runner_state.c
+        tools/slayer3d_fused.c
+    )
+    target_link_libraries(slayer3d_editor_web PRIVATE Slayer3D::slayer3d slayer3d_argtable3)
+    target_compile_features(slayer3d_editor_web PRIVATE c_std_17)
+    target_include_directories(slayer3d_editor_web PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+    target_compile_definitions(
+        slayer3d_editor_web
+        PRIVATE
+            SLAYER3D_MEDIA_DIR="/media"
+            SLAYER3D_EDITOR_DEFAULT_PROJECT="/apps/slayer3d_editor"
+            SLAYER3D_RUNNER_NO_MAIN
+    )
+    set_target_properties(slayer3d_editor_web PROPERTIES SUFFIX ".html")
+    target_link_options(
+        slayer3d_editor_web
+        PRIVATE
+            "-sALLOW_MEMORY_GROWTH=1"
+            # Data-action validation recurses through the authored editor
+            # shell, so keep the wasm stack explicit like the game-data test
+            # target does to avoid stack exhaustion before startup completes.
+            "-sSTACK_SIZE=8388608"
+            # The bundled editor textures include 8K sources that decode to
+            # ~170MB of RGBA each, so give the heap room to grow.
+            "-sINITIAL_MEMORY=268435456"
+            "-sMAXIMUM_MEMORY=2147483648"
+    )
+    slayer3d_target_preload_asset_directory(slayer3d_editor_web "${CMAKE_CURRENT_SOURCE_DIR}/apps/slayer3d_editor"
+                                            "/apps/slayer3d_editor")
+    slayer3d_target_preload_asset_directory(slayer3d_editor_web "${CMAKE_CURRENT_SOURCE_DIR}/media/audio"
+                                            "/media/audio")
+    slayer3d_target_preload_asset_directory(slayer3d_editor_web "${CMAKE_CURRENT_SOURCE_DIR}/media/fonts"
+                                            "/media/fonts")
+    slayer3d_target_preload_asset_directory(slayer3d_editor_web "${CMAKE_CURRENT_SOURCE_DIR}/media/sprites"
+                                            "/media/sprites")
+    slayer3d_enable_warnings(slayer3d_editor_web)
+endif()
+
 if(SLAYER3D_BUILD_TESTS)
     add_subdirectory(tests)
 endif()

--- a/docker/emscripten-editor/Dockerfile
+++ b/docker/emscripten-editor/Dockerfile
@@ -1,0 +1,19 @@
+# Build and host the browser build of the Slayer3D editor.
+#
+# Usage (from the repository root):
+#   docker build -f docker/emscripten-editor/Dockerfile -t slayer3d-editor-web .
+#   docker run --rm -it -p 8080:8080 slayer3d-editor-web
+#
+# Then open:
+#   http://localhost:8080/slayer3d_editor_web.html
+
+FROM emscripten/emsdk:latest
+
+WORKDIR /src
+COPY . .
+
+RUN emcmake cmake -S . -B build/emscripten-editor -DCMAKE_BUILD_TYPE=Release
+RUN cmake --build build/emscripten-editor --target slayer3d_editor_web --parallel
+
+EXPOSE 8080
+CMD ["python3", "-m", "http.server", "8080", "--bind", "0.0.0.0", "--directory", "build/emscripten-editor"]

--- a/docs/editor-packaging.md
+++ b/docs/editor-packaging.md
@@ -75,3 +75,48 @@ The editor is generic. Project assets and map files stay external unless the
 caller explicitly packages them. The embedded Slayer3D Editor project exists so
 a fresh executable opens into a useful brush editor immediately; users can then
 open or configure their own projects from the editor workflow.
+
+## Browser Editor (Emscripten)
+
+`slayer3d_editor_web` is an Emscripten-only CMake target that runs the same
+data-authored editor shell in a web browser. Instead of the desktop embedded
+asset pack (which requires the native `slayer3d_pack` tool), the web build
+preloads `apps/slayer3d_editor` and the built-in media it references into the
+Emscripten virtual filesystem and resolves the default project from
+`/apps/slayer3d_editor` at startup. No CLI arguments are required; the browser
+editor boots into the default untitled map.
+
+The supported build-and-host workflow is Docker-based:
+
+```sh
+docker build -f docker/emscripten-editor/Dockerfile -t slayer3d-editor-web .
+docker run --rm -it -p 8080:8080 slayer3d-editor-web
+```
+
+Then open:
+
+```text
+http://localhost:8080/slayer3d_editor_web.html
+```
+
+With a local Emscripten SDK, the same target builds directly:
+
+```sh
+emcmake cmake -S . -B build/emscripten-editor -DCMAKE_BUILD_TYPE=Release
+cmake --build build/emscripten-editor --target slayer3d_editor_web
+python3 -m http.server 8080 --directory build/emscripten-editor
+```
+
+The build produces `slayer3d_editor_web.html`, `.js`, `.wasm`, and `.data`
+artifacts in the build root. The managed game loop drives the browser build
+through `emscripten_set_main_loop_arg` rather than the native blocking loop;
+native desktop behavior is unchanged.
+
+### Current Browser Limitations
+
+- Saves write to the in-memory Emscripten filesystem, so edits do not persist
+  across page reloads. Browser-native import/export (file picker and download
+  bridge, or persistent IDBFS storage) is follow-up work.
+- Open/save file dialogs depend on SDL's dialog support for Emscripten. When a
+  dialog is unavailable, the editor reports "File dialog failed" in the editor
+  console instead of failing silently.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ data-authored games running on a generic SDL-powered runtime.
 - [Slayer3D Map Format](slayer3d-map-format.md): standalone brush level map
   structure, assets, materials, actors, properties, and editor metadata.
 - [Standalone Editor Packaging](editor-packaging.md): no-argument editor launch,
-  static desktop builds, and install layout.
+  static desktop builds, install layout, and the Docker-based browser editor.
 - [Retained UI Widgets](ui-widgets.md): data-authored UI layout, styling,
   dropdowns, dynamic text, and editor/game UI guidance.
 - [Gameplay Lua API](game-data-lua.md): Lua adapter model and runtime helper

--- a/include/slayer3d/game.h
+++ b/include/slayer3d/game.h
@@ -360,6 +360,20 @@ extern "C"
         float dynamic_world_render_max_scale; /**< Maximum adaptive 3D render scale, or 1.0 when <= 0. */
         float dynamic_world_render_target_fps; /**< Adaptive render target FPS, or 60 when <= 0. */
         bool enable_audio;                     /**< When true, create session audio before init when available. */
+
+        /**
+         * @brief Hand per-frame control to the browser on Emscripten builds.
+         *
+         * When true, browser builds register the frame callback with
+         * emscripten_set_main_loop_arg and slayer3d_run_game does not return;
+         * shutdown and engine cleanup run from the callback once quit is
+         * requested. Interactive browser apps should enable this so the page
+         * stays responsive. When false, browser builds run the same blocking
+         * loop as native, which freezes the tab until quit is requested and
+         * is only appropriate for bounded runs such as automated tests.
+         * Native builds ignore this field and always block until quit.
+         */
+        bool browser_main_loop;
     } slayer3d_game_config;
 
     /**

--- a/src/data_game.c
+++ b/src/data_game.c
@@ -1685,6 +1685,10 @@ bool slayer3d_data_game_runtime_process_event(slayer3d_data_game_runtime *runtim
 
     if (request->failed)
     {
+        char console_message[512];
+        SDL_snprintf(console_message, sizeof(console_message), "File dialog failed: %s",
+                     message[0] != '\0' ? message : "unknown error");
+        slayer3d_game_data_editor_publish_console_message(runtime->data, console_message);
         SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D file dialog failed: %s",
                     message[0] != '\0' ? message : "unknown error");
     }

--- a/src/game.c
+++ b/src/game.c
@@ -790,13 +790,19 @@ int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_ca
     run->last_counter = SDL_GetPerformanceCounter();
 
 #if defined(__EMSCRIPTEN__)
-    /* Browsers own the outer loop: register the per-frame callback and unwind
-     * back to the browser event loop instead of blocking. The callback runs
-     * shutdown and cleanup when quit is requested, and this call does not
-     * return, so caller code after slayer3d_run_game does not run on web. */
-    emscripten_set_main_loop_arg(slayer3d_game_emscripten_frame, run, 0, 1);
-    return 0;
-#else
+    if (config != NULL && config->browser_main_loop)
+    {
+        /* Browsers own the outer loop: register the per-frame callback and
+         * unwind back to the browser event loop instead of blocking. The
+         * callback runs shutdown and cleanup when quit is requested, and this
+         * call does not return, so caller code after slayer3d_run_game does
+         * not run on web. Bounded runs such as automated tests leave
+         * browser_main_loop false and use the blocking loop below. */
+        emscripten_set_main_loop_arg(slayer3d_game_emscripten_frame, run, 0, 1);
+        return 0;
+    }
+#endif
+
     while (!run->ctx.quit_requested)
     {
         slayer3d_game_run_frame(run);
@@ -805,5 +811,4 @@ int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_ca
     const int result = slayer3d_game_run_shutdown(run);
     SDL_free(run);
     return result;
-#endif
 }

--- a/src/game.c
+++ b/src/game.c
@@ -6,6 +6,10 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_stdinc.h>
 
+#if defined(__EMSCRIPTEN__)
+#include <emscripten.h>
+#endif
+
 #include "slayer3d/logic.h"
 #include "slayer3d/time.h"
 
@@ -506,233 +510,300 @@ static void slayer3d_game_sync_input_mouse_transform(const slayer3d_game_context
                                                 (float)logical_height / viewport_height, viewport_x, viewport_y);
 }
 
-int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_callbacks *callbacks, void *userdata)
+/**
+ * @brief Mutable state for one managed game loop run.
+ *
+ * The state is heap-allocated so browser builds can keep it alive after
+ * slayer3d_run_game hands per-frame control back to the browser event loop.
+ */
+typedef struct slayer3d_game_run_state
 {
     slayer3d_game_context ctx;
-    const float fixed_dt = slayer3d_game_fixed_dt(config);
-    const int max_ticks_per_frame = slayer3d_game_max_ticks_per_frame(config);
-    const bool profile_frames = SDL_getenv("SLAYER3D_PROFILE_FRAMES") != NULL;
-    float accumulator = 0.0f;
-    Uint64 last_counter = 0;
-    Uint64 profile_last_counter = 0;
-    double profile_poll_ms = 0.0;
-    double profile_tick_ms = 0.0;
-    double profile_render_ms = 0.0;
-    double profile_present_ms = 0.0;
-    double profile_frame_ms = 0.0;
-    int profile_frames_count = 0;
-    int profile_ticks_count = 0;
-    int profile_max_ticks = 0;
-    int result = 0;
+    slayer3d_game_callbacks callbacks;
+    void *userdata;
+    float fixed_dt;
+    int max_ticks_per_frame;
+    bool profile_frames;
+    float accumulator;
+    Uint64 last_counter;
+    Uint64 profile_last_counter;
+    double profile_poll_ms;
+    double profile_tick_ms;
+    double profile_render_ms;
+    double profile_present_ms;
+    double profile_frame_ms;
+    int profile_frames_count;
+    int profile_ticks_count;
+    int profile_max_ticks;
+    int result;
+} slayer3d_game_run_state;
 
-    SDL_zero(ctx);
+static void slayer3d_game_run_frame(slayer3d_game_run_state *run)
+{
+    slayer3d_game_context *ctx = &run->ctx;
+    const slayer3d_game_callbacks *callbacks = &run->callbacks;
+    const Uint64 frame_start_counter = SDL_GetPerformanceCounter();
+    Uint64 poll_start_counter = frame_start_counter;
+    Uint64 poll_end_counter;
+    Uint64 tick_start_counter;
+    Uint64 tick_end_counter;
+    Uint64 render_start_counter;
+    Uint64 render_end_counter;
+    Uint64 present_start_counter;
+    Uint64 present_end_counter;
+    SDL_Event event;
+    slayer3d_game_sync_input_mouse_transform(ctx);
+    while (SDL_PollEvent(&event))
+    {
+        ctx->input_event_consumed = false;
+
+        if (event.type == SDL_EVENT_QUIT)
+        {
+            ctx->quit_requested = true;
+            break;
+        }
+
+        if (callbacks->event != NULL && !callbacks->event(ctx, run->userdata, &event))
+        {
+            ctx->quit_requested = true;
+            break;
+        }
+
+        if (!ctx->input_event_consumed)
+        {
+            slayer3d_input_process_event(slayer3d_game_session_get_input(ctx->session), &event);
+        }
+    }
+    poll_end_counter = SDL_GetPerformanceCounter();
+
+    if (ctx->quit_requested)
+    {
+        return;
+    }
+
+    const Uint64 now = SDL_GetPerformanceCounter();
+    const float frame_dt = slayer3d_game_frame_delta(now, run->last_counter);
+    int ticks_this_frame = 0;
+    run->last_counter = now;
+
+    ctx->real_time += frame_dt;
+    slayer3d_time_update();
+    slayer3d_game_session_begin_frame(ctx->session, frame_dt);
+
+    if (ctx->paused)
+    {
+        tick_start_counter = SDL_GetPerformanceCounter();
+        slayer3d_game_session_update_input(ctx->session);
+        if (callbacks->pause_tick != NULL)
+        {
+            callbacks->pause_tick(ctx, run->userdata, frame_dt);
+        }
+        tick_end_counter = SDL_GetPerformanceCounter();
+    }
+    else
+    {
+        tick_start_counter = SDL_GetPerformanceCounter();
+        run->accumulator += frame_dt;
+
+        while (!ctx->quit_requested && !ctx->paused && run->accumulator >= run->fixed_dt &&
+               ticks_this_frame < run->max_ticks_per_frame)
+        {
+            slayer3d_game_session_begin_tick(ctx->session, run->fixed_dt);
+
+            if (callbacks->tick != NULL)
+            {
+                callbacks->tick(ctx, run->userdata, run->fixed_dt);
+            }
+
+            slayer3d_game_session_end_tick(ctx->session, run->fixed_dt);
+            run->accumulator -= run->fixed_dt;
+            ticks_this_frame++;
+        }
+
+        if (ticks_this_frame == run->max_ticks_per_frame && run->accumulator >= run->fixed_dt)
+        {
+            run->accumulator = SDL_fmodf(run->accumulator, run->fixed_dt);
+        }
+        tick_end_counter = SDL_GetPerformanceCounter();
+    }
+
+    if (ctx->quit_requested)
+    {
+        return;
+    }
+
+    if (callbacks->render != NULL)
+    {
+        float alpha = ctx->paused ? 0.0f : run->accumulator / run->fixed_dt;
+        if (alpha > 1.0f)
+        {
+            alpha = 1.0f;
+        }
+        render_start_counter = SDL_GetPerformanceCounter();
+        callbacks->render(ctx, run->userdata, alpha);
+        render_end_counter = SDL_GetPerformanceCounter();
+    }
+    else
+    {
+        render_start_counter = SDL_GetPerformanceCounter();
+        render_end_counter = render_start_counter;
+    }
+
+    present_start_counter = SDL_GetPerformanceCounter();
+    if (!slayer3d_present_render_context(ctx->renderer))
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D present failed: %s", SDL_GetError());
+        run->result = 1;
+        ctx->quit_requested = true;
+    }
+    present_end_counter = SDL_GetPerformanceCounter();
+    const float frame_ms =
+        (float)((double)(present_end_counter - frame_start_counter) * 1000.0 / (double)SDL_GetPerformanceFrequency());
+    if (!slayer3d_update_dynamic_world_render_scale(ctx->renderer, frame_ms))
+    {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D dynamic render scale update failed: %s", SDL_GetError());
+        SDL_ClearError();
+    }
+
+    if (run->profile_frames)
+    {
+        const double inv_freq_ms = 1000.0 / (double)SDL_GetPerformanceFrequency();
+        run->profile_poll_ms += (double)(poll_end_counter - poll_start_counter) * inv_freq_ms;
+        run->profile_tick_ms += (double)(tick_end_counter - tick_start_counter) * inv_freq_ms;
+        run->profile_render_ms += (double)(render_end_counter - render_start_counter) * inv_freq_ms;
+        run->profile_present_ms += (double)(present_end_counter - present_start_counter) * inv_freq_ms;
+        run->profile_frame_ms += (double)(present_end_counter - frame_start_counter) * inv_freq_ms;
+        run->profile_frames_count++;
+        run->profile_ticks_count += ticks_this_frame;
+        if (ticks_this_frame > run->profile_max_ticks)
+        {
+            run->profile_max_ticks = ticks_this_frame;
+        }
+
+        if (run->profile_last_counter == 0)
+        {
+            run->profile_last_counter = present_end_counter;
+        }
+        else if ((double)(present_end_counter - run->profile_last_counter) / (double)SDL_GetPerformanceFrequency() >=
+                 1.0)
+        {
+            const double frames = run->profile_frames_count > 0 ? (double)run->profile_frames_count : 1.0;
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "SLAYER3D profile: fps=%.1f frame=%.2fms poll=%.2f tick=%.2f render=%.2f present=%.2f "
+                        "ticks/frame=%.2f max_ticks=%d",
+                        frames * (double)SDL_GetPerformanceFrequency() /
+                            (double)(present_end_counter - run->profile_last_counter),
+                        run->profile_frame_ms / frames, run->profile_poll_ms / frames, run->profile_tick_ms / frames,
+                        run->profile_render_ms / frames, run->profile_present_ms / frames,
+                        run->profile_ticks_count / frames, run->profile_max_ticks);
+            run->profile_last_counter = present_end_counter;
+            run->profile_poll_ms = 0.0;
+            run->profile_tick_ms = 0.0;
+            run->profile_render_ms = 0.0;
+            run->profile_present_ms = 0.0;
+            run->profile_frame_ms = 0.0;
+            run->profile_frames_count = 0;
+            run->profile_ticks_count = 0;
+            run->profile_max_ticks = 0;
+        }
+    }
+}
+
+static int slayer3d_game_run_shutdown(slayer3d_game_run_state *run)
+{
+    if (run->callbacks.shutdown != NULL)
+    {
+        run->callbacks.shutdown(&run->ctx, run->userdata);
+    }
+
+#if SLAYER3D_GAME_ENABLE_GLOBAL_TEXT_INPUT
+    SDL_StopTextInput(run->ctx.window);
+#endif
+    slayer3d_game_cleanup_context(&run->ctx);
+    SDL_Quit();
+    return run->result;
+}
+
+#if defined(__EMSCRIPTEN__)
+static void slayer3d_game_emscripten_frame(void *userdata)
+{
+    slayer3d_game_run_state *run = (slayer3d_game_run_state *)userdata;
+    slayer3d_game_run_frame(run);
+    if (!run->ctx.quit_requested)
+    {
+        return;
+    }
+
+    (void)slayer3d_game_run_shutdown(run);
+    SDL_free(run);
+    emscripten_cancel_main_loop();
+}
+#endif
+
+int slayer3d_run_game(const slayer3d_game_config *config, const slayer3d_game_callbacks *callbacks, void *userdata)
+{
+    slayer3d_game_run_state *run = (slayer3d_game_run_state *)SDL_calloc(1, sizeof(*run));
+    if (run == NULL)
+    {
+        SDL_OutOfMemory();
+        return 1;
+    }
+
+    if (callbacks != NULL)
+    {
+        run->callbacks = *callbacks;
+    }
+    run->userdata = userdata;
+    run->fixed_dt = slayer3d_game_fixed_dt(config);
+    run->max_ticks_per_frame = slayer3d_game_max_ticks_per_frame(config);
+    run->profile_frames = SDL_getenv("SLAYER3D_PROFILE_FRAMES") != NULL;
+
     SDL_SetMainReady();
 
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMEPAD | SDL_INIT_HAPTIC))
     {
+        SDL_free(run);
         return 1;
     }
 
-    if (!slayer3d_game_create_context(config, &ctx))
+    if (!slayer3d_game_create_context(config, &run->ctx))
     {
-        slayer3d_game_cleanup_context(&ctx);
+        slayer3d_game_cleanup_context(&run->ctx);
         SDL_Quit();
+        SDL_free(run);
         return 1;
     }
 #if SLAYER3D_GAME_ENABLE_GLOBAL_TEXT_INPUT
-    SDL_StartTextInput(ctx.window);
+    SDL_StartTextInput(run->ctx.window);
 #endif
 
     slayer3d_time_reset();
 
-    if (callbacks != NULL && callbacks->init != NULL && !callbacks->init(&ctx, userdata))
+    if (run->callbacks.init != NULL && !run->callbacks.init(&run->ctx, run->userdata))
     {
-        slayer3d_game_cleanup_context(&ctx);
+        slayer3d_game_cleanup_context(&run->ctx);
         SDL_Quit();
+        SDL_free(run);
         return 1;
     }
 
-    last_counter = SDL_GetPerformanceCounter();
+    run->last_counter = SDL_GetPerformanceCounter();
 
-    while (!ctx.quit_requested)
+#if defined(__EMSCRIPTEN__)
+    /* Browsers own the outer loop: register the per-frame callback and unwind
+     * back to the browser event loop instead of blocking. The callback runs
+     * shutdown and cleanup when quit is requested, and this call does not
+     * return, so caller code after slayer3d_run_game does not run on web. */
+    emscripten_set_main_loop_arg(slayer3d_game_emscripten_frame, run, 0, 1);
+    return 0;
+#else
+    while (!run->ctx.quit_requested)
     {
-        const Uint64 frame_start_counter = SDL_GetPerformanceCounter();
-        Uint64 poll_start_counter = frame_start_counter;
-        Uint64 poll_end_counter;
-        Uint64 tick_start_counter;
-        Uint64 tick_end_counter;
-        Uint64 render_start_counter;
-        Uint64 render_end_counter;
-        Uint64 present_start_counter;
-        Uint64 present_end_counter;
-        SDL_Event event;
-        slayer3d_game_sync_input_mouse_transform(&ctx);
-        while (SDL_PollEvent(&event))
-        {
-            ctx.input_event_consumed = false;
-
-            if (event.type == SDL_EVENT_QUIT)
-            {
-                ctx.quit_requested = true;
-                break;
-            }
-
-            if (callbacks != NULL && callbacks->event != NULL && !callbacks->event(&ctx, userdata, &event))
-            {
-                ctx.quit_requested = true;
-                break;
-            }
-
-            if (!ctx.input_event_consumed)
-            {
-                slayer3d_input_process_event(slayer3d_game_session_get_input(ctx.session), &event);
-            }
-        }
-        poll_end_counter = SDL_GetPerformanceCounter();
-
-        if (ctx.quit_requested)
-        {
-            break;
-        }
-
-        const Uint64 now = SDL_GetPerformanceCounter();
-        const float frame_dt = slayer3d_game_frame_delta(now, last_counter);
-        int ticks_this_frame = 0;
-        last_counter = now;
-
-        ctx.real_time += frame_dt;
-        slayer3d_time_update();
-        slayer3d_game_session_begin_frame(ctx.session, frame_dt);
-
-        if (ctx.paused)
-        {
-            tick_start_counter = SDL_GetPerformanceCounter();
-            slayer3d_game_session_update_input(ctx.session);
-            if (callbacks != NULL && callbacks->pause_tick != NULL)
-            {
-                callbacks->pause_tick(&ctx, userdata, frame_dt);
-            }
-            tick_end_counter = SDL_GetPerformanceCounter();
-        }
-        else
-        {
-            tick_start_counter = SDL_GetPerformanceCounter();
-            accumulator += frame_dt;
-
-            while (!ctx.quit_requested && !ctx.paused && accumulator >= fixed_dt &&
-                   ticks_this_frame < max_ticks_per_frame)
-            {
-                slayer3d_game_session_begin_tick(ctx.session, fixed_dt);
-
-                if (callbacks != NULL && callbacks->tick != NULL)
-                {
-                    callbacks->tick(&ctx, userdata, fixed_dt);
-                }
-
-                slayer3d_game_session_end_tick(ctx.session, fixed_dt);
-                accumulator -= fixed_dt;
-                ticks_this_frame++;
-            }
-
-            if (ticks_this_frame == max_ticks_per_frame && accumulator >= fixed_dt)
-            {
-                accumulator = SDL_fmodf(accumulator, fixed_dt);
-            }
-            tick_end_counter = SDL_GetPerformanceCounter();
-        }
-
-        if (ctx.quit_requested)
-        {
-            break;
-        }
-
-        if (callbacks != NULL && callbacks->render != NULL)
-        {
-            float alpha = ctx.paused ? 0.0f : accumulator / fixed_dt;
-            if (alpha > 1.0f)
-            {
-                alpha = 1.0f;
-            }
-            render_start_counter = SDL_GetPerformanceCounter();
-            callbacks->render(&ctx, userdata, alpha);
-            render_end_counter = SDL_GetPerformanceCounter();
-        }
-        else
-        {
-            render_start_counter = SDL_GetPerformanceCounter();
-            render_end_counter = render_start_counter;
-        }
-
-        present_start_counter = SDL_GetPerformanceCounter();
-        if (!slayer3d_present_render_context(ctx.renderer))
-        {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D present failed: %s", SDL_GetError());
-            result = 1;
-            ctx.quit_requested = true;
-        }
-        present_end_counter = SDL_GetPerformanceCounter();
-        const float frame_ms = (float)((double)(present_end_counter - frame_start_counter) * 1000.0 /
-                                       (double)SDL_GetPerformanceFrequency());
-        if (!slayer3d_update_dynamic_world_render_scale(ctx.renderer, frame_ms))
-        {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "SLAYER3D dynamic render scale update failed: %s",
-                        SDL_GetError());
-            SDL_ClearError();
-        }
-
-        if (profile_frames)
-        {
-            const double inv_freq_ms = 1000.0 / (double)SDL_GetPerformanceFrequency();
-            profile_poll_ms += (double)(poll_end_counter - poll_start_counter) * inv_freq_ms;
-            profile_tick_ms += (double)(tick_end_counter - tick_start_counter) * inv_freq_ms;
-            profile_render_ms += (double)(render_end_counter - render_start_counter) * inv_freq_ms;
-            profile_present_ms += (double)(present_end_counter - present_start_counter) * inv_freq_ms;
-            profile_frame_ms += (double)(present_end_counter - frame_start_counter) * inv_freq_ms;
-            profile_frames_count++;
-            profile_ticks_count += ticks_this_frame;
-            if (ticks_this_frame > profile_max_ticks)
-            {
-                profile_max_ticks = ticks_this_frame;
-            }
-
-            if (profile_last_counter == 0)
-            {
-                profile_last_counter = present_end_counter;
-            }
-            else if ((double)(present_end_counter - profile_last_counter) / (double)SDL_GetPerformanceFrequency() >=
-                     1.0)
-            {
-                const double frames = profile_frames_count > 0 ? (double)profile_frames_count : 1.0;
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "SLAYER3D profile: fps=%.1f frame=%.2fms poll=%.2f tick=%.2f render=%.2f present=%.2f "
-                            "ticks/frame=%.2f max_ticks=%d",
-                            frames * (double)SDL_GetPerformanceFrequency() /
-                                (double)(present_end_counter - profile_last_counter),
-                            profile_frame_ms / frames, profile_poll_ms / frames, profile_tick_ms / frames,
-                            profile_render_ms / frames, profile_present_ms / frames, profile_ticks_count / frames,
-                            profile_max_ticks);
-                profile_last_counter = present_end_counter;
-                profile_poll_ms = 0.0;
-                profile_tick_ms = 0.0;
-                profile_render_ms = 0.0;
-                profile_present_ms = 0.0;
-                profile_frame_ms = 0.0;
-                profile_frames_count = 0;
-                profile_ticks_count = 0;
-                profile_max_ticks = 0;
-            }
-        }
+        slayer3d_game_run_frame(run);
     }
 
-    if (callbacks != NULL && callbacks->shutdown != NULL)
-    {
-        callbacks->shutdown(&ctx, userdata);
-    }
-
-#if SLAYER3D_GAME_ENABLE_GLOBAL_TEXT_INPUT
-    SDL_StopTextInput(ctx.window);
-#endif
-    slayer3d_game_cleanup_context(&ctx);
-    SDL_Quit();
+    const int result = slayer3d_game_run_shutdown(run);
+    SDL_free(run);
     return result;
+#endif
 }

--- a/src/game_data_editor_dialog_internal.h
+++ b/src/game_data_editor_dialog_internal.h
@@ -19,7 +19,10 @@ typedef struct editor_file_dialog_request
     bool failed;
 } editor_file_dialog_request;
 
+struct slayer3d_game_data_runtime;
+
 Uint32 slayer3d_game_data_editor_file_dialog_event_type(void);
 void slayer3d_game_data_editor_file_dialog_request_free(editor_file_dialog_request *request);
+void slayer3d_game_data_editor_publish_console_message(struct slayer3d_game_data_runtime *runtime, const char *message);
 
 #endif

--- a/src/game_data_editor_output_actions.c
+++ b/src/game_data_editor_output_actions.c
@@ -1,3 +1,4 @@
+#include "game_data_editor_dialog_internal.h"
 #include "game_data_internal.h"
 
 #include <SDL3/SDL_log.h>
@@ -123,6 +124,11 @@ void editor_publish_console_message(slayer3d_game_data_runtime *runtime, const c
     editor_clear_console_selection_state(runtime->scene_state);
     editor_refresh_console_lines(runtime);
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%s", message);
+}
+
+void slayer3d_game_data_editor_publish_console_message(struct slayer3d_game_data_runtime *runtime, const char *message)
+{
+    editor_publish_console_message(runtime, message);
 }
 
 void editor_refresh_console_lines(slayer3d_game_data_runtime *runtime)

--- a/tools/slayer3d_editor_cli.c
+++ b/tools/slayer3d_editor_cli.c
@@ -383,6 +383,7 @@ static bool editor_asset_source_copy(const slayer3d_editor_asset_source *source,
     return true;
 }
 
+#if defined(SLAYER3D_EDITOR_EMBEDDED_ASSETS)
 static bool editor_asset_source_init(slayer3d_editor_asset_source *source, const char *path, const char *relative_path,
                                      bool available)
 {
@@ -399,6 +400,7 @@ static bool editor_asset_source_init(slayer3d_editor_asset_source *source, const
     }
     return true;
 }
+#endif
 
 static bool editor_asset_sources_copy(const slayer3d_editor_asset_sources *sources,
                                       slayer3d_editor_asset_sources *out_sources)

--- a/tools/slayer3d_runner.c
+++ b/tools/slayer3d_runner.c
@@ -491,6 +491,10 @@ int slayer3d_runner_main(int argc, char **argv)
         return 1;
     }
 
+    /* Runner-hosted games are interactive apps: browser builds must yield to
+     * the browser between frames instead of blocking the tab. */
+    state.config.browser_main_loop = true;
+
     slayer3d_game_callbacks callbacks;
     SDL_zero(callbacks);
     callbacks.init = runner_init;


### PR DESCRIPTION
## Summary

First working browser build of the Slayer3D editor, per #496. The web editor boots with no CLI arguments into the bundled default editor project (menus, toolbar, inspector, viewport grid, and console reach "Editor ready"), served from a Docker-based Emscripten build.

Closes #496

### Managed loop refactor (`src/game.c`)

`slayer3d_run_game` is split into a heap-allocated `slayer3d_game_run_state` plus `slayer3d_game_run_frame` / `slayer3d_game_run_shutdown`. Native builds run the same blocking `while` loop as before with identical fixed-timestep, accumulator, pause, input, render, present, dynamic render scale, and profiling behavior. Emscripten builds register the per-frame function with `emscripten_set_main_loop_arg(..., 0, 1)` and return control to the browser; when quit is requested the callback runs the shutdown callback, engine cleanup, and `emscripten_cancel_main_loop`.

### Web editor target (`slayer3d_editor_web`)

Emscripten-only target reusing the editor/runner sources. Desktop embedded asset packs need the native `slayer3d_pack` tool, so the web build instead preloads `apps/slayer3d_editor` (project manifest + data) and the built-in media it references (`media/audio`, `media/fonts`, `media/sprites`) into the Emscripten VFS, and resolves the default project from `/apps/slayer3d_editor` via `SLAYER3D_EDITOR_DEFAULT_PROJECT`. Produces `slayer3d_editor_web.html/.js/.wasm/.data`. The existing Emscripten CI job builds this target as part of `cmake --build build/emscripten`, giving build-only verification without new CI steps.

### Web-safe project resolution and file dialogs

- No-argument launch resolves the preloaded project and saves to SDL's pref path (`/libsdl/...` on MEMFS); no host CWD or absolute-path dependence.
- File-dialog failures now publish "File dialog failed: ..." to the editor console (via a small wrapper around `editor_publish_console_message`) in addition to the SDL log warning, so unsupported browser dialogs fail visibly instead of silently. Browser-native import/export (file picker/download bridge or IDBFS persistence) is left as follow-up and documented.

### Docker workflow

```sh
docker build -f docker/emscripten-editor/Dockerfile -t slayer3d-editor-web .
docker run --rm -it -p 8080:8080 slayer3d-editor-web
# open http://localhost:8080/slayer3d_editor_web.html
```

Docs: new "Browser Editor (Emscripten)" section in `docs/editor-packaging.md` (indexed from `docs/index.md`).

## Verification

Native (macOS arm64):

- `cmake -B build/debug -DCMAKE_BUILD_TYPE=Debug -DSLAYER3D_BUILD_TESTS=ON && cmake --build build/debug --parallel` — clean.
- `ctest` (full suite in `build/debug`): **1484/1484 passed** (1 environmental skip).
- `./build/debug/slayer3d_editor` boots to `Editor ready` with the embedded project; a `new --project apps/slayer3d_editor` directory-project launch also boots normally.

Web (Docker 28.4):

- `docker build -f docker/emscripten-editor/Dockerfile -t slayer3d-editor-web .` — clean.
- `docker run --rm -it -p 8080:8080 slayer3d-editor-web` then drove `http://localhost:8080/slayer3d_editor_web.html` with headless Chromium (Puppeteer): console shows project resolution from `/apps/slayer3d_editor`, `Editor ready`, no fatal runtime errors, and a screenshot confirms the full nonblank editor shell (menus, toolbar, inspector, axis grid, console).

## Notes / follow-ups

- **Renderer**: the GL renderer loads desktop GL 3.3 entry points (e.g. `glDrawBuffer`) that WebGL2 does not expose, so the browser build takes the engine's existing software-renderer fallback — same as the Emscripten CI render tests today. A WebGL2/GLES3 port of `gl_renderer` is the follow-up flagged in #496's risk list.
- **Memory**: the web target links with `ALLOW_MEMORY_GROWTH`, 256MB initial / 2GB max heap; the bundled 8K editor textures (e.g. `lava.jpg`, 8000x5333) decode to ~170MB RGBA each and OOM'd under a lower cap.
- **Pre-existing, not web-specific**: directory-project launches warm scan-generated palette textures as `asset://data/textures/...` (project-dir-relative) while the asset mount is rooted at `data_root`, so those warms miss and log warnings. Reproduced identically on the native desktop editor with `--project apps/slayer3d_editor`; worth a separate fix to the asset-source relative-path semantics.
- Browser saves land in MEMFS and do not persist across reloads; documented as a limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)